### PR TITLE
feat(bok): add BOK interest rate connector

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/connectors/bok.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/connectors/bok.py
@@ -1,0 +1,252 @@
+"""BOK (Bank of Korea) interest rate connector using PublicDataReader."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, ClassVar
+
+import pandas as pd
+from PublicDataReader import Ecos
+
+from younggeul_core.connectors.hashing import sha256_payload
+from younggeul_core.connectors.manifest import build_manifest
+from younggeul_core.connectors.protocol import ConnectorResult
+from younggeul_core.connectors.rate_limit import RateLimiter
+from younggeul_core.connectors.retry import NonRetryableError, retry
+from younggeul_core.state.bronze import BronzeInterestRate
+
+# ---------------------------------------------------------------------------
+# Required columns from the ECOS StatisticSearch response
+# ---------------------------------------------------------------------------
+# The Ecos.get_statistic_search() returns a DataFrame with these columns.
+# We validate their presence and extract only what BronzeInterestRate needs.
+# ---------------------------------------------------------------------------
+
+REQUIRED_COLUMNS: frozenset[str] = frozenset(
+    {
+        "TIME",
+        "DATA_VALUE",
+        "UNIT_NAME",
+        "STAT_CODE",
+        "ITEM_CODE1",
+        "ITEM_NAME1",
+    }
+)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+@dataclass(frozen=True, slots=True)
+class BokInterestRateRequest:
+    """Partition-scoped request for one interest rate series over a date range.
+
+    Attributes:
+        stat_code: ECOS statistics table code (e.g., "722Y001").
+        item_code1: Primary item code (e.g., "0101000" for base rate).
+        frequency: Query frequency — "D" (daily), "M" (monthly), etc.
+        start_date: Start date in frequency-appropriate format (e.g., "20240101" or "202401").
+        end_date: End date in frequency-appropriate format.
+        rate_type: Normalized internal key (e.g., "base_rate", "loan_rate").
+        source_id: Source identifier (e.g., "bank_of_korea_base_rate").
+    """
+
+    stat_code: str
+    item_code1: str
+    frequency: str
+    start_date: str
+    end_date: str
+    rate_type: str
+    source_id: str
+
+
+def _safe_str(value: object) -> str | None:
+    """Convert a pandas cell value to str | None.
+
+    - NaN / None → None
+    - everything else → str(value), stripped
+    """
+    if value is None:
+        return None
+    if isinstance(value, float) and (math.isnan(value) or pd.isna(value)):
+        return None
+    result = str(value).strip()
+    return result if result else None
+
+
+def _normalize_time(time_str: str, frequency: str) -> str:
+    """Normalize ECOS TIME value to ISO date string.
+
+    - Daily "YYYYMMDD" → "YYYY-MM-DD"
+    - Monthly "YYYYMM" → "YYYY-MM-01"
+    - Quarterly "YYYYQ1" → "YYYY-01-01" (first day of quarter)
+    - Annual "YYYY" → "YYYY-01-01"
+    """
+    if frequency == "D" and len(time_str) == 8:  # noqa: PLR2004
+        return f"{time_str[:4]}-{time_str[4:6]}-{time_str[6:8]}"
+    if frequency == "M" and len(time_str) == 6:  # noqa: PLR2004
+        return f"{time_str[:4]}-{time_str[4:6]}-01"
+    if frequency == "Q" and len(time_str) == 6:  # noqa: PLR2004
+        # "2024Q1" → "2024-01-01", "2024Q2" → "2024-04-01", etc.
+        year = time_str[:4]
+        quarter = int(time_str[5])
+        month = (quarter - 1) * 3 + 1
+        return f"{year}-{month:02d}-01"
+    if frequency == "A" and len(time_str) == 4:  # noqa: PLR2004
+        return f"{time_str}-01-01"
+    # Fallback: return as-is
+    return time_str
+
+
+def _normalize_dataframe(
+    df: pd.DataFrame,
+    *,
+    frequency: str,
+) -> list[dict[str, Any]]:
+    """Convert ECOS DataFrame rows to normalized dicts.
+
+    - NaN → None
+    - TIME normalized to ISO date
+    - All values converted to strings
+    - Includes identity columns for hash completeness
+    """
+    rows: list[dict[str, Any]] = []
+    for _, series in df.iterrows():
+        row: dict[str, Any] = {}
+        for col in df.columns:
+            if col == "TIME":
+                raw_time = _safe_str(series[col])
+                row[col] = _normalize_time(raw_time, frequency) if raw_time else None
+            else:
+                row[col] = _safe_str(series[col])
+        rows.append(row)
+    return rows
+
+
+def _map_to_bronze(
+    raw_rows: list[dict[str, Any]],
+    *,
+    rate_type: str,
+    source_id: str,
+    ingest_timestamp: datetime,
+    raw_response_hash: str,
+) -> list[BronzeInterestRate]:
+    """Map normalized raw dicts to BronzeInterestRate records."""
+    records: list[BronzeInterestRate] = []
+    for raw in raw_rows:
+        records.append(
+            BronzeInterestRate(
+                ingest_timestamp=ingest_timestamp,
+                source_id=source_id,
+                raw_response_hash=raw_response_hash,
+                date=raw.get("TIME"),
+                rate_type=rate_type,
+                rate_value=raw.get("DATA_VALUE"),
+                unit=raw.get("UNIT_NAME"),
+            )
+        )
+    return records
+
+
+class BokInterestRateConnector:
+    """Connector for BOK interest rate data via PublicDataReader ECOS API.
+
+    Satisfies ``Connector[BokInterestRateRequest, BronzeInterestRate]`` protocol.
+    """
+
+    source_id: ClassVar[str] = "bank_of_korea_interest_rate"
+
+    def __init__(
+        self,
+        client: Ecos,
+        rate_limiter: RateLimiter,
+        now_fn: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        self._client = client
+        self._rate_limiter = rate_limiter
+        self._now_fn = now_fn
+
+    def fetch(self, request: BokInterestRateRequest) -> ConnectorResult[BronzeInterestRate]:
+        """Fetch interest rate data for one series over a date range."""
+        now = self._now_fn()
+
+        def _call_api() -> pd.DataFrame:
+            self._rate_limiter.wait()
+            result: pd.DataFrame = self._client.get_statistic_search(
+                통계표코드=request.stat_code,
+                주기=request.frequency,
+                검색시작일자=request.start_date,
+                검색종료일자=request.end_date,
+                통계항목코드1=request.item_code1,
+            )
+            return result
+
+        request_params = {
+            "stat_code": request.stat_code,
+            "item_code1": request.item_code1,
+            "frequency": request.frequency,
+            "start_date": request.start_date,
+            "end_date": request.end_date,
+        }
+
+        try:
+            raw_df = retry(_call_api)
+        except Exception as exc:
+            manifest = build_manifest(
+                source_id=request.source_id,
+                api_endpoint="StatisticSearch",
+                request_params=request_params,
+                response_count=0,
+                ingested_at=now,
+                status="failed",
+                error_message=str(exc),
+            )
+            return ConnectorResult(records=[], manifest=manifest)
+
+        # Handle empty response
+        if raw_df is None or raw_df.empty:
+            manifest = build_manifest(
+                source_id=request.source_id,
+                api_endpoint="StatisticSearch",
+                request_params=request_params,
+                response_count=0,
+                ingested_at=now,
+                status="success",
+            )
+            return ConnectorResult(records=[], manifest=manifest)
+
+        # Validate required columns
+        missing = REQUIRED_COLUMNS - set(raw_df.columns)
+        if missing:
+            msg = f"Missing expected columns in ECOS response: {sorted(missing)}"
+            raise NonRetryableError(msg)
+
+        # Stage 1: Normalize (NaN → None, TIME → ISO date)
+        raw_rows = _normalize_dataframe(raw_df, frequency=request.frequency)
+
+        # Compute hash from normalized raw dicts (before Bronze mapping)
+        response_hash = sha256_payload(raw_rows)
+
+        # Stage 2: Map to Bronze records
+        records = _map_to_bronze(
+            raw_rows,
+            rate_type=request.rate_type,
+            source_id=request.source_id,
+            ingest_timestamp=now,
+            raw_response_hash=response_hash,
+        )
+
+        manifest = build_manifest(
+            source_id=request.source_id,
+            api_endpoint="StatisticSearch",
+            request_params=request_params,
+            response_count=len(records),
+            ingested_at=now,
+            status="success",
+        )
+
+        return ConnectorResult(records=records, manifest=manifest)

--- a/apps/kr-seoul-apartment/tests/unit/test_bok.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_bok.py
@@ -1,0 +1,352 @@
+"""Unit tests for BokInterestRateConnector."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from younggeul_app_kr_seoul_apartment.connectors.bok import (
+    BokInterestRateConnector,
+    BokInterestRateRequest,
+    _normalize_dataframe,
+    _normalize_time,
+    _safe_str,
+)
+from younggeul_core.connectors.protocol import Connector, ConnectorResult
+from younggeul_core.connectors.rate_limit import RateLimiter
+from younggeul_core.connectors.retry import ConnectorError, NonRetryableError
+from younggeul_core.state.bronze import BronzeInterestRate
+
+_FIXED_NOW = datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _fixed_now() -> datetime:
+    return _FIXED_NOW
+
+
+def _make_rate_limiter() -> RateLimiter:
+    return RateLimiter(min_interval=0.0)
+
+
+def _base_rate_request() -> BokInterestRateRequest:
+    return BokInterestRateRequest(
+        stat_code="722Y001",
+        item_code1="0101000",
+        frequency="D",
+        start_date="20240101",
+        end_date="20240131",
+        rate_type="base_rate",
+        source_id="bank_of_korea_base_rate",
+    )
+
+
+def _monthly_rate_request() -> BokInterestRateRequest:
+    return BokInterestRateRequest(
+        stat_code="121Y006",
+        item_code1="BIS0020",
+        frequency="M",
+        start_date="202401",
+        end_date="202412",
+        rate_type="loan_rate",
+        source_id="bank_of_korea_loan_rate",
+    )
+
+
+def _sample_daily_dataframe() -> pd.DataFrame:
+    """Create a synthetic DataFrame matching ECOS StatisticSearch output (daily)."""
+    data: dict[str, list[Any]] = {
+        "STAT_CODE": ["722Y001"],
+        "STAT_NAME": ["한국은행 기준금리"],
+        "ITEM_CODE1": ["0101000"],
+        "ITEM_NAME1": ["한국은행 기준금리"],
+        "ITEM_CODE2": [" "],
+        "ITEM_NAME2": [" "],
+        "ITEM_CODE3": [" "],
+        "ITEM_NAME3": [" "],
+        "ITEM_CODE4": [" "],
+        "ITEM_NAME4": [" "],
+        "UNIT_NAME": ["%"],
+        "WGT": [np.nan],
+        "TIME": ["20240115"],
+        "DATA_VALUE": ["3.50"],
+    }
+    return pd.DataFrame(data)
+
+
+def _sample_monthly_dataframe() -> pd.DataFrame:
+    """Create a synthetic DataFrame matching ECOS StatisticSearch output (monthly)."""
+    data: dict[str, list[Any]] = {
+        "STAT_CODE": ["121Y006", "121Y006"],
+        "STAT_NAME": ["예금은행 대출금리", "예금은행 대출금리"],
+        "ITEM_CODE1": ["BIS0020", "BIS0020"],
+        "ITEM_NAME1": ["주택담보대출금리", "주택담보대출금리"],
+        "ITEM_CODE2": [" ", " "],
+        "ITEM_NAME2": [" ", " "],
+        "ITEM_CODE3": [" ", " "],
+        "ITEM_NAME3": [" ", " "],
+        "ITEM_CODE4": [" ", " "],
+        "ITEM_NAME4": [" ", " "],
+        "UNIT_NAME": ["연%", "연%"],
+        "WGT": [np.nan, np.nan],
+        "TIME": ["202401", "202402"],
+        "DATA_VALUE": ["4.28", "4.25"],
+    }
+    return pd.DataFrame(data)
+
+
+# ---------------------------------------------------------------------------
+# _safe_str tests
+# ---------------------------------------------------------------------------
+
+
+class TestSafeStr:
+    def test_none_returns_none(self) -> None:
+        assert _safe_str(None) is None
+
+    def test_nan_returns_none(self) -> None:
+        assert _safe_str(float("nan")) is None
+
+    def test_numpy_nan_returns_none(self) -> None:
+        assert _safe_str(np.nan) is None
+
+    def test_string_passthrough(self) -> None:
+        assert _safe_str("3.50") == "3.50"
+
+    def test_whitespace_stripped(self) -> None:
+        assert _safe_str("  hello  ") == "hello"
+
+    def test_empty_string_returns_none(self) -> None:
+        assert _safe_str("   ") is None
+
+
+# ---------------------------------------------------------------------------
+# _normalize_time tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeTime:
+    def test_daily_to_iso(self) -> None:
+        assert _normalize_time("20240115", "D") == "2024-01-15"
+
+    def test_monthly_to_iso_first_day(self) -> None:
+        assert _normalize_time("202401", "M") == "2024-01-01"
+
+    def test_quarterly_q1(self) -> None:
+        assert _normalize_time("2024Q1", "Q") == "2024-01-01"
+
+    def test_quarterly_q2(self) -> None:
+        assert _normalize_time("2024Q2", "Q") == "2024-04-01"
+
+    def test_quarterly_q3(self) -> None:
+        assert _normalize_time("2024Q3", "Q") == "2024-07-01"
+
+    def test_quarterly_q4(self) -> None:
+        assert _normalize_time("2024Q4", "Q") == "2024-10-01"
+
+    def test_annual_to_iso(self) -> None:
+        assert _normalize_time("2024", "A") == "2024-01-01"
+
+    def test_unknown_format_returns_as_is(self) -> None:
+        assert _normalize_time("20240115", "X") == "20240115"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_dataframe tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeDataframe:
+    def test_nan_converted_to_none(self) -> None:
+        df = pd.DataFrame({"WGT": [np.nan], "DATA_VALUE": ["3.50"], "TIME": ["20240101"]})
+        rows = _normalize_dataframe(df, frequency="D")
+        assert rows[0]["WGT"] is None
+        assert rows[0]["DATA_VALUE"] == "3.50"
+
+    def test_time_normalized_daily(self) -> None:
+        df = pd.DataFrame({"TIME": ["20240115"], "DATA_VALUE": ["3.50"]})
+        rows = _normalize_dataframe(df, frequency="D")
+        assert rows[0]["TIME"] == "2024-01-15"
+
+    def test_time_normalized_monthly(self) -> None:
+        df = pd.DataFrame({"TIME": ["202401"], "DATA_VALUE": ["3.50"]})
+        rows = _normalize_dataframe(df, frequency="M")
+        assert rows[0]["TIME"] == "2024-01-01"
+
+    def test_empty_dataframe(self) -> None:
+        df = pd.DataFrame()
+        rows = _normalize_dataframe(df, frequency="D")
+        assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# BokInterestRateConnector tests
+# ---------------------------------------------------------------------------
+
+
+class TestBokInterestRateConnector:
+    def _make_connector(self, client: MagicMock | None = None) -> tuple[BokInterestRateConnector, MagicMock]:
+        mock_client = client or MagicMock()
+        connector = BokInterestRateConnector(
+            client=mock_client,
+            rate_limiter=_make_rate_limiter(),
+            now_fn=_fixed_now,
+        )
+        return connector, mock_client
+
+    def test_satisfies_connector_protocol(self) -> None:
+        connector, _ = self._make_connector()
+        assert isinstance(connector, Connector)
+
+    def test_full_row_mapping_daily(self) -> None:
+        """Map a daily rate DataFrame row to BronzeInterestRate."""
+        connector, mock_client = self._make_connector()
+        mock_client.get_statistic_search.return_value = _sample_daily_dataframe()
+
+        request = _base_rate_request()
+        result = connector.fetch(request)
+
+        assert isinstance(result, ConnectorResult)
+        assert len(result.records) == 1
+
+        rec = result.records[0]
+        assert isinstance(rec, BronzeInterestRate)
+        assert rec.date == "2024-01-15"
+        assert rec.rate_type == "base_rate"
+        assert rec.rate_value == "3.50"
+        assert rec.unit == "%"
+        assert rec.source_id == "bank_of_korea_base_rate"
+        assert rec.ingest_timestamp == _FIXED_NOW
+        assert rec.raw_response_hash is not None
+        assert len(rec.raw_response_hash) == 64  # noqa: PLR2004
+
+    def test_full_row_mapping_monthly(self) -> None:
+        """Map monthly rate DataFrame rows to BronzeInterestRate."""
+        connector, mock_client = self._make_connector()
+        mock_client.get_statistic_search.return_value = _sample_monthly_dataframe()
+
+        request = _monthly_rate_request()
+        result = connector.fetch(request)
+
+        assert len(result.records) == 2  # noqa: PLR2004
+        assert result.records[0].date == "2024-01-01"
+        assert result.records[0].rate_value == "4.28"
+        assert result.records[0].rate_type == "loan_rate"
+        assert result.records[1].date == "2024-02-01"
+        assert result.records[1].rate_value == "4.25"
+
+    def test_empty_dataframe_returns_empty_result(self) -> None:
+        connector, mock_client = self._make_connector()
+        mock_client.get_statistic_search.return_value = pd.DataFrame()
+
+        request = _base_rate_request()
+        result = connector.fetch(request)
+
+        assert result.records == []
+        assert result.manifest.response_count == 0
+        assert result.manifest.status == "success"
+
+    def test_api_failure_returns_failed_manifest(self) -> None:
+        connector, mock_client = self._make_connector()
+        mock_client.get_statistic_search.side_effect = ConnectorError("ECOS timeout")
+
+        request = _base_rate_request()
+        result = connector.fetch(request)
+
+        assert result.records == []
+        assert result.manifest.status == "failed"
+        assert "ECOS timeout" in (result.manifest.error_message or "")
+
+    def test_missing_columns_raises_non_retryable(self) -> None:
+        connector, mock_client = self._make_connector()
+        mock_client.get_statistic_search.return_value = pd.DataFrame({"TIME": ["20240101"], "DATA_VALUE": ["3.50"]})
+
+        request = _base_rate_request()
+        with pytest.raises(NonRetryableError, match="Missing expected columns"):
+            connector.fetch(request)
+
+    def test_manifest_fields_correct(self) -> None:
+        connector, mock_client = self._make_connector()
+        mock_client.get_statistic_search.return_value = _sample_daily_dataframe()
+
+        request = _base_rate_request()
+        result = connector.fetch(request)
+
+        m = result.manifest
+        assert m.source_id == "bank_of_korea_base_rate"
+        assert m.api_endpoint == "StatisticSearch"
+        assert m.request_params == {
+            "stat_code": "722Y001",
+            "item_code1": "0101000",
+            "frequency": "D",
+            "start_date": "20240101",
+            "end_date": "20240131",
+        }
+        assert m.response_count == 1
+        assert m.status == "success"
+        assert m.ingested_at == _FIXED_NOW
+
+    def test_rate_limiter_called(self) -> None:
+        mock_limiter = MagicMock(spec=RateLimiter)
+        mock_client = MagicMock()
+        mock_client.get_statistic_search.return_value = _sample_daily_dataframe()
+
+        connector = BokInterestRateConnector(
+            client=mock_client,
+            rate_limiter=mock_limiter,
+            now_fn=_fixed_now,
+        )
+        request = _base_rate_request()
+        connector.fetch(request)
+
+        mock_limiter.wait.assert_called_once()
+
+    def test_hash_deterministic_for_same_data(self) -> None:
+        connector, mock_client = self._make_connector()
+        mock_client.get_statistic_search.return_value = _sample_daily_dataframe()
+
+        request = _base_rate_request()
+        r1 = connector.fetch(request)
+
+        mock_client.get_statistic_search.return_value = _sample_daily_dataframe()
+        r2 = connector.fetch(request)
+
+        assert r1.records[0].raw_response_hash == r2.records[0].raw_response_hash
+
+    def test_different_series_different_hash(self) -> None:
+        """Hashes differ for different series data (identity columns included)."""
+        connector, mock_client = self._make_connector()
+
+        mock_client.get_statistic_search.return_value = _sample_daily_dataframe()
+        r1 = connector.fetch(_base_rate_request())
+
+        mock_client.get_statistic_search.return_value = _sample_monthly_dataframe()
+        r2 = connector.fetch(_monthly_rate_request())
+
+        assert r1.records[0].raw_response_hash != r2.records[0].raw_response_hash
+
+
+# ---------------------------------------------------------------------------
+# BokInterestRateRequest tests
+# ---------------------------------------------------------------------------
+
+
+class TestBokInterestRateRequest:
+    def test_frozen(self) -> None:
+        req = _base_rate_request()
+        with pytest.raises(AttributeError):
+            req.stat_code = "999Y999"  # type: ignore[misc]
+
+    def test_fields(self) -> None:
+        req = _base_rate_request()
+        assert req.stat_code == "722Y001"
+        assert req.item_code1 == "0101000"
+        assert req.frequency == "D"
+        assert req.start_date == "20240101"
+        assert req.end_date == "20240131"
+        assert req.rate_type == "base_rate"
+        assert req.source_id == "bank_of_korea_base_rate"


### PR DESCRIPTION
## Summary

Implements `BokInterestRateConnector` for fetching interest rate data from the Bank of Korea (한국은행) ECOS Statistics API via PublicDataReader. This is the second of three data connectors in the M2 milestone.

## Design Decisions (Oracle-consulted)

- **Single parameterized connector** handles multiple rate series (기준금리, 대출금리) via `BokInterestRateRequest`
- **Partition scope**: `stat_code + item_code + frequency + start_date + end_date`
- **rate_type**: Normalized internal key (`"base_rate"`, `"loan_rate"`) — not raw Korean labels
- **date format**: ISO normalized — daily `"YYYY-MM-DD"`, monthly `"YYYY-MM-01"`, quarterly first day of quarter
- **source_id**: Per-series like `"bank_of_korea_base_rate"` (matches existing test fixtures)
- **Simple direct mapping** — no COLUMN_MAP needed (BOK has fewer fields than MOLIT)
- **Hash includes identity columns** (STAT_CODE, ITEM_CODE1) for series-aware hashing

## Changes

### Connector (`apps/kr-seoul-apartment/src/.../connectors/bok.py`)
- `BokInterestRateRequest` frozen dataclass (stat_code, item_code1, frequency, start/end date, rate_type, source_id)
- `BokInterestRateConnector` class satisfying `Connector[BokInterestRateRequest, BronzeInterestRate]` protocol
- `REQUIRED_COLUMNS` validation — missing columns → `NonRetryableError`
- `_normalize_time()` — ISO date conversion for daily/monthly/quarterly/annual frequencies
- Two-stage transform: normalize (NaN→None, TIME→ISO) → Bronze mapping
- Same retry/rate-limiter/manifest pattern as MOLIT connector

### Tests (`apps/kr-seoul-apartment/tests/unit/test_bok.py`)
- 30 unit tests across 5 test classes
- `TestSafeStr` (6): None, NaN, numpy NaN, string, whitespace strip, empty→None
- `TestNormalizeTime` (8): daily, monthly, quarterly Q1-Q4, annual, unknown fallback
- `TestNormalizeDataframe` (4): NaN→None, daily time norm, monthly time norm, empty DF
- `TestBokInterestRateConnector` (10): protocol conformance, daily mapping, monthly mapping, empty DF, API failure, missing columns, manifest fields, rate limiter, hash determinism, different-series-different-hash
- `TestBokInterestRateRequest` (2): frozen, fields
- All tests use synthetic fixtures — no real API calls

## Verification
- `ruff check .` ✅
- `ruff format --check .` ✅
- `mypy core/src/ apps/kr-seoul-apartment/src/` — 0 issues ✅
- `pytest` — 249 passed (219 existing + 30 new) ✅

Closes #85