### PR TITLE
feat(silver): add apartment transaction normalizer (Bronze→Silver)

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/__init__.py
@@ -1,0 +1,1 @@
+# transforms package

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal, InvalidOperation
+
+from younggeul_core.connectors.hashing import sha256_payload
+from younggeul_core.state.bronze import BronzeAptTransaction
+from younggeul_core.state.silver import SilverAptTransaction, SilverDataQualityScore
+
+SEOUL_GU_CODES: dict[str, str] = {
+    "11110": "종로구",
+    "11140": "중구",
+    "11170": "용산구",
+    "11200": "성동구",
+    "11215": "광진구",
+    "11230": "동대문구",
+    "11260": "중랑구",
+    "11290": "성북구",
+    "11305": "강북구",
+    "11320": "도봉구",
+    "11350": "노원구",
+    "11380": "은평구",
+    "11410": "서대문구",
+    "11440": "마포구",
+    "11470": "양천구",
+    "11500": "강서구",
+    "11530": "구로구",
+    "11545": "금천구",
+    "11560": "영등포구",
+    "11590": "동작구",
+    "11620": "관악구",
+    "11650": "서초구",
+    "11680": "강남구",
+    "11710": "송파구",
+    "11740": "강동구",
+}
+
+
+def parse_deal_amount(raw: str | None) -> int | None:
+    if raw is None:
+        return None
+    cleaned = raw.replace(",", "").strip()
+    if not cleaned:
+        return None
+    try:
+        amount_manwon = int(cleaned)
+    except ValueError:
+        return None
+    return amount_manwon * 10_000
+
+
+def parse_deal_date(year: str | None, month: str | None, day: str | None) -> date | None:
+    y = parse_int(year)
+    m = parse_int(month)
+    d = parse_int(day)
+    if y is None or m is None or d is None:
+        return None
+    try:
+        return date(y, m, d)
+    except ValueError:
+        return None
+
+
+def parse_int(raw: str | None) -> int | None:
+    if raw is None:
+        return None
+    cleaned = raw.strip()
+    if not cleaned:
+        return None
+    try:
+        return int(cleaned)
+    except ValueError:
+        return None
+
+
+def parse_decimal(raw: str | None) -> Decimal | None:
+    if raw is None:
+        return None
+    cleaned = raw.strip()
+    if not cleaned:
+        return None
+    try:
+        return Decimal(cleaned)
+    except InvalidOperation:
+        return None
+
+
+def derive_gu_code(sgg_code: str | None) -> str | None:
+    if sgg_code in SEOUL_GU_CODES:
+        return sgg_code
+    return None
+
+
+def derive_gu_name(gu_code: str | None) -> str | None:
+    if gu_code is None:
+        return None
+    return SEOUL_GU_CODES.get(gu_code)
+
+
+def is_cancelled(cancel_deal_type: str | None) -> bool:
+    if cancel_deal_type is None:
+        return False
+    return bool(cancel_deal_type.strip())
+
+
+def generate_transaction_id(bronze: BronzeAptTransaction) -> str:
+    payload = [
+        {
+            "sgg_code": bronze.sgg_code,
+            "deal_year": bronze.deal_year,
+            "deal_month": bronze.deal_month,
+            "deal_day": bronze.deal_day,
+            "apt_name": bronze.apt_name,
+            "floor": bronze.floor,
+            "area_exclusive": bronze.area_exclusive,
+            "serial_number": bronze.serial_number,
+        }
+    ]
+    return sha256_payload(payload)
+
+
+def compute_quality_score(bronze: BronzeAptTransaction, silver_fields: dict[str, object]) -> SilverDataQualityScore:
+    _ = bronze
+
+    completeness_fields = (
+        "deal_amount",
+        "deal_date",
+        "gu_code",
+        "apt_name",
+        "floor",
+        "area_exclusive_m2",
+    )
+    present_count = sum(1 for field in completeness_fields if silver_fields.get(field) is not None)
+    completeness = (present_count / len(completeness_fields)) * 100.0
+
+    consistency = 100.0
+    floor = silver_fields.get("floor")
+    area = silver_fields.get("area_exclusive_m2")
+    build_year = silver_fields.get("build_year")
+    deal_amount = silver_fields.get("deal_amount")
+
+    if isinstance(floor, int):
+        if floor < 1 or floor > 200:
+            consistency -= 25.0
+    else:
+        consistency -= 25.0
+
+    if isinstance(area, Decimal):
+        if area < Decimal("1") or area > Decimal("1000"):
+            consistency -= 25.0
+    else:
+        consistency -= 25.0
+
+    if isinstance(build_year, int):
+        if build_year < 1900 or build_year > 2030:
+            consistency -= 25.0
+    else:
+        consistency -= 25.0
+
+    if isinstance(deal_amount, int):
+        if deal_amount <= 0:
+            consistency -= 25.0
+    else:
+        consistency -= 25.0
+
+    if consistency < 0.0:
+        consistency = 0.0
+
+    overall = (completeness + consistency) / 2.0
+    return SilverDataQualityScore(
+        completeness=completeness,
+        consistency=consistency,
+        overall=overall,
+    )
+
+
+def _parse_cancel_date(raw: str | None) -> date | None:
+    if raw is None:
+        return None
+    cleaned = raw.strip()
+    if len(cleaned) != 8 or not cleaned.isdigit():
+        return None
+    return parse_deal_date(cleaned[0:4], cleaned[4:6], cleaned[6:8])
+
+
+def normalize_apt_transaction(bronze: BronzeAptTransaction) -> SilverAptTransaction | None:
+    gu_code = derive_gu_code(bronze.sgg_code)
+    if gu_code is None:
+        return None
+
+    gu_name = derive_gu_name(gu_code)
+    if gu_name is None:
+        return None
+
+    deal_amount = parse_deal_amount(bronze.deal_amount)
+    deal_date = parse_deal_date(bronze.deal_year, bronze.deal_month, bronze.deal_day)
+    build_year = parse_int(bronze.build_year)
+    floor = parse_int(bronze.floor)
+    area_exclusive_m2 = parse_decimal(bronze.area_exclusive)
+
+    if deal_amount is None or deal_date is None or build_year is None or floor is None or area_exclusive_m2 is None:
+        return None
+
+    dong_code = ""
+    if bronze.sgg_code is not None and bronze.umd_code is not None:
+        dong_code = f"{bronze.sgg_code}{bronze.umd_code}"
+
+    apt_name = bronze.apt_name or ""
+    silver_fields: dict[str, object] = {
+        "deal_amount": deal_amount,
+        "deal_date": deal_date,
+        "gu_code": gu_code,
+        "apt_name": apt_name,
+        "floor": floor,
+        "area_exclusive_m2": area_exclusive_m2,
+        "build_year": build_year,
+    }
+    quality_score = compute_quality_score(bronze, silver_fields)
+
+    return SilverAptTransaction(
+        transaction_id=generate_transaction_id(bronze),
+        deal_amount=deal_amount,
+        deal_date=deal_date,
+        build_year=build_year,
+        dong_code=dong_code,
+        dong_name=bronze.dong or "",
+        gu_code=gu_code,
+        gu_name=gu_name,
+        apt_name=apt_name,
+        floor=floor,
+        area_exclusive_m2=area_exclusive_m2,
+        jibun=bronze.jibun,
+        road_name=bronze.road_name,
+        is_cancelled=is_cancelled(bronze.cancel_deal_type),
+        cancel_date=_parse_cancel_date(bronze.cancel_deal_day),
+        deal_type=bronze.req_gbn,
+        source_id=bronze.source_id,
+        ingest_timestamp=bronze.ingest_timestamp,
+        quality_score=quality_score,
+    )
+
+
+def normalize_batch(records: list[BronzeAptTransaction]) -> list[SilverAptTransaction]:
+    normalized: list[SilverAptTransaction] = []
+    for record in records:
+        silver = normalize_apt_transaction(record)
+        if silver is not None:
+            normalized.append(silver)
+    return normalized

--- a/apps/kr-seoul-apartment/tests/unit/test_silver_apt.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_silver_apt.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from younggeul_app_kr_seoul_apartment.transforms.silver_apt import (
+    compute_quality_score,
+    derive_gu_code,
+    derive_gu_name,
+    generate_transaction_id,
+    is_cancelled,
+    normalize_apt_transaction,
+    normalize_batch,
+    parse_deal_amount,
+    parse_deal_date,
+    parse_decimal,
+    parse_int,
+)
+from younggeul_core.state.bronze import BronzeAptTransaction
+from younggeul_core.state.silver import SilverAptTransaction
+
+_FIXED_NOW = datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _base_bronze_data() -> dict[str, Any]:
+    return {
+        "ingest_timestamp": _FIXED_NOW,
+        "source_id": "molit.apartment.transactions",
+        "raw_response_hash": "abc" * 21 + "a",
+        "deal_amount": "82,000",
+        "build_year": "2016",
+        "deal_year": "2025",
+        "deal_month": "7",
+        "deal_day": "15",
+        "dong": "역삼동",
+        "apt_name": "래미안",
+        "floor": "12",
+        "area_exclusive": "84.99",
+        "jibun": "123-45",
+        "road_name": "테헤란로",
+        "serial_number": "2025-001",
+        "cancel_deal_type": None,
+        "cancel_deal_day": None,
+        "req_gbn": "중개거래",
+        "sgg_code": "11680",
+        "umd_code": "10300",
+    }
+
+
+def _make_bronze(**overrides: Any) -> BronzeAptTransaction:
+    payload = _base_bronze_data()
+    payload.update(overrides)
+    return BronzeAptTransaction(**payload)
+
+
+class TestParseDealAmount:
+    def test_none_returns_none(self) -> None:
+        assert parse_deal_amount(None) is None
+
+    def test_empty_returns_none(self) -> None:
+        assert parse_deal_amount("") is None
+
+    def test_comma_amount_82000(self) -> None:
+        assert parse_deal_amount("82,000") == 820_000_000
+
+    def test_comma_amount_50000(self) -> None:
+        assert parse_deal_amount("50,000") == 500_000_000
+
+    def test_no_comma_amount(self) -> None:
+        assert parse_deal_amount("82000") == 820_000_000
+
+    def test_invalid_returns_none(self) -> None:
+        assert parse_deal_amount("abc") is None
+
+
+class TestParseDealDate:
+    def test_valid_date(self) -> None:
+        assert parse_deal_date("2025", "7", "15") == date(2025, 7, 15)
+
+    def test_none_year_returns_none(self) -> None:
+        assert parse_deal_date(None, "7", "15") is None
+
+    def test_none_month_returns_none(self) -> None:
+        assert parse_deal_date("2025", None, "15") is None
+
+    def test_none_day_returns_none(self) -> None:
+        assert parse_deal_date("2025", "7", None) is None
+
+    def test_invalid_day_returns_none(self) -> None:
+        assert parse_deal_date("2025", "7", "32") is None
+
+
+class TestParseInt:
+    def test_valid_parse(self) -> None:
+        assert parse_int("12") == 12
+
+    def test_none_returns_none(self) -> None:
+        assert parse_int(None) is None
+
+    def test_empty_returns_none(self) -> None:
+        assert parse_int("") is None
+
+    def test_invalid_returns_none(self) -> None:
+        assert parse_int("xx") is None
+
+
+class TestParseDecimal:
+    def test_valid_parse(self) -> None:
+        assert parse_decimal("84.99") == Decimal("84.99")
+
+    def test_none_returns_none(self) -> None:
+        assert parse_decimal(None) is None
+
+    def test_empty_returns_none(self) -> None:
+        assert parse_decimal("") is None
+
+    def test_invalid_returns_none(self) -> None:
+        assert parse_decimal("xx") is None
+
+
+class TestDeriveGuCode:
+    def test_valid_seoul_code_returns_code(self) -> None:
+        assert derive_gu_code("11680") == "11680"
+
+    def test_non_seoul_code_returns_none(self) -> None:
+        assert derive_gu_code("41135") is None
+
+    def test_none_returns_none(self) -> None:
+        assert derive_gu_code(None) is None
+
+
+class TestDeriveGuName:
+    def test_valid_lookup_returns_name(self) -> None:
+        assert derive_gu_name("11680") == "강남구"
+
+    def test_unknown_returns_none(self) -> None:
+        assert derive_gu_name("99999") is None
+
+
+class TestIsCancelled:
+    def test_none_is_false(self) -> None:
+        assert is_cancelled(None) is False
+
+    def test_empty_is_false(self) -> None:
+        assert is_cancelled("") is False
+
+    def test_o_is_true(self) -> None:
+        assert is_cancelled("O") is True
+
+    def test_whitespace_is_false(self) -> None:
+        assert is_cancelled("   ") is False
+
+
+class TestGenerateTransactionId:
+    def test_deterministic_for_same_record(self) -> None:
+        bronze = _make_bronze()
+        assert generate_transaction_id(bronze) == generate_transaction_id(bronze)
+
+    def test_different_input_changes_id(self) -> None:
+        bronze1 = _make_bronze(serial_number="2025-001")
+        bronze2 = _make_bronze(serial_number="2025-002")
+        assert generate_transaction_id(bronze1) != generate_transaction_id(bronze2)
+
+
+class TestComputeQualityScore:
+    def test_all_fields_present_high_score(self) -> None:
+        bronze = _make_bronze()
+        fields: dict[str, object] = {
+            "deal_amount": 820_000_000,
+            "deal_date": date(2025, 7, 15),
+            "gu_code": "11680",
+            "apt_name": "래미안",
+            "floor": 12,
+            "area_exclusive_m2": Decimal("84.99"),
+            "build_year": 2016,
+        }
+        score = compute_quality_score(bronze, fields)
+        assert score.completeness == 100.0
+        assert score.consistency == 100.0
+        assert score.overall == 100.0
+
+    def test_missing_fields_lower_completeness(self) -> None:
+        bronze = _make_bronze()
+        fields: dict[str, object] = {
+            "deal_amount": 820_000_000,
+            "deal_date": date(2025, 7, 15),
+            "gu_code": "11680",
+            "apt_name": None,
+            "floor": 12,
+            "area_exclusive_m2": Decimal("84.99"),
+            "build_year": 2016,
+        }
+        score = compute_quality_score(bronze, fields)
+        assert score.completeness < 100.0
+        assert score.consistency == 100.0
+
+    def test_invalid_ranges_lower_consistency(self) -> None:
+        bronze = _make_bronze()
+        fields: dict[str, object] = {
+            "deal_amount": -1,
+            "deal_date": date(2025, 7, 15),
+            "gu_code": "11680",
+            "apt_name": "래미안",
+            "floor": 0,
+            "area_exclusive_m2": Decimal("1001"),
+            "build_year": 1800,
+        }
+        score = compute_quality_score(bronze, fields)
+        assert score.completeness == 100.0
+        assert score.consistency == 0.0
+        assert score.overall == 50.0
+
+
+class TestNormalizeAptTransaction:
+    def test_full_happy_path_maps_all_fields(self) -> None:
+        bronze = _make_bronze()
+        silver = normalize_apt_transaction(bronze)
+
+        assert isinstance(silver, SilverAptTransaction)
+        assert silver.transaction_id == generate_transaction_id(bronze)
+        assert silver.deal_amount == 820_000_000
+        assert silver.deal_date == date(2025, 7, 15)
+        assert silver.build_year == 2016
+        assert silver.dong_code == "1168010300"
+        assert silver.dong_name == "역삼동"
+        assert silver.gu_code == "11680"
+        assert silver.gu_name == "강남구"
+        assert silver.apt_name == "래미안"
+        assert silver.floor == 12
+        assert silver.area_exclusive_m2 == Decimal("84.99")
+        assert silver.jibun == "123-45"
+        assert silver.road_name == "테헤란로"
+        assert silver.is_cancelled is False
+        assert silver.cancel_date is None
+        assert silver.deal_type == "중개거래"
+        assert silver.source_id == "molit.apartment.transactions"
+        assert silver.ingest_timestamp == _FIXED_NOW
+        assert silver.quality_score is not None
+        assert silver.quality_score.overall == 100.0
+
+    def test_non_seoul_filtered_out(self) -> None:
+        bronze = _make_bronze(sgg_code="41135")
+        assert normalize_apt_transaction(bronze) is None
+
+    def test_cancelled_transaction_flag_true(self) -> None:
+        bronze = _make_bronze(cancel_deal_type="O", cancel_deal_day="20250720")
+        silver = normalize_apt_transaction(bronze)
+        assert silver is not None
+        assert silver.is_cancelled is True
+        assert silver.cancel_date == date(2025, 7, 20)
+
+    def test_missing_optional_fields_handled(self) -> None:
+        bronze = _make_bronze(jibun=None, road_name=None, dong=None, umd_code=None, req_gbn=None)
+        silver = normalize_apt_transaction(bronze)
+        assert silver is not None
+        assert silver.jibun is None
+        assert silver.road_name is None
+        assert silver.dong_name == ""
+        assert silver.dong_code == ""
+        assert silver.deal_type is None
+
+    def test_unparseable_build_year_skipped(self) -> None:
+        bronze = _make_bronze(build_year="abc")
+        assert normalize_apt_transaction(bronze) is None
+
+    def test_unparseable_floor_skipped(self) -> None:
+        bronze = _make_bronze(floor="abc")
+        assert normalize_apt_transaction(bronze) is None
+
+    def test_unparseable_deal_amount_skipped(self) -> None:
+        bronze = _make_bronze(deal_amount="abc")
+        assert normalize_apt_transaction(bronze) is None
+
+    def test_unparseable_deal_date_skipped(self) -> None:
+        bronze = _make_bronze(deal_day="32")
+        assert normalize_apt_transaction(bronze) is None
+
+
+class TestNormalizeBatch:
+    def test_filters_out_non_seoul_and_keeps_seoul(self) -> None:
+        seoul = _make_bronze(sgg_code="11680")
+        non_seoul = _make_bronze(sgg_code="41135")
+        rows = normalize_batch([seoul, non_seoul])
+        assert len(rows) == 1
+        assert rows[0].gu_code == "11680"
+
+    def test_skips_invalid_required_parse_fields(self) -> None:
+        valid = _make_bronze()
+        invalid = _make_bronze(build_year="bad")
+        rows = normalize_batch([valid, invalid])
+        assert len(rows) == 1
+        assert rows[0].build_year == 2016


### PR DESCRIPTION
## Summary

Implements the Silver apartment transaction normalizer — the first transform in the M3 Silver & Gold pipeline.

### Changes
- **`transforms/silver_apt.py`**: Deterministic Bronze→Silver transform for MOLIT apartment transaction data
  - Parse `deal_amount` (만원→원), `deal_date`, `build_year`, `floor`, `area_exclusive_m2` from raw Bronze strings
  - Filter Seoul-only records via `SEOUL_GU_CODES` (25 districts)
  - Generate deterministic `transaction_id` via SHA-256 of key fields
  - Compute `quality_score` (completeness + consistency + overall, 0-100 range)
  - Skip records with unparseable required fields (return `None`)
  - Handle cancellation flag (`is_cancelled`) and `cancel_date` parsing (`YYYYMMDD` format)
- **`transforms/__init__.py`**: Package init
- **`tests/unit/test_silver_apt.py`**: 43 unit tests covering all parse functions, filtering, quality scoring, full normalization, and batch processing

### Design Decisions
- **Seoul-only filter**: Records with `sgg_code` not in `SEOUL_GU_CODES` are silently dropped (non-Seoul data irrelevant for v0.1 scope)
- **Required fields**: If any of `deal_amount`, `deal_date`, `build_year`, `floor`, `area_exclusive_m2` can't be parsed → record skipped entirely
- **No LLMs** (ADR-004): All transforms are 100% deterministic
- **App-specific**: Code lives in `apps/kr-seoul-apartment/`, not `core/` (per Oracle architecture decision)

### Verification
- ✅ `ruff format --check` — clean
- ✅ `ruff check` — clean
- ✅ `pytest` — 326 tests passed (283 existing + 43 new), no regressions

Closes #89