### PR TITLE
fix(ci): resolve mypy strict errors and test import paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test-all: ## Run all tests including integration
 	pytest --cov
 
 test-contract: ## Run contract tests only
-	PYTHONPATH=core/src python3 -m pytest core/tests/contract/ -v
+	PYTHONPATH=core/src:benchmarks/kr-housing/src python3 -m pytest core/tests/contract/ benchmarks/kr-housing/tests/ -v
 
 clean: ## Remove build artifacts
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true

--- a/core/src/younggeul_core/evidence/schemas.py
+++ b/core/src/younggeul_core/evidence/schemas.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import re
-from typing import Literal
+from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -39,7 +39,7 @@ class EvidenceRecord(BaseModel):
 class ClaimRecord(BaseModel):
     claim_id: str
     run_id: str
-    claim_json: dict
+    claim_json: dict[str, Any]
     evidence_ids: list[str]
     gate_status: Literal["pending", "passed", "failed", "repaired"] = "pending"
     gate_checked_at: datetime | None = None
@@ -67,7 +67,7 @@ class GateResult(BaseModel):
     claim_id: str
     status: Literal["passed", "failed"]
     checked_evidence_ids: list[str]
-    mismatches: list[dict] = Field(default_factory=list)
+    mismatches: list[dict[str, Any]] = Field(default_factory=list)
     checked_at: datetime
 
     model_config = ConfigDict(frozen=True)

--- a/core/src/younggeul_core/storage/snapshot.py
+++ b/core/src/younggeul_core/storage/snapshot.py
@@ -44,17 +44,17 @@ class SnapshotManifest(BaseModel):
             raise ValueError("dataset_snapshot_id must be a 64-character lowercase hex SHA-256 string")
         return value
 
-    @computed_field
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def table_hashes(self) -> dict[str, str]:
         return {entry.table_name: entry.table_hash for entry in self.table_entries}
 
-    @computed_field
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def record_counts(self) -> dict[str, int]:
         return {entry.table_name: entry.record_count for entry in self.table_entries}
 
-    @computed_field
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def total_records(self) -> int:
         return sum(entry.record_count for entry in self.table_entries)

--- a/core/tests/contract/test_cross_schema.py
+++ b/core/tests/contract/test_cross_schema.py
@@ -8,8 +8,8 @@ from uuid import uuid4
 import pytest
 from pydantic import BaseModel, ValidationError, field_validator
 
-from core.src.younggeul_core.evidence import ClaimRecord, EvidenceRecord, GateResult
-from core.src.younggeul_core.state import (
+from younggeul_core.evidence import ClaimRecord, EvidenceRecord, GateResult
+from younggeul_core.state import (
     BronzeAptTransaction,
     BronzeInterestRate,
     BronzeMigration,
@@ -22,7 +22,7 @@ from core.src.younggeul_core.state import (
     SilverAptTransaction,
     SnapshotRef,
 )
-from core.src.younggeul_core.storage import SnapshotManifest, SnapshotTableEntry
+from younggeul_core.storage import SnapshotManifest, SnapshotTableEntry
 
 
 class BenchmarkScenarioContract(BaseModel):

--- a/core/tests/contract/test_gold_schema.py
+++ b/core/tests/contract/test_gold_schema.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 import pytest
 from pydantic import ValidationError
 
-from core.src.younggeul_core.state.gold import (
+from younggeul_core.state.gold import (
     BaselineForecast,
     GoldComplexMonthlyMetrics,
     GoldDistrictMonthlyMetrics,

--- a/core/tests/contract/test_silver_schema.py
+++ b/core/tests/contract/test_silver_schema.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 import pytest
 from pydantic import ValidationError
 
-from core.src.younggeul_core.state.silver import (
+from younggeul_core.state.silver import (
     SilverAptTransaction,
     SilverComplexBridge,
     SilverDataQualityScore,

--- a/core/tests/contract/test_simulation_schema.py
+++ b/core/tests/contract/test_simulation_schema.py
@@ -6,7 +6,7 @@ from typing import Callable
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from core.src.younggeul_core.state.simulation import (
+from younggeul_core.state.simulation import (
     ActionProposal,
     ParticipantState,
     ReportClaim,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,15 +39,27 @@ target-version = "py312"
 [tool.mypy]
 python_version = "3.12"
 strict = false
+plugins = ["pydantic.mypy"]
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
 
 [[tool.mypy.overrides]]
 module = ["core.*"]
 strict = true
 
 [tool.pytest.ini_options]
+addopts = "--import-mode=importlib"
 testpaths = [
   "core/tests",
   "apps/kr-seoul-apartment/tests",
+]
+pythonpath = [
+  "core/src",
+  "apps/kr-seoul-apartment/src",
+  "benchmarks/kr-housing/src",
 ]
 markers = [
   "slow: marks tests as slow",


### PR DESCRIPTION
## Summary
- Fix 5 mypy strict errors (`prop-decorator`, `type-arg`) in core schemas
- Fix test import paths (`core.src.younggeul_core` → `younggeul_core`) in 4 test files
- Configure pytest `pythonpath` + `importlib` mode for multi-package test collection
- Extend Makefile `test-contract` to include benchmark tests

## Verification
- `mypy core/src/ apps/kr-seoul-apartment/src/` → 21 files, 0 errors
- `ruff check .` → All checks passed
- `ruff format --check .` → 38 files formatted
- `pytest core/tests/ benchmarks/kr-housing/tests/` → 165 passed

Closes #79