### PR TITLE
feat(molit): add MOLIT apartment transaction connector

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
       - name: Install dependencies
-        run: uv pip install --system -e ".[dev]"
+        run: uv pip install --system -e ".[dev,kr-seoul-apartment]"
       - name: Ruff check
         run: ruff check .
       - name: Ruff format check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@v4
       - name: Install dependencies
-        run: uv pip install --system -e ".[dev]"
+        run: uv pip install --system -e ".[dev,kr-seoul-apartment]"
       - name: Run unit tests
         run: pytest -m "not slow and not integration" --cov --cov-report=xml
       - name: Upload coverage

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/connectors/molit.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/connectors/molit.py
@@ -1,0 +1,253 @@
+"""MOLIT apartment transaction connector using PublicDataReader."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, ClassVar
+
+import pandas as pd
+from PublicDataReader import TransactionPrice
+
+from younggeul_core.connectors.hashing import sha256_payload
+from younggeul_core.connectors.manifest import build_manifest
+from younggeul_core.connectors.protocol import ConnectorResult
+from younggeul_core.connectors.rate_limit import RateLimiter
+from younggeul_core.connectors.retry import NonRetryableError, retry
+from younggeul_core.state.bronze import BronzeAptTransaction
+
+# ---------------------------------------------------------------------------
+# Column mapping: PublicDataReader Korean column → BronzeAptTransaction field
+# ---------------------------------------------------------------------------
+# PublicDataReader returns columns in Korean when translate=True (default).
+# Some column names differ from the raw MOLIT API names.
+# ---------------------------------------------------------------------------
+
+COLUMN_MAP: dict[str, str] = {
+    "거래금액": "deal_amount",
+    "건축년도": "build_year",
+    "년": "deal_year",
+    "월": "deal_month",
+    "일": "deal_day",
+    "법정동": "dong",
+    "아파트": "apt_name",
+    "층": "floor",
+    "전용면적": "area_exclusive",
+    "지번": "jibun",
+    "법정동시군구코드": "regional_code",
+    "아파트동": "apt_dong",
+    "도로명": "road_name",
+    "도로명건물본번호코드": "road_name_bonbun",
+    "도로명건물부번호코드": "road_name_bubun",
+    "도로명코드": "road_name_code",
+    "도로명일련번호코드": "road_name_seq",
+    "도로명지상지하코드": "road_name_basement",
+    "본번": "bonbun",
+    "부번": "bubun",
+    "지역코드": "land_code",
+    "일련번호": "serial_number",
+    "해제여부": "cancel_deal_type",
+    "해제사유발생일": "cancel_deal_day",
+    "거래유형": "req_gbn",
+    "중개사소재지": "rdealer_lawdnm",
+    "매수자": "buyer_gbn",
+    "매도자": "seller_gbn",
+    "등기일자": "registration_date",
+    "시군구코드": "sgg_code",
+    "읍면동코드": "umd_code",
+}
+
+# Fields that are numeric in pandas but should be clean integer strings
+# (e.g., 2023.0 → "2023", 11650.0 → "11650")
+_INT_LIKE_FIELDS: frozenset[str] = frozenset(
+    {
+        "건축년도",
+        "년",
+        "월",
+        "일",
+        "층",
+        "법정동시군구코드",
+        "도로명건물본번호코드",
+        "도로명건물부번호코드",
+        "도로명코드",
+        "도로명일련번호코드",
+        "도로명지상지하코드",
+        "본번",
+        "부번",
+        "지역코드",
+        "시군구코드",
+        "읍면동코드",
+    }
+)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+@dataclass(frozen=True, slots=True)
+class MolitAptRequest:
+    """Partition-scoped request for one sigungu + one month."""
+
+    sigungu_code: str
+    year_month: str
+
+
+def _safe_str(value: object, *, int_like: bool = False) -> str | None:
+    """Convert a pandas cell value to str | None.
+
+    - NaN / None → None
+    - float that represents an integer (e.g. 2023.0) → "2023" when int_like=True
+    - everything else → str(value)
+    """
+    if value is None:
+        return None
+    if isinstance(value, float) and (math.isnan(value) or pd.isna(value)):
+        return None
+    if int_like and isinstance(value, float) and value == int(value):
+        return str(int(value))
+    return str(value)
+
+
+def _normalize_dataframe(df: pd.DataFrame) -> list[dict[str, Any]]:
+    """Convert DataFrame rows to dicts with NaN→None and int-like float fix.
+
+    Returns raw dicts with Korean column names (not yet mapped to Bronze fields).
+    """
+    rows: list[dict[str, Any]] = []
+    for _, series in df.iterrows():
+        row: dict[str, Any] = {}
+        for col in df.columns:
+            row[col] = _safe_str(series[col], int_like=col in _INT_LIKE_FIELDS)
+        rows.append(row)
+    return rows
+
+
+def _map_to_bronze(
+    raw_rows: list[dict[str, Any]],
+    *,
+    source_id: str,
+    ingest_timestamp: datetime,
+    raw_response_hash: str,
+) -> list[BronzeAptTransaction]:
+    """Map normalized raw dicts (Korean keys) to BronzeAptTransaction records."""
+    records: list[BronzeAptTransaction] = []
+    for raw in raw_rows:
+        mapped: dict[str, Any] = {
+            "ingest_timestamp": ingest_timestamp,
+            "source_id": source_id,
+            "raw_response_hash": raw_response_hash,
+        }
+        for korean_col, bronze_field in COLUMN_MAP.items():
+            mapped[bronze_field] = raw.get(korean_col)
+
+        # 법정동시군구코드 maps to both regional_code and sgg_code
+        sgg_value = raw.get("법정동시군구코드")
+        if sgg_value is not None:
+            mapped["sgg_code"] = sgg_value
+
+        records.append(BronzeAptTransaction(**mapped))
+    return records
+
+
+class MolitAptConnector:
+    """Connector for MOLIT apartment transaction data via PublicDataReader.
+
+    Satisfies ``Connector[MolitAptRequest, BronzeAptTransaction]`` protocol.
+    """
+
+    source_id: ClassVar[str] = "molit.apartment.transactions"
+
+    def __init__(
+        self,
+        client: TransactionPrice,
+        rate_limiter: RateLimiter,
+        now_fn: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        self._client = client
+        self._rate_limiter = rate_limiter
+        self._now_fn = now_fn
+
+    def fetch(self, request: MolitAptRequest) -> ConnectorResult[BronzeAptTransaction]:
+        """Fetch apartment transactions for one sigungu + one month."""
+        now = self._now_fn()
+
+        # Retry wraps only the API call; rate limit inside retried callable
+        def _call_api() -> pd.DataFrame:
+            self._rate_limiter.wait()
+            result: pd.DataFrame = self._client.get_data(
+                property_type="아파트",
+                trade_type="매매",
+                sigungu_code=request.sigungu_code,
+                year_month=request.year_month,
+            )
+            return result
+
+        try:
+            raw_df = retry(_call_api)
+        except Exception as exc:
+            # Build a failed manifest and re-raise
+            manifest = build_manifest(
+                source_id=self.source_id,
+                api_endpoint="getRTMSDataSvcAptTradeDev",
+                request_params={
+                    "sigungu_code": request.sigungu_code,
+                    "year_month": request.year_month,
+                },
+                response_count=0,
+                ingested_at=now,
+                status="failed",
+                error_message=str(exc),
+            )
+            return ConnectorResult(records=[], manifest=manifest)
+
+        # Handle empty response
+        if raw_df is None or raw_df.empty:
+            manifest = build_manifest(
+                source_id=self.source_id,
+                api_endpoint="getRTMSDataSvcAptTradeDev",
+                request_params={
+                    "sigungu_code": request.sigungu_code,
+                    "year_month": request.year_month,
+                },
+                response_count=0,
+                ingested_at=now,
+                status="success",
+            )
+            return ConnectorResult(records=[], manifest=manifest)
+
+        # Validate expected columns exist
+        missing = set(COLUMN_MAP.keys()) - set(raw_df.columns)
+        if missing:
+            msg = f"Missing expected columns in MOLIT response: {sorted(missing)}"
+            raise NonRetryableError(msg)
+
+        # Stage 1: Normalize (NaN → None, float fix)
+        raw_rows = _normalize_dataframe(raw_df)
+
+        # Compute hash from normalized raw dicts (before Bronze mapping)
+        response_hash = sha256_payload(raw_rows)
+
+        # Stage 2: Map to Bronze records
+        records = _map_to_bronze(
+            raw_rows,
+            source_id=self.source_id,
+            ingest_timestamp=now,
+            raw_response_hash=response_hash,
+        )
+
+        manifest = build_manifest(
+            source_id=self.source_id,
+            api_endpoint="getRTMSDataSvcAptTradeDev",
+            request_params={
+                "sigungu_code": request.sigungu_code,
+                "year_month": request.year_month,
+            },
+            response_count=len(records),
+            ingested_at=now,
+            status="success",
+        )
+
+        return ConnectorResult(records=records, manifest=manifest)

--- a/apps/kr-seoul-apartment/tests/unit/test_molit.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_molit.py
@@ -1,0 +1,255 @@
+"""Unit tests for MolitAptConnector."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from younggeul_app_kr_seoul_apartment.connectors.molit import (
+    MolitAptConnector,
+    MolitAptRequest,
+    _normalize_dataframe,
+    _safe_str,
+)
+from younggeul_core.connectors.protocol import Connector, ConnectorResult
+from younggeul_core.connectors.rate_limit import RateLimiter
+from younggeul_core.connectors.retry import ConnectorError
+from younggeul_core.state.bronze import BronzeAptTransaction
+
+_FIXED_NOW = datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _fixed_now() -> datetime:
+    return _FIXED_NOW
+
+
+def _make_rate_limiter() -> RateLimiter:
+    return RateLimiter(min_interval=0.0)
+
+
+def _sample_dataframe() -> pd.DataFrame:
+    """Create a synthetic DataFrame matching PublicDataReader output."""
+    data: dict[str, list[Any]] = {
+        "거래금액": ["82,000"],
+        "건축년도": [2016.0],
+        "년": [2025.0],
+        "월": [7.0],
+        "일": [15.0],
+        "법정동": ["역삼동"],
+        "아파트": ["래미안"],
+        "층": [12.0],
+        "전용면적": [84.99],
+        "지번": ["123-45"],
+        "법정동시군구코드": [11680.0],
+        "아파트동": ["101동"],
+        "도로명": ["테헤란로"],
+        "도로명건물본번호코드": [123.0],
+        "도로명건물부번호코드": [1.0],
+        "도로명코드": [4100001.0],
+        "도로명일련번호코드": [1.0],
+        "도로명지상지하코드": [0.0],
+        "본번": [123.0],
+        "부번": [1.0],
+        "지역코드": [680.0],
+        "일련번호": ["2025-001"],
+        "해제여부": [np.nan],
+        "해제사유발생일": [np.nan],
+        "거래유형": ["중개거래"],
+        "중개사소재지": ["서울 강남구"],
+        "매수자": ["개인"],
+        "매도자": ["개인"],
+        "등기일자": ["20250720"],
+        "시군구코드": [11680.0],
+        "읍면동코드": [10300.0],
+    }
+    return pd.DataFrame(data)
+
+
+class TestSafeStr:
+    def test_none_returns_none(self) -> None:
+        assert _safe_str(None) is None
+
+    def test_nan_returns_none(self) -> None:
+        assert _safe_str(float("nan")) is None
+
+    def test_numpy_nan_returns_none(self) -> None:
+        assert _safe_str(np.nan) is None
+
+    def test_int_like_float_with_flag(self) -> None:
+        assert _safe_str(2023.0, int_like=True) == "2023"
+
+    def test_int_like_float_without_flag(self) -> None:
+        assert _safe_str(2023.0, int_like=False) == "2023.0"
+
+    def test_regular_float(self) -> None:
+        assert _safe_str(84.99, int_like=False) == "84.99"
+
+    def test_string_passthrough(self) -> None:
+        assert _safe_str("역삼동") == "역삼동"
+
+
+class TestNormalizeDataframe:
+    def test_nan_converted_to_none(self) -> None:
+        df = pd.DataFrame({"해제여부": [np.nan], "아파트": ["래미안"]})
+        rows = _normalize_dataframe(df)
+        assert rows[0]["해제여부"] is None
+        assert rows[0]["아파트"] == "래미안"
+
+    def test_int_like_floats_normalized(self) -> None:
+        df = pd.DataFrame({"건축년도": [2016.0], "법정동시군구코드": [11680.0]})
+        rows = _normalize_dataframe(df)
+        assert rows[0]["건축년도"] == "2016"
+        assert rows[0]["법정동시군구코드"] == "11680"
+
+    def test_empty_dataframe(self) -> None:
+        df = pd.DataFrame()
+        rows = _normalize_dataframe(df)
+        assert rows == []
+
+
+class TestMolitAptConnector:
+    def _make_connector(self, client: MagicMock | None = None) -> tuple[MolitAptConnector, MagicMock]:
+        mock_client = client or MagicMock()
+        connector = MolitAptConnector(
+            client=mock_client,
+            rate_limiter=_make_rate_limiter(),
+            now_fn=_fixed_now,
+        )
+        return connector, mock_client
+
+    def test_satisfies_connector_protocol(self) -> None:
+        connector, _ = self._make_connector()
+        assert isinstance(connector, Connector)
+
+    def test_full_row_mapping(self) -> None:
+        """Map a fully populated DataFrame row to BronzeAptTransaction."""
+        connector, mock_client = self._make_connector()
+        mock_client.get_data.return_value = _sample_dataframe()
+
+        request = MolitAptRequest(sigungu_code="11680", year_month="202507")
+        result = connector.fetch(request)
+
+        assert isinstance(result, ConnectorResult)
+        assert len(result.records) == 1
+
+        rec = result.records[0]
+        assert isinstance(rec, BronzeAptTransaction)
+        assert rec.deal_amount == "82,000"
+        assert rec.build_year == "2016"
+        assert rec.deal_year == "2025"
+        assert rec.deal_month == "7"
+        assert rec.deal_day == "15"
+        assert rec.dong == "역삼동"
+        assert rec.apt_name == "래미안"
+        assert rec.floor == "12"
+        assert rec.area_exclusive == "84.99"
+        assert rec.jibun == "123-45"
+        assert rec.regional_code == "11680"
+        assert rec.sgg_code == "11680"
+        assert rec.apt_dong == "101동"
+        assert rec.road_name == "테헤란로"
+        assert rec.cancel_deal_type is None  # NaN → None
+        assert rec.req_gbn == "중개거래"
+        assert rec.registration_date == "20250720"
+        assert rec.umd_code == "10300"
+
+        # Metadata
+        assert rec.source_id == "molit.apartment.transactions"
+        assert rec.ingest_timestamp == _FIXED_NOW
+        assert rec.raw_response_hash is not None
+        assert len(rec.raw_response_hash) == 64  # noqa: PLR2004
+
+    def test_empty_dataframe_returns_empty_result(self) -> None:
+        connector, mock_client = self._make_connector()
+        mock_client.get_data.return_value = pd.DataFrame()
+
+        request = MolitAptRequest(sigungu_code="11680", year_month="202507")
+        result = connector.fetch(request)
+
+        assert result.records == []
+        assert result.manifest.response_count == 0
+        assert result.manifest.status == "success"
+
+    def test_api_failure_returns_failed_manifest(self) -> None:
+        connector, mock_client = self._make_connector()
+        mock_client.get_data.side_effect = ConnectorError("API timeout")
+
+        request = MolitAptRequest(sigungu_code="11680", year_month="202507")
+        result = connector.fetch(request)
+
+        assert result.records == []
+        assert result.manifest.status == "failed"
+        assert "API timeout" in (result.manifest.error_message or "")
+
+    def test_missing_columns_raises_non_retryable(self) -> None:
+        connector, mock_client = self._make_connector()
+        # DataFrame with only a few columns
+        mock_client.get_data.return_value = pd.DataFrame({"거래금액": ["50,000"], "아파트": ["래미안"]})
+
+        request = MolitAptRequest(sigungu_code="11680", year_month="202507")
+        from younggeul_core.connectors.retry import NonRetryableError
+
+        with pytest.raises(NonRetryableError, match="Missing expected columns"):
+            connector.fetch(request)
+
+    def test_manifest_fields_correct(self) -> None:
+        connector, mock_client = self._make_connector()
+        mock_client.get_data.return_value = _sample_dataframe()
+
+        request = MolitAptRequest(sigungu_code="11680", year_month="202507")
+        result = connector.fetch(request)
+
+        m = result.manifest
+        assert m.source_id == "molit.apartment.transactions"
+        assert m.api_endpoint == "getRTMSDataSvcAptTradeDev"
+        assert m.request_params == {
+            "sigungu_code": "11680",
+            "year_month": "202507",
+        }
+        assert m.response_count == 1
+        assert m.status == "success"
+        assert m.ingested_at == _FIXED_NOW
+
+    def test_rate_limiter_called(self) -> None:
+        mock_limiter = MagicMock(spec=RateLimiter)
+        mock_client = MagicMock()
+        mock_client.get_data.return_value = _sample_dataframe()
+
+        connector = MolitAptConnector(
+            client=mock_client,
+            rate_limiter=mock_limiter,
+            now_fn=_fixed_now,
+        )
+        request = MolitAptRequest(sigungu_code="11680", year_month="202507")
+        connector.fetch(request)
+
+        mock_limiter.wait.assert_called_once()
+
+    def test_hash_deterministic_for_same_data(self) -> None:
+        connector, mock_client = self._make_connector()
+        mock_client.get_data.return_value = _sample_dataframe()
+
+        request = MolitAptRequest(sigungu_code="11680", year_month="202507")
+        r1 = connector.fetch(request)
+
+        mock_client.get_data.return_value = _sample_dataframe()
+        r2 = connector.fetch(request)
+
+        assert r1.records[0].raw_response_hash == r2.records[0].raw_response_hash
+
+
+class TestMolitAptRequest:
+    def test_frozen(self) -> None:
+        req = MolitAptRequest(sigungu_code="11680", year_month="202507")
+        with pytest.raises(AttributeError):
+            req.sigungu_code = "99999"  # type: ignore[misc]
+
+    def test_fields(self) -> None:
+        req = MolitAptRequest(sigungu_code="11680", year_month="202507")
+        assert req.sigungu_code == "11680"
+        assert req.year_month == "202507"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ dev = [
   "ruff",
   "mypy",
   "pre-commit",
+  "pandas-stubs",
+]
+kr-seoul-apartment = [
+  "PublicDataReader>=1.1",
+  "pandas>=2.0",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -49,6 +54,10 @@ warn_required_dynamic_aliases = true
 [[tool.mypy.overrides]]
 module = ["core.*"]
 strict = true
+
+[[tool.mypy.overrides]]
+module = ["PublicDataReader", "PublicDataReader.*"]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 addopts = "--import-mode=importlib"


### PR DESCRIPTION
## Summary

Implements `MolitAptConnector` for fetching apartment transaction data from the MOLIT (국토교통부) API via PublicDataReader. This is the first of three data connectors in the M2 milestone.

## Changes

### Connector (`apps/kr-seoul-apartment/src/.../connectors/molit.py`)
- `MolitAptRequest` frozen dataclass for partition-scoped requests (one sigungu + one month)
- `MolitAptConnector` class satisfying `Connector[MolitAptRequest, BronzeAptTransaction]` protocol
- `COLUMN_MAP`: 30 Korean→Bronze field mappings
- Two-stage transformation: DataFrame → normalized raw dicts (NaN→None, float→int fix) → `BronzeAptTransaction`
- `raw_response_hash` computed from normalized raw dicts BEFORE Bronze mapping (deterministic)
- `retry()` wraps only the API call; `rate_limiter.wait()` inside retried callable
- Missing expected columns → `NonRetryableError` (not retried)

### Tests (`apps/kr-seoul-apartment/tests/unit/test_molit.py`)
- 20 unit tests across 4 test classes
- `TestSafeStr` (7): None, NaN, numpy NaN, int-like float, regular float, string
- `TestNormalizeDataframe` (3): NaN conversion, int-like normalization, empty DF
- `TestMolitAptConnector` (8): protocol conformance, full row mapping, empty DF, API failure, missing columns, manifest fields, rate limiter, hash determinism
- `TestMolitAptRequest` (2): frozen, fields
- All tests use synthetic fixtures — no real API calls

### Infrastructure
- Add `kr-seoul-apartment` optional dependency group (`PublicDataReader>=1.1`, `pandas>=2.0`)
- Add `pandas-stubs` to dev deps for mypy
- Add mypy override for `PublicDataReader` (no stubs available)
- Update CI lint + test workflows to install `.[dev,kr-seoul-apartment]`

## Verification
- `ruff check .` ✅
- `ruff format --check .` ✅
- `mypy core/src/ apps/kr-seoul-apartment/src/` — 0 issues ✅
- `pytest` — 219 passed (199 existing + 20 new) ✅

Closes #83