### PR TITLE
feat(snapshot): add file-based snapshot publisher and resolver

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/snapshot.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/snapshot.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from younggeul_core.state.gold import GoldDistrictMonthlyMetrics
+from younggeul_core.state.simulation import SnapshotRef
+from younggeul_core.storage.snapshot import SnapshotManifest, SnapshotTableEntry
+
+_TABLE_NAME = "gold_district_monthly_metrics"
+_TABLE_FILE_NAME = "gold_district_monthly_metrics.jsonl"
+_MANIFEST_FILE_NAME = "manifest.json"
+
+
+def _sorted_gold_rows(gold_rows: list[GoldDistrictMonthlyMetrics]) -> list[GoldDistrictMonthlyMetrics]:
+    return sorted(gold_rows, key=lambda row: (row.gu_code, row.period))
+
+
+def _jsonl_bytes(gold_rows: list[GoldDistrictMonthlyMetrics]) -> bytes:
+    if not gold_rows:
+        return b""
+    lines = [row.model_dump_json().encode("utf-8") for row in gold_rows]
+    return b"\n".join(lines) + b"\n"
+
+
+def _load_manifest(manifest_path: Path) -> SnapshotManifest:
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValueError(f"Invalid manifest JSON at {manifest_path}") from exc
+
+    try:
+        manifest = SnapshotManifest.model_validate(payload)
+    except ValidationError as exc:
+        raise ValueError(f"Invalid manifest schema at {manifest_path}") from exc
+
+    if not manifest.validate_integrity():
+        raise ValueError(f"Manifest integrity check failed at {manifest_path}")
+
+    return manifest
+
+
+def publish_snapshot(gold_rows: list[GoldDistrictMonthlyMetrics], base_dir: Path) -> SnapshotRef:
+    sorted_rows = _sorted_gold_rows(gold_rows)
+    jsonl_content = _jsonl_bytes(sorted_rows)
+    table_hash = hashlib.sha256(jsonl_content).hexdigest()
+    dataset_snapshot_id = SnapshotManifest.compute_snapshot_id({_TABLE_NAME: table_hash})
+
+    snapshot_dir = base_dir / dataset_snapshot_id
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+    table_path = snapshot_dir / _TABLE_FILE_NAME
+    table_path.write_bytes(jsonl_content)
+
+    created_at = datetime.now(timezone.utc)
+    manifest = SnapshotManifest(
+        dataset_snapshot_id=dataset_snapshot_id,
+        created_at=created_at,
+        table_entries=[
+            SnapshotTableEntry(
+                table_name=_TABLE_NAME,
+                table_hash=table_hash,
+                record_count=len(sorted_rows),
+                schema_version="1.0.0",
+                file_format="jsonl",
+            )
+        ],
+    )
+
+    manifest_path = snapshot_dir / _MANIFEST_FILE_NAME
+    manifest_path.write_text(manifest.model_dump_json(), encoding="utf-8")
+
+    return SnapshotRef(
+        dataset_snapshot_id=dataset_snapshot_id,
+        created_at=created_at,
+        table_count=1,
+    )
+
+
+def resolve_snapshot(snapshot_id: str, base_dir: Path) -> tuple[SnapshotManifest, list[GoldDistrictMonthlyMetrics]]:
+    if snapshot_id == "latest":
+        latest_manifest: SnapshotManifest | None = None
+        latest_snapshot_dir: Path | None = None
+
+        for candidate in base_dir.iterdir():
+            if not candidate.is_dir():
+                continue
+            manifest_path = candidate / _MANIFEST_FILE_NAME
+            if not manifest_path.exists():
+                continue
+            manifest = _load_manifest(manifest_path)
+            if latest_manifest is None or manifest.created_at > latest_manifest.created_at:
+                latest_manifest = manifest
+                latest_snapshot_dir = candidate
+
+        if latest_manifest is None or latest_snapshot_dir is None:
+            raise FileNotFoundError(f"No snapshots found in {base_dir}")
+
+        manifest = latest_manifest
+        snapshot_dir = latest_snapshot_dir
+    else:
+        snapshot_dir = base_dir / snapshot_id
+        if not snapshot_dir.exists():
+            raise FileNotFoundError(f"Snapshot directory not found: {snapshot_dir}")
+
+        manifest = _load_manifest(snapshot_dir / _MANIFEST_FILE_NAME)
+
+    table_entry = manifest.get_table(_TABLE_NAME)
+    if table_entry is None:
+        raise ValueError(f"Manifest missing table entry: {_TABLE_NAME}")
+
+    table_path = snapshot_dir / _TABLE_FILE_NAME
+    table_content = table_path.read_bytes()
+    computed_hash = hashlib.sha256(table_content).hexdigest()
+    if computed_hash != table_entry.table_hash:
+        raise ValueError(f"Table hash mismatch for {_TABLE_NAME}")
+
+    decoded = table_content.decode("utf-8")
+    rows: list[GoldDistrictMonthlyMetrics] = []
+    for line in decoded.splitlines():
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSONL content at {table_path}") from exc
+        try:
+            rows.append(GoldDistrictMonthlyMetrics.model_validate(payload))
+        except ValidationError as exc:
+            raise ValueError(f"Invalid gold row content at {table_path}") from exc
+
+    return manifest, rows

--- a/apps/kr-seoul-apartment/tests/unit/test_snapshot.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_snapshot.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from younggeul_app_kr_seoul_apartment.snapshot import publish_snapshot, resolve_snapshot
+from younggeul_core.state.gold import GoldDistrictMonthlyMetrics
+from younggeul_core.state.simulation import SnapshotRef
+from younggeul_core.storage.snapshot import SnapshotManifest, SnapshotTableEntry
+
+
+def _make_gold(**overrides: Any) -> GoldDistrictMonthlyMetrics:
+    payload: dict[str, Any] = {
+        "gu_code": "11680",
+        "gu_name": "강남구",
+        "period": "2025-07",
+        "sale_count": 10,
+        "avg_price": 1_000,
+        "median_price": 1_000,
+        "min_price": 900,
+        "max_price": 1_100,
+        "price_per_pyeong_avg": 300,
+        "yoy_price_change": None,
+        "mom_price_change": None,
+        "yoy_volume_change": None,
+        "mom_volume_change": None,
+        "avg_area_m2": Decimal("84.99"),
+        "base_interest_rate": Decimal("3.50"),
+        "net_migration": 10000,
+        "dataset_snapshot_id": "free-form-gold-snapshot-id",
+    }
+    payload.update(overrides)
+    return GoldDistrictMonthlyMetrics(**payload)
+
+
+def _snapshot_dir(base_dir: Path, snapshot_id: str) -> Path:
+    return base_dir / snapshot_id
+
+
+def _manifest_path(base_dir: Path, snapshot_id: str) -> Path:
+    return _snapshot_dir(base_dir, snapshot_id) / "manifest.json"
+
+
+def _table_path(base_dir: Path, snapshot_id: str) -> Path:
+    return _snapshot_dir(base_dir, snapshot_id) / "gold_district_monthly_metrics.jsonl"
+
+
+def _load_manifest(base_dir: Path, snapshot_id: str) -> dict[str, Any]:
+    payload = json.loads(_manifest_path(base_dir, snapshot_id).read_text(encoding="utf-8"))
+    return cast(dict[str, Any], payload)
+
+
+def _make_jsonl_bytes(rows: list[GoldDistrictMonthlyMetrics]) -> bytes:
+    if not rows:
+        return b""
+    return b"\n".join(row.model_dump_json().encode("utf-8") for row in rows) + b"\n"
+
+
+def _write_manual_snapshot(
+    base_dir: Path,
+    content: bytes,
+    created_at: datetime,
+) -> str:
+
+    table_hash = hashlib.sha256(content).hexdigest()
+    dataset_snapshot_id = SnapshotManifest.compute_snapshot_id({"gold_district_monthly_metrics": table_hash})
+
+    snapshot_dir = base_dir / dataset_snapshot_id
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+    table_file = snapshot_dir / "gold_district_monthly_metrics.jsonl"
+    table_file.write_bytes(content)
+
+    manifest = SnapshotManifest(
+        dataset_snapshot_id=dataset_snapshot_id,
+        created_at=created_at,
+        table_entries=[
+            SnapshotTableEntry(
+                table_name="gold_district_monthly_metrics",
+                table_hash=table_hash,
+                record_count=len(content.splitlines()),
+                schema_version="1.0.0",
+                file_format="jsonl",
+            )
+        ],
+    )
+    (snapshot_dir / "manifest.json").write_text(manifest.model_dump_json(), encoding="utf-8")
+    return dataset_snapshot_id
+
+
+class TestPublishSnapshot:
+    def test_returns_snapshot_ref_with_expected_fields(self, tmp_path: Path) -> None:
+        row = _make_gold()
+
+        ref = publish_snapshot([row], tmp_path)
+
+        assert isinstance(ref, SnapshotRef)
+        assert len(ref.dataset_snapshot_id) == 64
+        assert ref.table_count == 1
+        assert ref.created_at.tzinfo is not None
+
+    def test_creates_snapshot_directory_and_expected_files(self, tmp_path: Path) -> None:
+        ref = publish_snapshot([_make_gold()], tmp_path)
+
+        snapshot_dir = _snapshot_dir(tmp_path, ref.dataset_snapshot_id)
+        assert snapshot_dir.is_dir()
+        assert _manifest_path(tmp_path, ref.dataset_snapshot_id).is_file()
+        assert _table_path(tmp_path, ref.dataset_snapshot_id).is_file()
+
+    def test_writes_rows_sorted_by_gu_code_and_period(self, tmp_path: Path) -> None:
+        rows = [
+            _make_gold(gu_code="11710", gu_name="송파구", period="2025-08"),
+            _make_gold(gu_code="11680", gu_name="강남구", period="2025-08"),
+            _make_gold(gu_code="11680", gu_name="강남구", period="2025-07"),
+        ]
+        ref = publish_snapshot(rows, tmp_path)
+
+        content = _table_path(tmp_path, ref.dataset_snapshot_id).read_text(encoding="utf-8")
+        restored = [GoldDistrictMonthlyMetrics.model_validate(json.loads(line)) for line in content.splitlines()]
+
+        assert [(row.gu_code, row.period) for row in restored] == [
+            ("11680", "2025-07"),
+            ("11680", "2025-08"),
+            ("11710", "2025-08"),
+        ]
+
+    def test_snapshot_id_is_deterministic_for_same_rows(self, tmp_path: Path) -> None:
+        rows = [
+            _make_gold(gu_code="11710", gu_name="송파구", period="2025-08"),
+            _make_gold(gu_code="11680", gu_name="강남구", period="2025-07"),
+        ]
+
+        first = publish_snapshot(rows, tmp_path / "run-a")
+        second = publish_snapshot(list(reversed(rows)), tmp_path / "run-b")
+
+        assert first.dataset_snapshot_id == second.dataset_snapshot_id
+
+    def test_empty_rows_creates_empty_jsonl_and_zero_record_count(self, tmp_path: Path) -> None:
+        ref = publish_snapshot([], tmp_path)
+
+        assert _table_path(tmp_path, ref.dataset_snapshot_id).read_bytes() == b""
+        manifest = SnapshotManifest.model_validate_json(
+            _manifest_path(tmp_path, ref.dataset_snapshot_id).read_text(encoding="utf-8")
+        )
+        entry = manifest.get_table("gold_district_monthly_metrics")
+
+        assert entry is not None
+        assert entry.record_count == 0
+        assert manifest.validate_integrity() is True
+
+    def test_manifest_table_hash_matches_jsonl_file_bytes(self, tmp_path: Path) -> None:
+        ref = publish_snapshot([_make_gold(), _make_gold(period="2025-08")], tmp_path)
+
+        table_bytes = _table_path(tmp_path, ref.dataset_snapshot_id).read_bytes()
+        manifest = SnapshotManifest.model_validate_json(
+            _manifest_path(tmp_path, ref.dataset_snapshot_id).read_text(encoding="utf-8")
+        )
+        entry = manifest.get_table("gold_district_monthly_metrics")
+
+        assert entry is not None
+        assert entry.table_hash == hashlib.sha256(table_bytes).hexdigest()
+
+    def test_manifest_sets_jsonl_file_format_and_schema_version(self, tmp_path: Path) -> None:
+        ref = publish_snapshot([_make_gold()], tmp_path)
+        manifest = SnapshotManifest.model_validate_json(
+            _manifest_path(tmp_path, ref.dataset_snapshot_id).read_text(encoding="utf-8")
+        )
+        entry = manifest.get_table("gold_district_monthly_metrics")
+
+        assert entry is not None
+        assert entry.file_format == "jsonl"
+        assert entry.schema_version == "1.0.0"
+
+    def test_does_not_mutate_dataset_snapshot_id_on_input_rows(self, tmp_path: Path) -> None:
+        row = _make_gold(dataset_snapshot_id="custom-row-id")
+
+        publish_snapshot([row], tmp_path)
+
+        assert row.dataset_snapshot_id == "custom-row-id"
+
+    def test_supports_duplicate_rows(self, tmp_path: Path) -> None:
+        row = _make_gold()
+        ref = publish_snapshot([row, row], tmp_path)
+
+        manifest = SnapshotManifest.model_validate_json(
+            _manifest_path(tmp_path, ref.dataset_snapshot_id).read_text(encoding="utf-8")
+        )
+        _, restored = resolve_snapshot(ref.dataset_snapshot_id, tmp_path)
+
+        entry = manifest.get_table("gold_district_monthly_metrics")
+        assert entry is not None
+        assert entry.record_count == 2
+        assert restored == [row, row]
+
+    def test_supports_single_row_publish(self, tmp_path: Path) -> None:
+        row = _make_gold(gu_code="11470", gu_name="양천구")
+
+        ref = publish_snapshot([row], tmp_path)
+        _, restored = resolve_snapshot(ref.dataset_snapshot_id, tmp_path)
+
+        assert restored == [row]
+
+    def test_supports_special_characters_in_gu_name(self, tmp_path: Path) -> None:
+        row = _make_gold(gu_name='종로구 "청계천" 🏙️ / 테스트')
+
+        ref = publish_snapshot([row], tmp_path)
+        _, restored = resolve_snapshot(ref.dataset_snapshot_id, tmp_path)
+
+        assert restored[0].gu_name == '종로구 "청계천" 🏙️ / 테스트'
+
+
+class TestResolveSnapshot:
+    def test_resolve_by_explicit_snapshot_id(self, tmp_path: Path) -> None:
+        rows = [_make_gold(period="2025-07"), _make_gold(period="2025-08")]
+        ref = publish_snapshot(rows, tmp_path)
+
+        manifest, restored = resolve_snapshot(ref.dataset_snapshot_id, tmp_path)
+
+        assert manifest.dataset_snapshot_id == ref.dataset_snapshot_id
+        assert restored == sorted(rows, key=lambda row: (row.gu_code, row.period))
+
+    def test_resolve_latest_picks_manifest_with_newest_created_at(self, tmp_path: Path) -> None:
+        first_ref = publish_snapshot([_make_gold(period="2025-07")], tmp_path)
+        second_ref = publish_snapshot([_make_gold(period="2025-08")], tmp_path)
+
+        first_manifest = _load_manifest(tmp_path, first_ref.dataset_snapshot_id)
+        second_manifest = _load_manifest(tmp_path, second_ref.dataset_snapshot_id)
+        first_manifest["created_at"] = "2026-03-29T00:00:00Z"
+        second_manifest["created_at"] = "2026-03-30T00:00:00Z"
+        _manifest_path(tmp_path, first_ref.dataset_snapshot_id).write_text(
+            json.dumps(first_manifest, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        _manifest_path(tmp_path, second_ref.dataset_snapshot_id).write_text(
+            json.dumps(second_manifest, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        manifest, rows = resolve_snapshot("latest", tmp_path)
+
+        assert manifest.dataset_snapshot_id == second_ref.dataset_snapshot_id
+        assert rows == sorted([_make_gold(period="2025-08")], key=lambda row: (row.gu_code, row.period))
+
+    def test_resolve_latest_with_single_snapshot(self, tmp_path: Path) -> None:
+        ref = publish_snapshot([_make_gold(period="2025-09")], tmp_path)
+
+        manifest, rows = resolve_snapshot("latest", tmp_path)
+
+        assert manifest.dataset_snapshot_id == ref.dataset_snapshot_id
+        assert len(rows) == 1
+        assert rows[0].period == "2025-09"
+
+    def test_latest_raises_when_base_dir_has_no_snapshots(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            resolve_snapshot("latest", tmp_path)
+
+    def test_explicit_snapshot_id_raises_when_directory_missing(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            resolve_snapshot("a" * 64, tmp_path)
+
+    def test_explicit_snapshot_id_raises_when_manifest_missing(self, tmp_path: Path) -> None:
+        snapshot_id = "b" * 64
+        _snapshot_dir(tmp_path, snapshot_id).mkdir(parents=True)
+
+        with pytest.raises(FileNotFoundError):
+            resolve_snapshot(snapshot_id, tmp_path)
+
+    def test_explicit_snapshot_id_raises_when_jsonl_missing(self, tmp_path: Path) -> None:
+        ref = publish_snapshot([_make_gold()], tmp_path)
+        _table_path(tmp_path, ref.dataset_snapshot_id).unlink()
+
+        with pytest.raises(FileNotFoundError):
+            resolve_snapshot(ref.dataset_snapshot_id, tmp_path)
+
+    def test_latest_ignores_non_snapshot_directories_without_manifest(self, tmp_path: Path) -> None:
+        (tmp_path / "misc").mkdir(parents=True)
+        ref = publish_snapshot([_make_gold(period="2025-11")], tmp_path)
+
+        manifest, rows = resolve_snapshot("latest", tmp_path)
+
+        assert manifest.dataset_snapshot_id == ref.dataset_snapshot_id
+        assert rows[0].period == "2025-11"
+
+
+class TestResolveSnapshotIntegrity:
+    def test_detects_tampered_jsonl_content_hash_mismatch(self, tmp_path: Path) -> None:
+        ref = publish_snapshot([_make_gold()], tmp_path)
+        table_file = _table_path(tmp_path, ref.dataset_snapshot_id)
+        table_file.write_text(table_file.read_text(encoding="utf-8") + '{"tampered":true}\n', encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Table hash mismatch"):
+            resolve_snapshot(ref.dataset_snapshot_id, tmp_path)
+
+    def test_detects_tampered_manifest_table_hash_integrity_failure(self, tmp_path: Path) -> None:
+        ref = publish_snapshot([_make_gold()], tmp_path)
+        payload = _load_manifest(tmp_path, ref.dataset_snapshot_id)
+        payload["table_entries"][0]["table_hash"] = "f" * 64
+        _manifest_path(tmp_path, ref.dataset_snapshot_id).write_text(
+            json.dumps(payload, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="Manifest integrity check failed"):
+            resolve_snapshot(ref.dataset_snapshot_id, tmp_path)
+
+    def test_detects_tampered_manifest_dataset_snapshot_id_integrity_failure(self, tmp_path: Path) -> None:
+        ref = publish_snapshot([_make_gold()], tmp_path)
+        payload = _load_manifest(tmp_path, ref.dataset_snapshot_id)
+        payload["dataset_snapshot_id"] = "a" * 64
+        _manifest_path(tmp_path, ref.dataset_snapshot_id).write_text(
+            json.dumps(payload, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="Manifest integrity check failed"):
+            resolve_snapshot(ref.dataset_snapshot_id, tmp_path)
+
+    def test_corrupt_manifest_json_raises_value_error(self, tmp_path: Path) -> None:
+        ref = publish_snapshot([_make_gold()], tmp_path)
+        _manifest_path(tmp_path, ref.dataset_snapshot_id).write_text("{not-json", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Invalid manifest JSON"):
+            resolve_snapshot(ref.dataset_snapshot_id, tmp_path)
+
+    def test_manifest_missing_required_table_entry_raises_value_error(self, tmp_path: Path) -> None:
+        content = _make_jsonl_bytes([_make_gold()])
+        table_hash = hashlib.sha256(content).hexdigest()
+        manifest = SnapshotManifest(
+            dataset_snapshot_id=SnapshotManifest.compute_snapshot_id({"other_table": table_hash}),
+            created_at=datetime(2026, 3, 29, 12, 0, tzinfo=timezone.utc),
+            table_entries=[
+                SnapshotTableEntry(
+                    table_name="other_table",
+                    table_hash=table_hash,
+                    record_count=1,
+                    schema_version="1.0.0",
+                    file_format="jsonl",
+                )
+            ],
+        )
+
+        snapshot_dir = tmp_path / manifest.dataset_snapshot_id
+        snapshot_dir.mkdir(parents=True)
+        (snapshot_dir / "gold_district_monthly_metrics.jsonl").write_bytes(content)
+        (snapshot_dir / "manifest.json").write_text(manifest.model_dump_json(), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Manifest missing table entry"):
+            resolve_snapshot(manifest.dataset_snapshot_id, tmp_path)
+
+    def test_invalid_jsonl_row_content_raises_value_error(self, tmp_path: Path) -> None:
+        invalid_content = b'{"gu_code": "11680", "period": "2025-07"}\n'
+        snapshot_id = _write_manual_snapshot(
+            tmp_path,
+            content=invalid_content,
+            created_at=datetime(2026, 3, 29, 12, 0, tzinfo=timezone.utc),
+        )
+
+        with pytest.raises(ValueError, match="Invalid gold row content"):
+            resolve_snapshot(snapshot_id, tmp_path)
+
+    def test_latest_raises_when_only_non_snapshot_directories_exist(self, tmp_path: Path) -> None:
+        (tmp_path / "dir-a").mkdir(parents=True)
+        (tmp_path / "dir-b").mkdir(parents=True)
+
+        with pytest.raises(FileNotFoundError):
+            resolve_snapshot("latest", tmp_path)
+
+    def test_latest_raises_for_invalid_manifest_schema(self, tmp_path: Path) -> None:
+        snapshot_dir = tmp_path / "invalid-manifest"
+        snapshot_dir.mkdir(parents=True)
+        (snapshot_dir / "manifest.json").write_text("{}", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Invalid manifest schema"):
+            resolve_snapshot("latest", tmp_path)


### PR DESCRIPTION
## Summary
- Implement `publish_snapshot()` and `resolve_snapshot()` for Gold district monthly metrics
- SHA-256 integrity verification with JSONL file format
- Supports explicit snapshot ID and `"latest"` resolution

## Details
- `publish_snapshot(gold_rows, base_dir) -> SnapshotRef`: Sorts rows by (gu_code, period), writes `manifest.json` + `gold_district_monthly_metrics.jsonl`, computes deterministic `dataset_snapshot_id` via SHA-256
- `resolve_snapshot(snapshot_id, base_dir)`: Loads snapshot by explicit ID or `"latest"` (picks most recent `created_at`), validates manifest integrity and file hash
- Gold rows' `dataset_snapshot_id` field left untouched (avoids self-referential hash cycle per Oracle design decision)
- 27 unit tests: publish round-trip, resolve latest, integrity validation, corrupt file detection, edge cases

## Files Changed
- `apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/snapshot.py` (new)
- `apps/kr-seoul-apartment/tests/unit/test_snapshot.py` (new)

## Test Results
- 27 new tests, 281 total app tests passing
- Lint clean, format clean

Closes #98