### PR TITLE
feat(simulation): intake planner node with IntakePlan schema and StructuredLLM port

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph.py
@@ -18,6 +18,8 @@ from younggeul_core.state.simulation import (
 
 from .events import EventStore, SimulationEvent
 from .graph_state import SimulationGraphState
+from .llm.ports import StructuredLLM
+from .nodes.intake_planner import make_intake_planner_node
 
 DEFAULT_MAX_ROUNDS = 3
 
@@ -26,10 +28,17 @@ def build_simulation_graph(
     event_store: EventStore,
     *,
     default_max_rounds: int = DEFAULT_MAX_ROUNDS,
+    structured_llm: StructuredLLM | None = None,
 ) -> CompiledStateGraph[Any, Any, Any, Any]:
     graph = StateGraph(SimulationGraphState)
 
-    graph.add_node("intake_planner", _make_intake_planner_stub(event_store))
+    intake_planner_node = (
+        make_intake_planner_node(event_store, structured_llm)
+        if structured_llm is not None
+        else _make_intake_planner_stub(event_store)
+    )
+
+    graph.add_node("intake_planner", intake_planner_node)
     graph.add_node("scenario_builder", _make_scenario_builder_stub(event_store))
     graph.add_node("world_initializer", _make_world_initializer_stub(event_store, default_max_rounds))
     graph.add_node("round_runner", _make_round_runner_stub(event_store))

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from importlib import import_module
+from typing import Any, Sequence, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+from .ports import LLMMessage
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class StructuredLLMTransportError(RuntimeError):
+    pass
+
+
+class StructuredLLMResponseError(ValueError):
+    pass
+
+
+class LiteLLMStructuredLLM:
+    def __init__(self, model: str, **default_kwargs: Any) -> None:
+        self.model = model
+        self._default_kwargs = default_kwargs
+
+    def generate_structured(
+        self,
+        *,
+        messages: Sequence[LLMMessage],
+        response_model: type[T],
+        temperature: float = 0.0,
+    ) -> T:
+        litellm = import_module("litellm")
+
+        schema = response_model.model_json_schema()
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {"name": response_model.__name__, "schema": schema},
+        }
+
+        try:
+            response = litellm.completion(
+                model=self.model,
+                messages=list(messages),
+                temperature=temperature,
+                response_format=response_format,
+                **self._default_kwargs,
+            )
+        except Exception as exc:
+            raise StructuredLLMTransportError(f"LLM call failed: {exc}") from exc
+
+        raw_content = response.choices[0].message.content
+        if raw_content is None:
+            raise StructuredLLMResponseError("LLM returned empty content")
+
+        try:
+            data = json.loads(raw_content)
+        except json.JSONDecodeError as exc:
+            raise StructuredLLMResponseError(f"LLM returned invalid JSON: {raw_content[:200]}") from exc
+
+        try:
+            return response_model.model_validate(data)
+        except ValidationError as exc:
+            raise StructuredLLMResponseError(f"LLM output failed schema validation: {exc}") from exc

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/ports.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/ports.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Literal, Protocol, Sequence, TypeVar
+
+from pydantic import BaseModel
+from typing_extensions import TypedDict
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class LLMMessage(TypedDict):
+    role: Literal["system", "user", "assistant"]
+    content: str
+
+
+class StructuredLLM(Protocol):
+    def generate_structured(
+        self,
+        *,
+        messages: Sequence[LLMMessage],
+        response_model: type[T],
+        temperature: float = 0.0,
+    ) -> T: ...

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/intake_planner.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/intake_planner.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..events import EventStore, SimulationEvent
+from ..graph_state import SimulationGraphState
+from ..llm.ports import LLMMessage, StructuredLLM
+from ..schemas.intake import IntakePlan
+
+INTAKE_SYSTEM_PROMPT = """You are the intake planner for a Korean real-estate simulation engine.
+
+Given the user's natural-language query, extract a structured IntakePlan.
+
+Guidelines:
+- analysis_mode: "baseline" for simple what-if, "stress" for adverse scenario, "compare" for A/B comparison.
+- geography_hint: Korean district name if mentioned (e.g., "강남구", "서초구").
+- segment_hint: Property type/segment if mentioned (e.g., "아파트", "오피스텔").
+- horizon_months: Simulation horizon in months (default 12 if not specified).
+- requested_shocks: External shocks mentioned (e.g., "금리인상", "공급확대").
+- participant_focus: Types of market participants to model (e.g., "실수요자", "투자자").
+- constraints and assumptions: Any explicit constraints or assumptions stated.
+- ambiguities: List anything unclear in the user's query that might affect simulation accuracy.
+- Always preserve the original user_query verbatim.
+- objective: One-sentence summary of what the user wants to learn.
+"""
+
+
+def make_intake_planner_node(
+    event_store: EventStore,
+    structured_llm: StructuredLLM,
+) -> Any:
+    def node(state: SimulationGraphState) -> dict[str, Any]:
+        from datetime import datetime, timezone
+        from uuid import uuid4
+
+        user_query = state.get("user_query", "")
+
+        messages: list[LLMMessage] = [
+            {"role": "system", "content": INTAKE_SYSTEM_PROMPT},
+            {"role": "user", "content": user_query},
+        ]
+
+        plan = structured_llm.generate_structured(
+            messages=messages,
+            response_model=IntakePlan,
+            temperature=0.0,
+        )
+
+        event_id = str(uuid4())
+        run_meta = state.get("run_meta")
+        if run_meta is None:
+            msg = "run_meta is required before emitting simulation events"
+            raise ValueError(msg)
+
+        event = SimulationEvent(
+            event_id=event_id,
+            run_id=run_meta.run_id,
+            round_no=0,
+            event_type="INTAKE_PLANNED",
+            timestamp=datetime.now(timezone.utc),
+            payload=plan.model_dump(),
+        )
+        event_store.append(event)
+
+        return {
+            "intake_plan": plan.model_dump(),
+            "event_refs": [event_id],
+        }
+
+    return node

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/intake.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/intake.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class IntakePlan(BaseModel, frozen=True):
+    user_query: str
+    objective: str
+    analysis_mode: Literal["baseline", "stress", "compare"]
+    geography_hint: str | None = None
+    segment_hint: str | None = None
+    horizon_months: int = Field(ge=1, le=120)
+    requested_shocks: list[str] = Field(default_factory=list)
+    participant_focus: list[str] = Field(default_factory=list)
+    constraints: list[str] = Field(default_factory=list)
+    assumptions: list[str] = Field(default_factory=list)
+    ambiguities: list[str] = Field(default_factory=list)

--- a/apps/kr-seoul-apartment/tests/unit/test_intake_planner.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_intake_planner.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import json
+from importlib import import_module
+from types import SimpleNamespace
+from typing import Any, TypeVar
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+event_store_module = import_module("younggeul_app_kr_seoul_apartment.simulation.event_store")
+graph_module = import_module("younggeul_app_kr_seoul_apartment.simulation.graph")
+graph_state_module = import_module("younggeul_app_kr_seoul_apartment.simulation.graph_state")
+litellm_adapter_module = import_module("younggeul_app_kr_seoul_apartment.simulation.llm.litellm_adapter")
+llm_ports_module = import_module("younggeul_app_kr_seoul_apartment.simulation.llm.ports")
+intake_node_module = import_module("younggeul_app_kr_seoul_apartment.simulation.nodes.intake_planner")
+intake_schema_module = import_module("younggeul_app_kr_seoul_apartment.simulation.schemas.intake")
+
+InMemoryEventStore = event_store_module.InMemoryEventStore
+build_simulation_graph = graph_module.build_simulation_graph
+SimulationGraphState = graph_state_module.SimulationGraphState
+seed_graph_state = graph_state_module.seed_graph_state
+LiteLLMStructuredLLM = litellm_adapter_module.LiteLLMStructuredLLM
+StructuredLLMResponseError = litellm_adapter_module.StructuredLLMResponseError
+StructuredLLMTransportError = litellm_adapter_module.StructuredLLMTransportError
+LLMMessage = llm_ports_module.LLMMessage
+StructuredLLM = llm_ports_module.StructuredLLM
+INTAKE_SYSTEM_PROMPT = intake_node_module.INTAKE_SYSTEM_PROMPT
+make_intake_planner_node = intake_node_module.make_intake_planner_node
+IntakePlan = intake_schema_module.IntakePlan
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def _make_plan(**overrides: Any) -> IntakePlan:
+    payload: dict[str, Any] = {
+        "user_query": "강남구 아파트를 스트레스 테스트해줘",
+        "objective": "금리 인상 시 가격 민감도를 확인한다.",
+        "analysis_mode": "stress",
+        "geography_hint": "강남구",
+        "segment_hint": "아파트",
+        "horizon_months": 12,
+        "requested_shocks": ["금리인상"],
+        "participant_focus": ["실수요자", "투자자"],
+        "constraints": ["월 1회 업데이트"],
+        "assumptions": ["정책 변화 없음"],
+        "ambiguities": ["시작 시점이 불명확함"],
+    }
+    payload.update(overrides)
+    return IntakePlan(**payload)
+
+
+def _make_choice(content: str | None) -> SimpleNamespace:
+    return SimpleNamespace(message=SimpleNamespace(content=content))
+
+
+class FakeStructuredLLM:
+    def __init__(self, response: BaseModel) -> None:
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def generate_structured(
+        self,
+        *,
+        messages: list[LLMMessage],
+        response_model: type[T],
+        temperature: float = 0.0,
+    ) -> T:
+        self.calls.append(
+            {
+                "messages": list(messages),
+                "response_model": response_model,
+                "temperature": temperature,
+            }
+        )
+        return response_model.model_validate(self.response.model_dump())
+
+
+class TestIntakePlanSchema:
+    def test_valid_construction(self) -> None:
+        plan = _make_plan()
+
+        assert plan.analysis_mode == "stress"
+        assert plan.horizon_months == 12
+        assert plan.geography_hint == "강남구"
+
+    def test_frozen_immutability(self) -> None:
+        plan = _make_plan()
+
+        with pytest.raises(ValidationError):
+            plan.objective = "다른 목표"
+
+    def test_field_defaults(self) -> None:
+        plan = _make_plan(
+            geography_hint=None,
+            segment_hint=None,
+            requested_shocks=[],
+            participant_focus=[],
+            constraints=[],
+            assumptions=[],
+            ambiguities=[],
+        )
+
+        assert plan.geography_hint is None
+        assert plan.segment_hint is None
+        assert plan.requested_shocks == []
+        assert plan.participant_focus == []
+        assert plan.constraints == []
+        assert plan.assumptions == []
+        assert plan.ambiguities == []
+
+    @pytest.mark.parametrize("value", [1, 120])
+    def test_horizon_months_accepts_boundaries(self, value: int) -> None:
+        plan = _make_plan(horizon_months=value)
+
+        assert plan.horizon_months == value
+
+    @pytest.mark.parametrize("value", [0, 121])
+    def test_horizon_months_rejects_out_of_range(self, value: int) -> None:
+        with pytest.raises(ValidationError):
+            _make_plan(horizon_months=value)
+
+    def test_analysis_mode_literal_validation(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_plan(analysis_mode="unknown")
+
+
+class TestLLMPorts:
+    def test_llm_message_typeddict_valid_construction(self) -> None:
+        message: LLMMessage = {"role": "user", "content": "분석해줘"}
+
+        assert message["role"] == "user"
+        assert message["content"] == "분석해줘"
+
+    def test_fake_implementation_matches_structured_llm_contract(self) -> None:
+        fake = FakeStructuredLLM(_make_plan())
+
+        def call_port(llm: StructuredLLM) -> IntakePlan:
+            return llm.generate_structured(
+                messages=[{"role": "user", "content": "질문"}],
+                response_model=IntakePlan,
+                temperature=0.0,
+            )
+
+        result = call_port(fake)
+
+        assert isinstance(result, IntakePlan)
+        assert result.user_query == _make_plan().user_query
+
+
+class TestLiteLLMStructuredLLM:
+    def test_calls_litellm_with_expected_args(self) -> None:
+        adapter = LiteLLMStructuredLLM(model="gpt-test", api_key="secret", timeout=20)
+        expected_plan = _make_plan()
+        mock_litellm = MagicMock()
+        mock_litellm.completion.return_value = SimpleNamespace(choices=[_make_choice(expected_plan.model_dump_json())])
+
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            result = adapter.generate_structured(
+                messages=[{"role": "user", "content": expected_plan.user_query}],
+                response_model=IntakePlan,
+                temperature=0.25,
+            )
+
+        assert result == expected_plan
+        mock_litellm.completion.assert_called_once()
+        call_kwargs = mock_litellm.completion.call_args.kwargs
+        assert call_kwargs["model"] == "gpt-test"
+        assert call_kwargs["messages"] == [{"role": "user", "content": expected_plan.user_query}]
+        assert call_kwargs["temperature"] == 0.25
+        assert call_kwargs["api_key"] == "secret"
+        assert call_kwargs["timeout"] == 20
+        response_format = call_kwargs["response_format"]
+        assert response_format["type"] == "json_schema"
+        assert response_format["json_schema"]["name"] == "IntakePlan"
+        assert response_format["json_schema"]["schema"] == IntakePlan.model_json_schema()
+
+    def test_raises_transport_error_on_litellm_failure(self) -> None:
+        adapter = LiteLLMStructuredLLM(model="gpt-test")
+        mock_litellm = MagicMock()
+        mock_litellm.completion.side_effect = RuntimeError("network down")
+
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            with pytest.raises(StructuredLLMTransportError, match="LLM call failed"):
+                adapter.generate_structured(
+                    messages=[{"role": "user", "content": "질문"}],
+                    response_model=IntakePlan,
+                )
+
+    def test_raises_response_error_on_empty_content(self) -> None:
+        adapter = LiteLLMStructuredLLM(model="gpt-test")
+        mock_litellm = MagicMock()
+        mock_litellm.completion.return_value = SimpleNamespace(choices=[_make_choice(None)])
+
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            with pytest.raises(StructuredLLMResponseError, match="empty content"):
+                adapter.generate_structured(
+                    messages=[{"role": "user", "content": "질문"}],
+                    response_model=IntakePlan,
+                )
+
+    def test_raises_response_error_on_invalid_json(self) -> None:
+        adapter = LiteLLMStructuredLLM(model="gpt-test")
+        mock_litellm = MagicMock()
+        mock_litellm.completion.return_value = SimpleNamespace(choices=[_make_choice("not-json")])
+
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            with pytest.raises(StructuredLLMResponseError, match="invalid JSON"):
+                adapter.generate_structured(
+                    messages=[{"role": "user", "content": "질문"}],
+                    response_model=IntakePlan,
+                )
+
+    def test_raises_response_error_on_schema_validation_failure(self) -> None:
+        adapter = LiteLLMStructuredLLM(model="gpt-test")
+        bad_payload = json.dumps({"user_query": "질문"})
+        mock_litellm = MagicMock()
+        mock_litellm.completion.return_value = SimpleNamespace(choices=[_make_choice(bad_payload)])
+
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            with pytest.raises(StructuredLLMResponseError, match="schema validation"):
+                adapter.generate_structured(
+                    messages=[{"role": "user", "content": "질문"}],
+                    response_model=IntakePlan,
+                )
+
+
+class TestIntakePlannerNode:
+    def test_returns_intake_plan_and_event_refs(self) -> None:
+        store = InMemoryEventStore()
+        plan = _make_plan()
+        llm = FakeStructuredLLM(plan)
+        node = make_intake_planner_node(store, llm)
+        state = seed_graph_state(plan.user_query, "run-node-001", "run-node", "gpt-test")
+
+        result = node(state)
+
+        assert result["intake_plan"] == plan.model_dump()
+        assert len(result["event_refs"]) == 1
+        assert isinstance(result["event_refs"][0], str)
+
+    def test_emits_intake_planned_event_with_payload(self) -> None:
+        store = InMemoryEventStore()
+        plan = _make_plan()
+        llm = FakeStructuredLLM(plan)
+        node = make_intake_planner_node(store, llm)
+        state = seed_graph_state(plan.user_query, "run-node-002", "run-node", "gpt-test")
+
+        result = node(state)
+
+        events = store.get_events_by_type("run-node-002", "INTAKE_PLANNED")
+        assert len(events) == 1
+        assert events[0].payload == plan.model_dump()
+        assert events[0].event_id == result["event_refs"][0]
+        assert events[0].round_no == 0
+
+    def test_raises_when_run_meta_missing(self) -> None:
+        store = InMemoryEventStore()
+        llm = FakeStructuredLLM(_make_plan())
+        node = make_intake_planner_node(store, llm)
+        state: SimulationGraphState = {"user_query": "강남구 분석"}
+
+        with pytest.raises(ValueError, match="run_meta is required"):
+            node(state)
+
+    def test_passes_system_and_user_messages_to_llm(self) -> None:
+        store = InMemoryEventStore()
+        plan = _make_plan(user_query="서초구 아파트 전망")
+        llm = FakeStructuredLLM(plan)
+        node = make_intake_planner_node(store, llm)
+        state = seed_graph_state(plan.user_query, "run-node-003", "run-node", "gpt-test")
+
+        node(state)
+
+        assert len(llm.calls) == 1
+        messages = llm.calls[0]["messages"]
+        assert messages == [
+            {"role": "system", "content": INTAKE_SYSTEM_PROMPT},
+            {"role": "user", "content": "서초구 아파트 전망"},
+        ]
+        assert llm.calls[0]["response_model"] is IntakePlan
+        assert llm.calls[0]["temperature"] == 0.0
+
+
+class TestGraphWiring:
+    def test_build_graph_uses_real_intake_node_when_structured_llm_provided(self) -> None:
+        store = InMemoryEventStore()
+        plan = _make_plan(user_query="강남구 비교 시나리오", analysis_mode="compare")
+        llm = FakeStructuredLLM(plan)
+        graph = build_simulation_graph(store, structured_llm=llm)
+        seed = seed_graph_state(plan.user_query, "run-graph-real", "run-real", "gpt-test")
+        seed["max_rounds"] = 0
+
+        final = graph.invoke(seed)
+
+        assert final["intake_plan"] == plan.model_dump()
+        assert "planner_status" not in final["intake_plan"]
+        assert len(llm.calls) == 1
+
+    def test_build_graph_keeps_stub_when_structured_llm_not_provided(self) -> None:
+        store = InMemoryEventStore()
+        graph = build_simulation_graph(store)
+        seed = seed_graph_state("기본 시나리오", "run-graph-stub", "run-stub", "gpt-test")
+        seed["max_rounds"] = 0
+
+        final = graph.invoke(seed)
+
+        assert final["intake_plan"]["planner_status"] == "stub"
+        assert final["intake_plan"]["query"] == "기본 시나리오"


### PR DESCRIPTION
## Summary

Implements M5-PR4: First LLM-powered node in the simulation graph. Adds the intake planner that parses natural-language user queries into structured `IntakePlan` objects.

### Changes
- **IntakePlan schema** (`simulation/schemas/intake.py`): Frozen Pydantic model with fields for analysis_mode, geography_hint, horizon_months, requested_shocks, etc.
- **StructuredLLM Protocol** (`simulation/llm/ports.py`): Port interface for typed LLM backends with `generate_structured()` method
- **LiteLLM adapter** (`simulation/llm/litellm_adapter.py`): Production adapter using litellm.completion with JSON-schema response_format. Fail-fast error handling (StructuredLLMTransportError, StructuredLLMResponseError)
- **Intake planner node** (`simulation/nodes/intake_planner.py`): `make_intake_planner_node()` with Korean real-estate system prompt, emits INTAKE_PLANNED event
- **Graph wiring update** (`simulation/graph.py`): `build_simulation_graph()` accepts optional `structured_llm` parameter — uses real intake planner when provided, falls back to existing stub when None (backwards compatible)
- **21 new unit tests** covering schema validation, LLM port protocol, adapter behavior (success + 4 error paths), node logic, and graph wiring

### Architecture
- Dependency injection via `StructuredLLM` protocol — no framework coupling in the port
- LiteLLM adapter is lazy-imported to avoid import-time dependency
- IntakePlan stored as `dict[str, Any]` in graph state via `.model_dump()` (avoids LangGraph TypedDict serialization issues)
- No retry, no silent fallback — fail-fast design per project conventions

### Test coverage
- 21 new tests + 24 existing graph tests = 45 simulation tests
- 629 total tests passing

Closes #45