### PR TITLE
feat(simulation): scenario builder node with SnapshotReader port and shock catalog

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/domain/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/domain/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/domain/gu_resolver.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/domain/gu_resolver.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+SEOUL_GU_MAP: dict[str, str] = {
+    "11110": "종로구",
+    "11140": "중구",
+    "11170": "용산구",
+    "11200": "성동구",
+    "11215": "광진구",
+    "11230": "동대문구",
+    "11260": "중랑구",
+    "11290": "성북구",
+    "11305": "강북구",
+    "11320": "도봉구",
+    "11350": "노원구",
+    "11380": "은평구",
+    "11410": "서대문구",
+    "11440": "마포구",
+    "11470": "양천구",
+    "11500": "강서구",
+    "11530": "구로구",
+    "11545": "금천구",
+    "11560": "영등포구",
+    "11590": "동작구",
+    "11620": "관악구",
+    "11650": "서초구",
+    "11680": "강남구",
+    "11710": "송파구",
+    "11740": "강동구",
+}
+SEOUL_NAME_TO_CODE: dict[str, str] = {name: code for code, name in SEOUL_GU_MAP.items()}
+
+
+def resolve_gu_codes(
+    geography_hint: str | None,
+    available_gu_codes: list[str],
+) -> tuple[list[str], list[str]]:
+    if geography_hint is None:
+        return list(available_gu_codes), []
+
+    hint = geography_hint.strip()
+    if not hint:
+        return list(available_gu_codes), ["Geography hint was empty; using all available districts."]
+
+    warnings: list[str] = []
+    available_set = set(available_gu_codes)
+
+    if hint in SEOUL_GU_MAP:
+        if hint in available_set:
+            return [hint], warnings
+        return list(available_gu_codes), [f"Requested gu code '{hint}' is unavailable in snapshot coverage."]
+
+    direct_code = SEOUL_NAME_TO_CODE.get(hint)
+    if direct_code is not None:
+        if direct_code in available_set:
+            return [direct_code], warnings
+        return list(available_gu_codes), [f"Requested district '{hint}' is unavailable in snapshot coverage."]
+
+    matched_codes = [
+        code for code in available_gu_codes if SEOUL_GU_MAP.get(code) is not None and SEOUL_GU_MAP[code] in hint
+    ]
+    if matched_codes:
+        return matched_codes, warnings
+
+    warnings.append(f"Could not resolve geography hint '{geography_hint}'; using all available districts.")
+    return list(available_gu_codes), warnings

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/domain/shock_catalog.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/domain/shock_catalog.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+from younggeul_core.state.simulation import Shock
+
+
+class _ShockTemplate(TypedDict):
+    shock_type: Literal["interest_rate", "regulation", "supply", "demand", "external"]
+    description: str
+    magnitude: float
+
+
+SUPPORTED_SHOCK_KEYS: dict[str, _ShockTemplate] = {
+    "rate_up": {
+        "shock_type": "interest_rate",
+        "description": "Interest rate hike",
+        "magnitude": 0.3,
+    },
+    "rate_down": {
+        "shock_type": "interest_rate",
+        "description": "Interest rate cut",
+        "magnitude": -0.3,
+    },
+    "demand_surge": {
+        "shock_type": "demand",
+        "description": "Demand surge",
+        "magnitude": 0.5,
+    },
+    "demand_drop": {
+        "shock_type": "demand",
+        "description": "Demand drop",
+        "magnitude": -0.5,
+    },
+    "supply_increase": {
+        "shock_type": "supply",
+        "description": "Supply increase",
+        "magnitude": 0.4,
+    },
+    "regulation_tighten": {
+        "shock_type": "regulation",
+        "description": "Tighter regulation",
+        "magnitude": 0.4,
+    },
+    "regulation_loosen": {
+        "shock_type": "regulation",
+        "description": "Loosened regulation",
+        "magnitude": -0.4,
+    },
+    "sentiment_drop": {
+        "shock_type": "external",
+        "description": "Market sentiment deterioration",
+        "magnitude": -0.4,
+    },
+}
+
+KOREAN_SHOCK_ALIASES: dict[str, str] = {
+    "금리인상": "rate_up",
+    "금리인하": "rate_down",
+    "금리 인상": "rate_up",
+    "금리 인하": "rate_down",
+    "수요증가": "demand_surge",
+    "수요감소": "demand_drop",
+    "공급확대": "supply_increase",
+    "공급 확대": "supply_increase",
+    "규제강화": "regulation_tighten",
+    "규제완화": "regulation_loosen",
+    "규제 강화": "regulation_tighten",
+    "규제 완화": "regulation_loosen",
+    "심리위축": "sentiment_drop",
+}
+
+
+def normalize_shock_key(raw: str) -> str | None:
+    candidate = raw.strip().lower()
+    if candidate in SUPPORTED_SHOCK_KEYS:
+        return candidate
+    if candidate in KOREAN_SHOCK_ALIASES:
+        return KOREAN_SHOCK_ALIASES[candidate]
+    return None
+
+
+def expand_shock(
+    key: str,
+    target_gus: list[str],
+    start_period: str,
+    end_period: str | None,
+) -> Shock:
+    del start_period
+    del end_period
+    template = SUPPORTED_SHOCK_KEYS[key]
+    return Shock(
+        shock_type=template["shock_type"],
+        description=template["description"],
+        magnitude=template["magnitude"],
+        target_segments=list(target_gus),
+    )

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph.py
@@ -20,6 +20,8 @@ from .events import EventStore, SimulationEvent
 from .graph_state import SimulationGraphState
 from .llm.ports import StructuredLLM
 from .nodes.intake_planner import make_intake_planner_node
+from .nodes.scenario_builder import make_scenario_builder_node
+from .ports.snapshot_reader import SnapshotReader
 
 DEFAULT_MAX_ROUNDS = 3
 
@@ -29,6 +31,7 @@ def build_simulation_graph(
     *,
     default_max_rounds: int = DEFAULT_MAX_ROUNDS,
     structured_llm: StructuredLLM | None = None,
+    snapshot_reader: SnapshotReader | None = None,
 ) -> CompiledStateGraph[Any, Any, Any, Any]:
     graph = StateGraph(SimulationGraphState)
 
@@ -37,9 +40,14 @@ def build_simulation_graph(
         if structured_llm is not None
         else _make_intake_planner_stub(event_store)
     )
+    scenario_builder_node = (
+        make_scenario_builder_node(event_store, structured_llm, snapshot_reader)
+        if structured_llm is not None and snapshot_reader is not None
+        else _make_scenario_builder_stub(event_store)
+    )
 
     graph.add_node("intake_planner", intake_planner_node)
-    graph.add_node("scenario_builder", _make_scenario_builder_stub(event_store))
+    graph.add_node("scenario_builder", scenario_builder_node)
     graph.add_node("world_initializer", _make_world_initializer_stub(event_store, default_max_rounds))
     graph.add_node("round_runner", _make_round_runner_stub(event_store))
     graph.add_node("report_writer", _make_report_writer_stub(event_store))

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph_state.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph_state.py
@@ -23,6 +23,7 @@ from younggeul_core.state.simulation import (
 class SimulationGraphState(TypedDict, total=False):
     user_query: str
     intake_plan: dict[str, Any]
+    participant_roster: dict[str, Any]
 
     run_meta: RunMeta
     snapshot: SnapshotRef

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/scenario_builder.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/scenario_builder.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from math import ceil
+from typing import Any, Literal, cast
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from younggeul_core.state.simulation import ScenarioSpec
+
+from ..domain.gu_resolver import resolve_gu_codes
+from ..domain.shock_catalog import SUPPORTED_SHOCK_KEYS, expand_shock, normalize_shock_key
+from ..events import EventStore, SimulationEvent
+from ..graph_state import SimulationGraphState
+from ..llm.ports import LLMMessage, StructuredLLM
+from ..ports.snapshot_reader import SnapshotReader
+from ..schemas.intake import IntakePlan
+from ..schemas.participant_roster import ParticipantRosterSpec, RoleBucketSpec
+
+_ROLE_SET = {"buyer", "investor", "tenant", "landlord", "broker"}
+_SENTIMENT_SET = {"bearish", "neutral", "bullish"}
+
+
+class ScenarioSelection(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    scenario_name: str
+    selected_shock_keys: list[str]
+    roster_buckets: list[RoleBucketSpec]
+
+
+def compute_max_rounds(horizon_months: int, shock_count: int, analysis_mode: str) -> int:
+    base = ceil(horizon_months / 3)
+    if shock_count >= 2:
+        base += 1
+    if analysis_mode in ("stress", "compare"):
+        base += 1
+    return min(8, max(1, base))
+
+
+def _parse_period(period: str) -> tuple[int, int]:
+    year_text, month_text = period.split("-", 1)
+    return int(year_text), int(month_text)
+
+
+def _month_start_after(period: str) -> date:
+    year, month = _parse_period(period)
+    if month == 12:
+        return date(year + 1, 1, 1)
+    return date(year, month + 1, 1)
+
+
+def _add_months(month_start: date, months: int) -> date:
+    total_month = (month_start.year * 12 + month_start.month - 1) + months
+    year = total_month // 12
+    month = total_month % 12 + 1
+    return date(year, month, 1)
+
+
+def _clamp_int(value: Any, min_value: int, max_value: int, fallback: int) -> int:
+    try:
+        raw = int(value)
+    except (TypeError, ValueError):
+        return fallback
+    return max(min_value, min(max_value, raw))
+
+
+def _clamp_float(value: Any, min_value: float, max_value: float, fallback: float) -> float:
+    try:
+        raw = float(value)
+    except (TypeError, ValueError):
+        return fallback
+    return max(min_value, min(max_value, raw))
+
+
+def _sanitize_roster_buckets(raw_buckets: list[Any]) -> list[RoleBucketSpec]:
+    sanitized: list[RoleBucketSpec] = []
+    for raw_bucket in raw_buckets:
+        bucket_data = raw_bucket if isinstance(raw_bucket, dict) else {}
+        role = bucket_data.get("role")
+        if role not in _ROLE_SET:
+            continue
+
+        count = _clamp_int(bucket_data.get("count", 1), 1, 50, 1)
+
+        capital_min = _clamp_float(bucket_data.get("capital_min_multiplier", 0.5), 0.0, 10.0, 0.5)
+        capital_max = _clamp_float(bucket_data.get("capital_max_multiplier", 1.5), 0.0, 10.0, 1.5)
+        if capital_min > capital_max:
+            capital_min, capital_max = capital_max, capital_min
+
+        holdings_min = _clamp_int(bucket_data.get("holdings_min", 0), 0, 20, 0)
+        holdings_max = _clamp_int(bucket_data.get("holdings_max", 2), 0, 20, 2)
+        if holdings_min > holdings_max:
+            holdings_min, holdings_max = holdings_max, holdings_min
+
+        risk_min = _clamp_float(bucket_data.get("risk_min", 0.2), 0.0, 1.0, 0.2)
+        risk_max = _clamp_float(bucket_data.get("risk_max", 0.8), 0.0, 1.0, 0.8)
+        if risk_min > risk_max:
+            risk_min, risk_max = risk_max, risk_min
+
+        raw_sentiment = bucket_data.get("sentiment_bias")
+        if raw_sentiment in _SENTIMENT_SET:
+            sentiment_bias: Literal["bearish", "neutral", "bullish"] = cast(
+                Literal["bearish", "neutral", "bullish"],
+                raw_sentiment,
+            )
+        else:
+            sentiment_bias = "neutral"
+
+        sanitized.append(
+            RoleBucketSpec(
+                role=role,
+                count=count,
+                capital_min_multiplier=capital_min,
+                capital_max_multiplier=capital_max,
+                holdings_min=holdings_min,
+                holdings_max=holdings_max,
+                risk_min=risk_min,
+                risk_max=risk_max,
+                sentiment_bias=sentiment_bias,
+            )
+        )
+
+    if sanitized:
+        return sanitized
+
+    return [
+        RoleBucketSpec(
+            role="buyer",
+            count=10,
+            capital_min_multiplier=0.8,
+            capital_max_multiplier=1.2,
+            holdings_min=0,
+            holdings_max=2,
+            risk_min=0.2,
+            risk_max=0.7,
+            sentiment_bias="neutral",
+        )
+    ]
+
+
+def _build_system_prompt(plan: IntakePlan) -> str:
+    shock_lines = [
+        f"- {key}: {value['description']} ({value['shock_type']}, magnitude={value['magnitude']})"
+        for key, value in SUPPORTED_SHOCK_KEYS.items()
+    ]
+    roles = sorted(_ROLE_SET)
+    return "\n".join(
+        [
+            "You are the scenario builder for a Seoul apartment simulation.",
+            "Choose only from the supported shock catalog keys and role options.",
+            "Return ScenarioSelection JSON only.",
+            "",
+            "Supported shock keys:",
+            *shock_lines,
+            "",
+            f"Supported roles: {', '.join(roles)}",
+            "",
+            "User intake context:",
+            f"- objective: {plan.objective}",
+            f"- analysis_mode: {plan.analysis_mode}",
+            f"- requested_shocks: {plan.requested_shocks}",
+            f"- participant_focus: {plan.participant_focus}",
+            f"- horizon_months: {plan.horizon_months}",
+        ]
+    )
+
+
+def _normalize_selected_shocks(raw_keys: list[str]) -> list[str]:
+    normalized: list[str] = []
+    for raw_key in raw_keys:
+        normalized_key = normalize_shock_key(raw_key)
+        if normalized_key is None:
+            continue
+        if normalized_key not in normalized:
+            normalized.append(normalized_key)
+    return normalized
+
+
+def make_scenario_builder_node(
+    event_store: EventStore,
+    structured_llm: StructuredLLM,
+    snapshot_reader: SnapshotReader,
+) -> Any:
+    def node(state: SimulationGraphState) -> dict[str, Any]:
+        intake_plan_raw = state.get("intake_plan")
+        if intake_plan_raw is None:
+            raise ValueError("intake_plan is required before scenario_builder")
+
+        snapshot = state.get("snapshot")
+        if snapshot is None:
+            raise ValueError("snapshot is required before scenario_builder")
+
+        intake_plan = IntakePlan.model_validate(intake_plan_raw)
+        coverage = snapshot_reader.get_coverage(snapshot)
+
+        target_gus, warnings = resolve_gu_codes(intake_plan.geography_hint, coverage.available_gu_codes)
+
+        target_period_start = _month_start_after(coverage.max_period)
+        target_period_end = _add_months(target_period_start, intake_plan.horizon_months - 1)
+        start_period = target_period_start.strftime("%Y-%m")
+        end_period = target_period_end.strftime("%Y-%m")
+
+        messages: list[LLMMessage] = [
+            {"role": "system", "content": _build_system_prompt(intake_plan)},
+            {
+                "role": "user",
+                "content": (
+                    f"objective={intake_plan.objective}\n"
+                    f"analysis_mode={intake_plan.analysis_mode}\n"
+                    f"requested_shocks={intake_plan.requested_shocks}\n"
+                    f"participant_focus={intake_plan.participant_focus}"
+                ),
+            },
+        ]
+
+        llm_selection = structured_llm.generate_structured(
+            messages=messages,
+            response_model=ScenarioSelection,
+            temperature=0.0,
+        )
+
+        selected_shocks = _normalize_selected_shocks(llm_selection.selected_shock_keys)
+        if intake_plan.analysis_mode == "stress" and not selected_shocks:
+            selected_shocks = ["sentiment_drop"]
+            warnings.append("Stress mode requires at least one shock; defaulted to sentiment_drop.")
+        if intake_plan.analysis_mode == "compare":
+            warnings.append("Compare mode currently builds one scenario from combined assumptions.")
+
+        shocks = [expand_shock(key, target_gus, start_period, end_period) for key in selected_shocks]
+
+        scenario = ScenarioSpec(
+            scenario_name=llm_selection.scenario_name.strip() or "Scenario",
+            target_gus=target_gus,
+            target_period_start=target_period_start,
+            target_period_end=target_period_end,
+            shocks=shocks,
+        )
+
+        raw_buckets: list[Any]
+        try:
+            raw_buckets = llm_selection.model_dump()["roster_buckets"]
+            if not isinstance(raw_buckets, list):
+                raw_buckets = []
+        except (ValidationError, KeyError, TypeError):
+            raw_buckets = []
+
+        roster_buckets = _sanitize_roster_buckets(raw_buckets)
+        roster = ParticipantRosterSpec(seed=snapshot.dataset_snapshot_id[:12], buckets=roster_buckets)
+
+        max_rounds = compute_max_rounds(intake_plan.horizon_months, len(shocks), intake_plan.analysis_mode)
+
+        run_meta = state.get("run_meta")
+        if run_meta is None:
+            raise ValueError("run_meta is required before emitting simulation events")
+
+        event_id = str(uuid4())
+        event_store.append(
+            SimulationEvent(
+                event_id=event_id,
+                run_id=run_meta.run_id,
+                round_no=0,
+                event_type="SCENARIO_BUILT",
+                timestamp=datetime.now(timezone.utc),
+                payload={
+                    "scenario": scenario.model_dump(),
+                    "participant_roster": roster.model_dump(),
+                    "max_rounds": max_rounds,
+                    "warnings": warnings,
+                },
+            )
+        )
+
+        return {
+            "scenario": scenario,
+            "participant_roster": roster.model_dump(),
+            "max_rounds": max_rounds,
+            "warnings": warnings,
+            "event_refs": [event_id],
+        }
+
+    return node

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/ports/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/ports/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/ports/snapshot_reader.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/ports/snapshot_reader.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Protocol, Sequence, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict
+
+from younggeul_core.state.gold import BaselineForecast, GoldDistrictMonthlyMetrics
+from younggeul_core.state.simulation import SnapshotRef
+
+
+class SnapshotCoverage(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    available_gu_codes: list[str]
+    available_gu_names: dict[str, str]
+    min_period: str
+    max_period: str
+    record_count: int
+
+
+@runtime_checkable
+class SnapshotReader(Protocol):
+    def get_coverage(self, snapshot: SnapshotRef) -> SnapshotCoverage: ...
+
+    def get_latest_metrics(
+        self,
+        snapshot: SnapshotRef,
+        gu_codes: Sequence[str] | None = None,
+    ) -> list[GoldDistrictMonthlyMetrics]: ...
+
+    def get_baseline_forecasts(
+        self,
+        snapshot: SnapshotRef,
+        gu_codes: Sequence[str] | None = None,
+    ) -> list[BaselineForecast]: ...

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/participant_roster.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/participant_roster.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RoleBucketSpec(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    role: Literal["buyer", "investor", "tenant", "landlord", "broker"]
+    count: int = Field(ge=1, le=50)
+    capital_min_multiplier: float = Field(ge=0.0, le=10.0)
+    capital_max_multiplier: float = Field(ge=0.0, le=10.0)
+    holdings_min: int = Field(ge=0, le=20)
+    holdings_max: int = Field(ge=0, le=20)
+    risk_min: float = Field(ge=0.0, le=1.0)
+    risk_max: float = Field(ge=0.0, le=1.0)
+    sentiment_bias: Literal["bearish", "neutral", "bullish"]
+
+
+class ParticipantRosterSpec(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    seed: str
+    buckets: list[RoleBucketSpec] = Field(min_length=1)

--- a/apps/kr-seoul-apartment/tests/unit/test_scenario_builder.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_scenario_builder.py
@@ -1,0 +1,593 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Any, TypeVar, cast
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from younggeul_app_kr_seoul_apartment.simulation.domain.gu_resolver import resolve_gu_codes
+from younggeul_app_kr_seoul_apartment.simulation.domain.shock_catalog import (
+    SUPPORTED_SHOCK_KEYS,
+    expand_shock,
+    normalize_shock_key,
+)
+from younggeul_app_kr_seoul_apartment.simulation.event_store import InMemoryEventStore
+from younggeul_app_kr_seoul_apartment.simulation.graph import build_simulation_graph
+from younggeul_app_kr_seoul_apartment.simulation.graph_state import seed_graph_state
+from younggeul_app_kr_seoul_apartment.simulation.llm.ports import LLMMessage
+from younggeul_app_kr_seoul_apartment.simulation.nodes.scenario_builder import (
+    ScenarioSelection,
+    compute_max_rounds,
+    make_scenario_builder_node,
+)
+from younggeul_app_kr_seoul_apartment.simulation.ports.snapshot_reader import SnapshotCoverage
+from younggeul_app_kr_seoul_apartment.simulation.schemas.intake import IntakePlan
+from younggeul_app_kr_seoul_apartment.simulation.schemas.participant_roster import (
+    ParticipantRosterSpec,
+    RoleBucketSpec,
+)
+from younggeul_core.state.gold import BaselineForecast, GoldDistrictMonthlyMetrics
+from younggeul_core.state.simulation import ScenarioSpec, SnapshotRef
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def _make_snapshot_ref() -> SnapshotRef:
+    return SnapshotRef(
+        dataset_snapshot_id="a" * 64,
+        created_at=datetime(2026, 1, 3, 0, 0, tzinfo=timezone.utc),
+        table_count=2,
+    )
+
+
+def _make_coverage(**overrides: Any) -> SnapshotCoverage:
+    payload: dict[str, Any] = {
+        "available_gu_codes": ["11680", "11650", "11710"],
+        "available_gu_names": {
+            "11680": "강남구",
+            "11650": "서초구",
+            "11710": "송파구",
+        },
+        "min_period": "2024-01",
+        "max_period": "2025-12",
+        "record_count": 999,
+    }
+    payload.update(overrides)
+    return SnapshotCoverage(**payload)
+
+
+def _make_intake_plan(**overrides: Any) -> IntakePlan:
+    payload: dict[str, Any] = {
+        "user_query": "강남구 스트레스 테스트",
+        "objective": "충격 하에서 가격·거래량 변화를 점검한다.",
+        "analysis_mode": "stress",
+        "geography_hint": "강남구",
+        "segment_hint": "아파트",
+        "horizon_months": 6,
+        "requested_shocks": ["금리인상", "규제강화"],
+        "participant_focus": ["실수요자", "투자자"],
+        "constraints": [],
+        "assumptions": [],
+        "ambiguities": [],
+    }
+    payload.update(overrides)
+    return IntakePlan(**payload)
+
+
+def _make_role_bucket(**overrides: Any) -> RoleBucketSpec:
+    payload: dict[str, Any] = {
+        "role": "buyer",
+        "count": 10,
+        "capital_min_multiplier": 0.8,
+        "capital_max_multiplier": 1.2,
+        "holdings_min": 0,
+        "holdings_max": 2,
+        "risk_min": 0.2,
+        "risk_max": 0.8,
+        "sentiment_bias": "neutral",
+    }
+    payload.update(overrides)
+    return RoleBucketSpec(**payload)
+
+
+def _make_selection(**overrides: Any) -> ScenarioSelection:
+    payload: dict[str, Any] = {
+        "scenario_name": "Stress Case Alpha",
+        "selected_shock_keys": ["rate_up", "regulation_tighten"],
+        "roster_buckets": [_make_role_bucket(), _make_role_bucket(role="investor", count=6)],
+    }
+    payload.update(overrides)
+    return ScenarioSelection(**payload)
+
+
+class FakeStructuredLLM:
+    def __init__(self, response: BaseModel, *, bypass_validation: bool = False) -> None:
+        self._response = response
+        self._bypass_validation = bypass_validation
+        self.calls: list[dict[str, Any]] = []
+
+    def generate_structured(
+        self,
+        *,
+        messages: list[LLMMessage],
+        response_model: type[T],
+        temperature: float = 0.0,
+    ) -> T:
+        self.calls.append(
+            {
+                "messages": list(messages),
+                "response_model": response_model,
+                "temperature": temperature,
+            }
+        )
+        if self._bypass_validation:
+            return cast(T, self._response)
+        return response_model.model_validate(self._response.model_dump())
+
+
+class FakeMultiplexStructuredLLM:
+    def __init__(self, intake_plan: IntakePlan, selection: ScenarioSelection) -> None:
+        self._intake_plan = intake_plan
+        self._selection = selection
+        self.calls: list[dict[str, Any]] = []
+
+    def generate_structured(
+        self,
+        *,
+        messages: list[LLMMessage],
+        response_model: type[T],
+        temperature: float = 0.0,
+    ) -> T:
+        self.calls.append(
+            {
+                "messages": list(messages),
+                "response_model": response_model,
+                "temperature": temperature,
+            }
+        )
+        if response_model is IntakePlan:
+            return cast(T, response_model.model_validate(self._intake_plan.model_dump()))
+        return cast(T, response_model.model_validate(self._selection.model_dump()))
+
+
+class FakeSnapshotReader:
+    def __init__(
+        self,
+        coverage: SnapshotCoverage,
+        metrics: list[GoldDistrictMonthlyMetrics] | None = None,
+        forecasts: list[BaselineForecast] | None = None,
+    ) -> None:
+        self.coverage = coverage
+        self.metrics = metrics or []
+        self.forecasts = forecasts or []
+
+    def get_coverage(self, snapshot: SnapshotRef) -> SnapshotCoverage:
+        _ = snapshot
+        return self.coverage
+
+    def get_latest_metrics(
+        self,
+        snapshot: SnapshotRef,
+        gu_codes: list[str] | None = None,
+    ) -> list[GoldDistrictMonthlyMetrics]:
+        _ = snapshot
+        _ = gu_codes
+        return self.metrics
+
+    def get_baseline_forecasts(
+        self,
+        snapshot: SnapshotRef,
+        gu_codes: list[str] | None = None,
+    ) -> list[BaselineForecast]:
+        _ = snapshot
+        _ = gu_codes
+        return self.forecasts
+
+
+class TestSnapshotCoverageSchema:
+    def test_constructs_with_valid_fields(self) -> None:
+        coverage = _make_coverage()
+
+        assert coverage.min_period == "2024-01"
+        assert coverage.max_period == "2025-12"
+        assert coverage.available_gu_names["11680"] == "강남구"
+
+    def test_is_frozen(self) -> None:
+        coverage = _make_coverage()
+
+        with pytest.raises(ValidationError):
+            coverage.max_period = "2026-01"
+
+
+class TestParticipantRosterSpecSchema:
+    def test_role_bucket_valid_construction(self) -> None:
+        bucket = _make_role_bucket(role="landlord", count=3)
+
+        assert bucket.role == "landlord"
+        assert bucket.count == 3
+
+    def test_role_bucket_rejects_invalid_role(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_role_bucket(role="developer")
+
+    @pytest.mark.parametrize("count", [1, 50])
+    def test_role_bucket_accepts_count_boundaries(self, count: int) -> None:
+        bucket = _make_role_bucket(count=count)
+
+        assert bucket.count == count
+
+    @pytest.mark.parametrize("count", [0, 51])
+    def test_role_bucket_rejects_count_out_of_range(self, count: int) -> None:
+        with pytest.raises(ValidationError):
+            _make_role_bucket(count=count)
+
+    @pytest.mark.parametrize("field,value", [("risk_min", -0.01), ("risk_max", 1.01)])
+    def test_role_bucket_rejects_risk_bounds(self, field: str, value: float) -> None:
+        with pytest.raises(ValidationError):
+            _make_role_bucket(**{field: value})
+
+    def test_roster_requires_non_empty_buckets(self) -> None:
+        with pytest.raises(ValidationError):
+            ParticipantRosterSpec(seed="abc", buckets=[])
+
+    def test_roster_is_frozen(self) -> None:
+        roster = ParticipantRosterSpec(seed="seed-1", buckets=[_make_role_bucket()])
+
+        with pytest.raises(ValidationError):
+            roster.seed = "changed"
+
+    def test_roster_valid_construction(self) -> None:
+        roster = ParticipantRosterSpec(seed="seed-1", buckets=[_make_role_bucket(), _make_role_bucket(role="tenant")])
+
+        assert len(roster.buckets) == 2
+
+
+class TestShockCatalog:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("rate_up", "rate_up"),
+            ("  rate_down  ", "rate_down"),
+            ("DEMAND_SURGE", "demand_surge"),
+        ],
+    )
+    def test_normalize_shock_key_for_english(self, raw: str, expected: str) -> None:
+        assert normalize_shock_key(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("금리인상", "rate_up"),
+            ("금리 인하", "rate_down"),
+            ("수요증가", "demand_surge"),
+            ("공급 확대", "supply_increase"),
+            ("규제완화", "regulation_loosen"),
+            ("심리위축", "sentiment_drop"),
+        ],
+    )
+    def test_normalize_shock_key_for_korean_aliases(self, raw: str, expected: str) -> None:
+        assert normalize_shock_key(raw) == expected
+
+    @pytest.mark.parametrize("raw", ["", "unknown", "가격상승", "sentiment_up"])
+    def test_normalize_shock_key_unknown_returns_none(self, raw: str) -> None:
+        assert normalize_shock_key(raw) is None
+
+    def test_expand_shock_returns_valid_shock(self) -> None:
+        shock = expand_shock("rate_up", ["11680", "11650"], "2026-01", "2026-06")
+
+        assert shock.shock_type == "interest_rate"
+        assert shock.description == "Interest rate hike"
+        assert shock.magnitude == 0.3
+        assert shock.target_segments == ["11680", "11650"]
+
+    def test_expand_shock_raises_on_unknown_key(self) -> None:
+        with pytest.raises(KeyError):
+            expand_shock("unknown_key", ["11680"], "2026-01", None)
+
+    def test_supported_shock_keys_exposes_catalog(self) -> None:
+        assert "rate_up" in SUPPORTED_SHOCK_KEYS
+        assert SUPPORTED_SHOCK_KEYS["rate_up"]["description"] == "Interest rate hike"
+
+
+class TestGuResolver:
+    def test_none_hint_returns_all_available(self) -> None:
+        resolved, warnings = resolve_gu_codes(None, ["11680", "11710"])
+
+        assert resolved == ["11680", "11710"]
+        assert warnings == []
+
+    def test_exact_code_match(self) -> None:
+        resolved, warnings = resolve_gu_codes("11680", ["11680", "11710"])
+
+        assert resolved == ["11680"]
+        assert warnings == []
+
+    def test_exact_name_match(self) -> None:
+        resolved, warnings = resolve_gu_codes("서초구", ["11650", "11710"])
+
+        assert resolved == ["11650"]
+        assert warnings == []
+
+    def test_substring_name_match(self) -> None:
+        resolved, warnings = resolve_gu_codes("강남구와 송파구를 보고 싶다", ["11680", "11710", "11650"])
+
+        assert resolved == ["11680", "11710"]
+        assert warnings == []
+
+    def test_unresolved_hint_returns_all_plus_warning(self) -> None:
+        resolved, warnings = resolve_gu_codes("부산 해운대", ["11680", "11710"])
+
+        assert resolved == ["11680", "11710"]
+        assert len(warnings) == 1
+        assert "Could not resolve geography hint" in warnings[0]
+
+    def test_exact_code_unavailable_returns_warning(self) -> None:
+        resolved, warnings = resolve_gu_codes("11680", ["11710"])
+
+        assert resolved == ["11710"]
+        assert len(warnings) == 1
+        assert "unavailable" in warnings[0]
+
+
+class TestMaxRoundsFormula:
+    @pytest.mark.parametrize(
+        "horizon,shock_count,mode,expected",
+        [
+            (1, 0, "baseline", 1),
+            (3, 0, "baseline", 1),
+            (6, 1, "baseline", 2),
+            (6, 2, "baseline", 3),
+            (6, 2, "stress", 4),
+            (12, 0, "compare", 5),
+            (60, 5, "stress", 8),
+        ],
+    )
+    def test_compute_max_rounds(self, horizon: int, shock_count: int, mode: str, expected: int) -> None:
+        assert compute_max_rounds(horizon, shock_count, mode) == expected
+
+
+def _make_state_for_builder(
+    run_id: str,
+    *,
+    intake_plan: IntakePlan | None = None,
+    snapshot: SnapshotRef | None = None,
+) -> dict[str, Any]:
+    plan = intake_plan or _make_intake_plan()
+    state = seed_graph_state(plan.user_query, run_id, f"run-{run_id}", "gpt-test")
+    state["intake_plan"] = plan.model_dump()
+    state["snapshot"] = snapshot or _make_snapshot_ref()
+    return state
+
+
+class TestScenarioBuilderNode:
+    def test_returns_state_update_with_expected_keys(self) -> None:
+        store = InMemoryEventStore()
+        llm = FakeStructuredLLM(_make_selection())
+        node = make_scenario_builder_node(store, llm, FakeSnapshotReader(_make_coverage()))
+
+        result = node(_make_state_for_builder("scenario-node-001"))
+
+        assert set(result.keys()) == {"scenario", "participant_roster", "max_rounds", "warnings", "event_refs"}
+        assert isinstance(result["scenario"], ScenarioSpec)
+        assert isinstance(result["participant_roster"], dict)
+        assert isinstance(result["max_rounds"], int)
+
+    def test_emits_scenario_built_event(self) -> None:
+        run_id = "scenario-node-002"
+        store = InMemoryEventStore()
+        llm = FakeStructuredLLM(_make_selection())
+        node = make_scenario_builder_node(store, llm, FakeSnapshotReader(_make_coverage()))
+
+        result = node(_make_state_for_builder(run_id))
+        events = store.get_events_by_type(run_id, "SCENARIO_BUILT")
+
+        assert len(events) == 1
+        assert events[0].event_id == result["event_refs"][0]
+        assert events[0].payload["scenario"]["scenario_name"] == "Stress Case Alpha"
+
+    def test_resolves_geography_using_hint(self) -> None:
+        store = InMemoryEventStore()
+        llm = FakeStructuredLLM(_make_selection())
+        node = make_scenario_builder_node(store, llm, FakeSnapshotReader(_make_coverage()))
+        state = _make_state_for_builder("scenario-node-003", intake_plan=_make_intake_plan(geography_hint="서초구"))
+
+        result = node(state)
+
+        assert result["scenario"].target_gus == ["11650"]
+
+    def test_computes_period_from_coverage_and_horizon(self) -> None:
+        store = InMemoryEventStore()
+        llm = FakeStructuredLLM(_make_selection())
+        coverage = _make_coverage(max_period="2025-11")
+        node = make_scenario_builder_node(store, llm, FakeSnapshotReader(coverage))
+        state = _make_state_for_builder("scenario-node-004", intake_plan=_make_intake_plan(horizon_months=4))
+
+        result = node(state)
+
+        assert result["scenario"].target_period_start == date(2025, 12, 1)
+        assert result["scenario"].target_period_end == date(2026, 3, 1)
+
+    def test_filters_invalid_shock_keys(self) -> None:
+        store = InMemoryEventStore()
+        selection = _make_selection(selected_shock_keys=["rate_up", "does_not_exist", "금리인하"])
+        llm = FakeStructuredLLM(selection)
+        node = make_scenario_builder_node(store, llm, FakeSnapshotReader(_make_coverage()))
+
+        result = node(_make_state_for_builder("scenario-node-005"))
+
+        shocks = result["scenario"].shocks
+        assert len(shocks) == 2
+        assert shocks[0].description == "Interest rate hike"
+        assert shocks[1].description == "Interest rate cut"
+
+    def test_post_validates_roster_buckets_and_clamps_counts(self) -> None:
+        store = InMemoryEventStore()
+        unsafe = ScenarioSelection.model_construct(
+            scenario_name="Unsafe",
+            selected_shock_keys=["rate_up"],
+            roster_buckets=[
+                {
+                    "role": "buyer",
+                    "count": 999,
+                    "capital_min_multiplier": -1,
+                    "capital_max_multiplier": 20,
+                    "holdings_min": -3,
+                    "holdings_max": 99,
+                    "risk_min": -2,
+                    "risk_max": 3,
+                    "sentiment_bias": "rocket",
+                },
+                {
+                    "role": "ghost",
+                    "count": 5,
+                    "capital_min_multiplier": 1,
+                    "capital_max_multiplier": 2,
+                    "holdings_min": 0,
+                    "holdings_max": 1,
+                    "risk_min": 0.1,
+                    "risk_max": 0.2,
+                    "sentiment_bias": "neutral",
+                },
+            ],
+        )
+        llm = FakeStructuredLLM(unsafe, bypass_validation=True)
+        node = make_scenario_builder_node(store, llm, FakeSnapshotReader(_make_coverage()))
+
+        result = node(_make_state_for_builder("scenario-node-006"))
+        buckets = result["participant_roster"]["buckets"]
+
+        assert len(buckets) == 1
+        assert buckets[0]["role"] == "buyer"
+        assert buckets[0]["count"] == 50
+        assert buckets[0]["capital_min_multiplier"] == 0.0
+        assert buckets[0]["capital_max_multiplier"] == 10.0
+        assert buckets[0]["holdings_min"] == 0
+        assert buckets[0]["holdings_max"] == 20
+        assert buckets[0]["risk_min"] == 0.0
+        assert buckets[0]["risk_max"] == 1.0
+        assert buckets[0]["sentiment_bias"] == "neutral"
+
+    def test_compare_mode_adds_warning(self) -> None:
+        store = InMemoryEventStore()
+        llm = FakeStructuredLLM(_make_selection())
+        node = make_scenario_builder_node(store, llm, FakeSnapshotReader(_make_coverage()))
+        state = _make_state_for_builder("scenario-node-007", intake_plan=_make_intake_plan(analysis_mode="compare"))
+
+        result = node(state)
+
+        assert any("Compare mode" in warning for warning in result["warnings"])
+
+    def test_stress_mode_adds_default_shock_if_none_selected(self) -> None:
+        store = InMemoryEventStore()
+        llm = FakeStructuredLLM(_make_selection(selected_shock_keys=[]))
+        node = make_scenario_builder_node(store, llm, FakeSnapshotReader(_make_coverage()))
+        state = _make_state_for_builder("scenario-node-008", intake_plan=_make_intake_plan(analysis_mode="stress"))
+
+        result = node(state)
+
+        assert len(result["scenario"].shocks) == 1
+        assert result["scenario"].shocks[0].description == "Market sentiment deterioration"
+        assert any("Stress mode requires at least one shock" in warning for warning in result["warnings"])
+
+    def test_calls_llm_with_scenario_selection_response_model(self) -> None:
+        store = InMemoryEventStore()
+        llm = FakeStructuredLLM(_make_selection())
+        node = make_scenario_builder_node(store, llm, FakeSnapshotReader(_make_coverage()))
+
+        node(_make_state_for_builder("scenario-node-009"))
+
+        assert len(llm.calls) == 1
+        assert llm.calls[0]["response_model"] is ScenarioSelection
+        assert llm.calls[0]["temperature"] == 0.0
+        assert llm.calls[0]["messages"][0]["role"] == "system"
+
+    def test_raises_if_snapshot_missing(self) -> None:
+        store = InMemoryEventStore()
+        llm = FakeStructuredLLM(_make_selection())
+        node = make_scenario_builder_node(store, llm, FakeSnapshotReader(_make_coverage()))
+        state = seed_graph_state("질문", "scenario-node-010", "run", "gpt-test")
+        state["intake_plan"] = _make_intake_plan().model_dump()
+
+        with pytest.raises(ValueError, match="snapshot is required"):
+            node(state)
+
+
+class TestGraphWiringForScenarioBuilder:
+    def test_uses_real_scenario_builder_when_llm_and_snapshot_reader_provided(self) -> None:
+        run_id = "graph-real-scenario"
+        store = InMemoryEventStore()
+        plan = _make_intake_plan(analysis_mode="baseline")
+        llm = FakeMultiplexStructuredLLM(plan, _make_selection(scenario_name="Real Scenario"))
+        reader = FakeSnapshotReader(_make_coverage())
+        graph = build_simulation_graph(store, structured_llm=llm, snapshot_reader=reader)
+        state = _make_state_for_builder(run_id, intake_plan=plan)
+        state["max_rounds"] = 0
+
+        final = graph.invoke(state)
+
+        assert final["scenario"].scenario_name == "Real Scenario"
+        assert "participant_roster" in final
+        assert (
+            store.get_events_by_type(run_id, "SCENARIO_BUILT")[0].payload["scenario"]["scenario_name"]
+            == "Real Scenario"
+        )
+
+    def test_uses_stub_scenario_builder_when_snapshot_reader_missing(self) -> None:
+        run_id = "graph-stub-scenario"
+        store = InMemoryEventStore()
+        llm = FakeMultiplexStructuredLLM(
+            _make_intake_plan(analysis_mode="baseline"), _make_selection(scenario_name="Should Not Appear")
+        )
+        graph = build_simulation_graph(store, structured_llm=llm)
+        seed = seed_graph_state("기본 시나리오", run_id, "run-stub", "gpt-test")
+        seed["max_rounds"] = 0
+
+        final = graph.invoke(seed)
+
+        assert final["scenario"].scenario_name == "Stub Scenario"
+
+
+def test_fake_snapshot_reader_signature_smoke() -> None:
+    coverage = _make_coverage()
+    metrics = [
+        GoldDistrictMonthlyMetrics(
+            gu_code="11680",
+            gu_name="강남구",
+            period="2025-12",
+            sale_count=10,
+            avg_price=100,
+            median_price=90,
+            min_price=50,
+            max_price=150,
+            price_per_pyeong_avg=80,
+            yoy_price_change=0.1,
+            mom_price_change=0.01,
+            yoy_volume_change=0.2,
+            mom_volume_change=0.03,
+            avg_area_m2=Decimal("84.5"),
+            base_interest_rate=Decimal("3.25"),
+            net_migration=20,
+            dataset_snapshot_id="a" * 64,
+        )
+    ]
+    forecasts = [
+        BaselineForecast(
+            gu_code="11680",
+            gu_name="강남구",
+            target_period="2026-01",
+            direction="up",
+            direction_confidence=0.7,
+            predicted_volume=12,
+            predicted_median_price=95,
+            model_name="baseline-v1",
+            features_used=["mom_price_change"],
+        )
+    ]
+    reader = FakeSnapshotReader(coverage, metrics=metrics, forecasts=forecasts)
+    snapshot = _make_snapshot_ref()
+
+    assert reader.get_coverage(snapshot) == coverage
+    assert reader.get_latest_metrics(snapshot) == metrics
+    assert reader.get_baseline_forecasts(snapshot) == forecasts


### PR DESCRIPTION
## Summary

Implements M5-PR5: Scenario builder — the second LLM-powered node. Converts IntakePlan + snapshot data into a concrete ScenarioSpec with shocks, participant roster, and round configuration.

### New modules
- **SnapshotReader Protocol** (`simulation/ports/snapshot_reader.py`): Read-only port for gold data access with `get_coverage()`, `get_latest_metrics()`, `get_baseline_forecasts()`
- **ParticipantRosterSpec** (`simulation/schemas/participant_roster.py`): Specification for participant mix (role buckets with count/capital/risk bounds)
- **Shock catalog** (`simulation/domain/shock_catalog.py`): 8 supported shock types with Korean aliases, deterministic expansion to `Shock` objects
- **Gu resolver** (`simulation/domain/gu_resolver.py`): Seoul district code/name resolution with substring matching and fallback
- **Scenario builder node** (`simulation/nodes/scenario_builder.py`): Hybrid LLM + deterministic pipeline

### Architecture
- **Hybrid approach**: LLM selects from whitelisted options (shock keys, role types), then outputs are validated and expanded deterministically
- **Post-validation**: Invalid LLM selections are filtered, counts clamped, roles validated against core Literals
- **Deterministic max_rounds**: `ceil(horizon/3)` + shock bonus + stress bonus, clamped [1, 8]
- **Shock catalog**: LLM cannot invent freeform parameters — only selects from predefined catalog keys
- **Compare mode**: v0.1 builds single scenario with warning (multi-branch orchestration deferred)

### Graph wiring
- `build_simulation_graph()` now accepts `snapshot_reader` parameter
- Real scenario builder used when both `structured_llm` AND `snapshot_reader` provided
- Falls back to stub otherwise (backwards compatible)

### Test coverage
- 55 new tests covering: schemas, shock catalog, gu resolver, max_rounds formula, node behavior, graph wiring
- 684 total tests passing

Closes #46