### PR TITLE
feat(simulation): add offline replay engine for event folding (#111)

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/replay/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/replay/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .engine import HANDLERS, ReplayContext, ReplayEngine, ReplayError, ReplayResult
+
+__all__ = [
+    "HANDLERS",
+    "ReplayContext",
+    "ReplayEngine",
+    "ReplayError",
+    "ReplayResult",
+]

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/replay/engine.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/replay/engine.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any, Callable, Literal
+
+from pydantic import ValidationError
+
+from ..events import EventStore, SimulationEvent
+from ..graph_state import SimulationGraphState
+from ..schemas.intake import IntakePlan
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    state: SimulationGraphState
+    completeness: Literal["partial", "full"]
+    event_count: int
+    warnings: list[str]
+    world_summary: dict[str, dict[str, int]] | None
+    participant_count: int | None
+    anchor_period: str | None
+
+
+@dataclass(frozen=True)
+class ReplayContext:
+    strict: bool = True
+
+
+class ReplayError(Exception):
+    pass
+
+
+EventHandler = Callable[[SimulationGraphState, SimulationEvent, ReplayContext], SimulationGraphState]
+
+
+def _copy_state(state: SimulationGraphState) -> SimulationGraphState:
+    return {**state}
+
+
+def _state_warnings(state: SimulationGraphState) -> list[str]:
+    raw = state.get("warnings")
+    if not isinstance(raw, list):
+        return []
+    return [warning for warning in raw if isinstance(warning, str)]
+
+
+def _append_warnings(state: SimulationGraphState, warnings: list[str]) -> SimulationGraphState:
+    if not warnings:
+        return state
+
+    next_state = _copy_state(state)
+    existing = _state_warnings(next_state)
+    next_state["warnings"] = existing + warnings
+    return next_state
+
+
+def _warning_list(payload: dict[str, Any]) -> list[str]:
+    raw = payload.get("warnings", [])
+    if not isinstance(raw, list):
+        return []
+    return [warning for warning in raw if isinstance(warning, str)]
+
+
+def _handle_intake_planned(
+    state: SimulationGraphState,
+    event: SimulationEvent,
+    context: ReplayContext,
+) -> SimulationGraphState:
+    _ = context
+    try:
+        intake_plan = IntakePlan.model_validate(event.payload)
+    except ValidationError as exc:
+        raise ReplayError(f"Invalid INTAKE_PLANNED payload for event_id={event.event_id}") from exc
+
+    next_state = _copy_state(state)
+    payload = intake_plan.model_dump()
+    next_state["intake_plan"] = payload
+    user_query = payload.get("user_query")
+    if isinstance(user_query, str):
+        next_state["user_query"] = user_query
+    return next_state
+
+
+def _handle_scenario_built(
+    state: SimulationGraphState,
+    event: SimulationEvent,
+    context: ReplayContext,
+) -> SimulationGraphState:
+    _ = context
+
+    raw_scenario = event.payload.get("scenario")
+    if not isinstance(raw_scenario, dict):
+        raise ReplayError(f"Invalid SCENARIO_BUILT payload for event_id={event.event_id}: missing scenario")
+
+    scenario_spec_model = import_module("younggeul_core.state.simulation").ScenarioSpec
+    try:
+        scenario = scenario_spec_model.model_validate(raw_scenario)
+    except ValidationError as exc:
+        raise ReplayError(f"Invalid SCENARIO_BUILT scenario payload for event_id={event.event_id}") from exc
+
+    next_state = _copy_state(state)
+    next_state["scenario"] = scenario
+
+    participant_roster = event.payload.get("participant_roster")
+    if not isinstance(participant_roster, dict):
+        raise ReplayError(f"Invalid SCENARIO_BUILT payload for event_id={event.event_id}: missing participant_roster")
+    next_state["participant_roster"] = participant_roster
+
+    max_rounds = event.payload.get("max_rounds")
+    if not isinstance(max_rounds, int):
+        raise ReplayError(f"Invalid SCENARIO_BUILT payload for event_id={event.event_id}: missing max_rounds")
+    next_state["max_rounds"] = max_rounds
+
+    return _append_warnings(next_state, _warning_list(event.payload))
+
+
+def _handle_world_initialized(
+    state: SimulationGraphState,
+    event: SimulationEvent,
+    context: ReplayContext,
+) -> SimulationGraphState:
+    _ = context
+    return _append_warnings(state, _warning_list(event.payload))
+
+
+HANDLERS: dict[str, EventHandler] = {
+    "INTAKE_PLANNED": _handle_intake_planned,
+    "SCENARIO_BUILT": _handle_scenario_built,
+    "WORLD_INITIALIZED": _handle_world_initialized,
+}
+
+
+class ReplayEngine:
+    def __init__(self, event_store: EventStore) -> None:
+        self._event_store = event_store
+
+    def replay(self, run_id: str, *, strict: bool = True) -> ReplayResult:
+        context = ReplayContext(strict=strict)
+        events = self._event_store.get_events(run_id)
+
+        state: SimulationGraphState = {}
+        replay_warnings: list[str] = []
+
+        if not events:
+            replay_warnings.append(f"No events found for run_id={run_id}.")
+            return ReplayResult(
+                state=state,
+                completeness="partial",
+                event_count=0,
+                warnings=replay_warnings,
+                world_summary=None,
+                participant_count=None,
+                anchor_period=None,
+            )
+
+        world_summary: dict[str, dict[str, int]] | None = None
+        participant_count: int | None = None
+        anchor_period: str | None = None
+
+        for event in events:
+            handler = HANDLERS.get(event.event_type)
+            if handler is None:
+                if context.strict:
+                    raise ReplayError(f"Unknown event type: {event.event_type} (event_id={event.event_id})")
+                replay_warnings.append(
+                    f"Skipped unknown event type '{event.event_type}' for event_id={event.event_id}."
+                )
+                continue
+
+            state = handler(state, event, context)
+
+            if event.event_type == "WORLD_INITIALIZED":
+                raw_world_summary = event.payload.get("world_summary")
+                if isinstance(raw_world_summary, dict):
+                    world_summary = {
+                        gu_code: values
+                        for gu_code, values in raw_world_summary.items()
+                        if isinstance(gu_code, str) and isinstance(values, dict)
+                    }
+
+                raw_participant_count = event.payload.get("participant_count")
+                if isinstance(raw_participant_count, int):
+                    participant_count = raw_participant_count
+
+                raw_anchor_period = event.payload.get("anchor_period")
+                if isinstance(raw_anchor_period, str):
+                    anchor_period = raw_anchor_period
+
+        state_has_full_core = all(
+            key in state for key in ("intake_plan", "scenario", "participant_roster", "max_rounds")
+        )
+        completeness: Literal["partial", "full"] = (
+            "full"
+            if state_has_full_core
+            and world_summary is not None
+            and participant_count is not None
+            and anchor_period is not None
+            else "partial"
+        )
+
+        return ReplayResult(
+            state=state,
+            completeness=completeness,
+            event_count=len(events),
+            warnings=[*_state_warnings(state), *replay_warnings],
+            world_summary=world_summary,
+            participant_count=participant_count,
+            anchor_period=anchor_period,
+        )

--- a/apps/kr-seoul-apartment/tests/unit/test_replay_engine.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_replay_engine.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from importlib import import_module
+from typing import Any
+
+import pytest
+
+event_store_module = import_module("younggeul_app_kr_seoul_apartment.simulation.event_store")
+events_module = import_module("younggeul_app_kr_seoul_apartment.simulation.events")
+replay_module = import_module("younggeul_app_kr_seoul_apartment.simulation.replay")
+intake_module = import_module("younggeul_app_kr_seoul_apartment.simulation.schemas.intake")
+roster_module = import_module("younggeul_app_kr_seoul_apartment.simulation.schemas.participant_roster")
+simulation_state_module = import_module("younggeul_core.state.simulation")
+
+InMemoryEventStore = event_store_module.InMemoryEventStore
+SimulationEvent = events_module.SimulationEvent
+HANDLERS = replay_module.HANDLERS
+ReplayContext = replay_module.ReplayContext
+ReplayEngine = replay_module.ReplayEngine
+ReplayError = replay_module.ReplayError
+IntakePlan = intake_module.IntakePlan
+ParticipantRosterSpec = roster_module.ParticipantRosterSpec
+RoleBucketSpec = roster_module.RoleBucketSpec
+ScenarioSpec = simulation_state_module.ScenarioSpec
+
+
+def _event(
+    *,
+    event_id: str,
+    run_id: str = "run-001",
+    event_type: str,
+    payload: dict[str, Any],
+    offset_seconds: int = 0,
+) -> SimulationEvent:
+    return SimulationEvent(
+        event_id=event_id,
+        run_id=run_id,
+        round_no=0,
+        event_type=event_type,
+        timestamp=datetime(2026, 3, 29, 12, 0, 0, tzinfo=timezone.utc) + timedelta(seconds=offset_seconds),
+        payload=payload,
+    )
+
+
+def _intake_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = IntakePlan(
+        user_query="강남구 아파트 전망을 분석해줘",
+        objective="금리 충격에 대한 가격 반응을 파악한다.",
+        analysis_mode="stress",
+        geography_hint="강남구",
+        segment_hint="아파트",
+        horizon_months=12,
+        requested_shocks=["금리인상"],
+        participant_focus=["실수요자", "투자자"],
+        constraints=[],
+        assumptions=[],
+        ambiguities=[],
+    ).model_dump()
+    payload.update(overrides)
+    return payload
+
+
+def _scenario_payload(**overrides: Any) -> dict[str, Any]:
+    scenario = ScenarioSpec(
+        scenario_name="Stress Alpha",
+        target_gus=["11680", "11650"],
+        target_period_start=date(2026, 1, 1),
+        target_period_end=date(2026, 6, 1),
+        shocks=[],
+    )
+    roster = ParticipantRosterSpec(
+        seed="seed-01",
+        buckets=[
+            RoleBucketSpec(
+                role="buyer",
+                count=4,
+                capital_min_multiplier=0.8,
+                capital_max_multiplier=1.2,
+                holdings_min=0,
+                holdings_max=2,
+                risk_min=0.2,
+                risk_max=0.8,
+                sentiment_bias="neutral",
+            )
+        ],
+    )
+    payload: dict[str, Any] = {
+        "scenario": scenario.model_dump(),
+        "participant_roster": roster.model_dump(),
+        "max_rounds": 4,
+        "warnings": ["Scenario warning"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _world_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "world_summary": {
+            "11680": {"median_price": 1_900_000, "volume": 130},
+            "11650": {"median_price": 1_700_000, "volume": 90},
+        },
+        "participant_count": 12,
+        "anchor_period": "2025-12",
+        "warnings": ["World warning"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestReplayEngine:
+    def test_replay_all_supported_events_returns_full_result(self) -> None:
+        store = InMemoryEventStore()
+        store.append(_event(event_id="evt-1", event_type="INTAKE_PLANNED", payload=_intake_payload(), offset_seconds=0))
+        store.append(
+            _event(event_id="evt-2", event_type="SCENARIO_BUILT", payload=_scenario_payload(), offset_seconds=1)
+        )
+        store.append(
+            _event(event_id="evt-3", event_type="WORLD_INITIALIZED", payload=_world_payload(), offset_seconds=2)
+        )
+
+        result = ReplayEngine(store).replay("run-001")
+
+        assert result.completeness == "full"
+        assert result.event_count == 3
+        assert result.state["user_query"] == "강남구 아파트 전망을 분석해줘"
+        assert result.state["max_rounds"] == 4
+        assert result.world_summary is not None
+        assert result.participant_count == 12
+        assert result.anchor_period == "2025-12"
+
+    def test_replay_intake_only_is_partial(self) -> None:
+        store = InMemoryEventStore()
+        store.append(_event(event_id="evt-1", event_type="INTAKE_PLANNED", payload=_intake_payload()))
+
+        result = ReplayEngine(store).replay("run-001")
+
+        assert result.completeness == "partial"
+        assert "intake_plan" in result.state
+        assert result.state["user_query"] == _intake_payload()["user_query"]
+        assert "scenario" not in result.state
+
+    def test_unknown_event_type_strict_mode_raises(self) -> None:
+        store = InMemoryEventStore()
+        store.append(_event(event_id="evt-1", event_type="UNKNOWN", payload={}))
+
+        with pytest.raises(ReplayError, match="Unknown event type"):
+            ReplayEngine(store).replay("run-001", strict=True)
+
+    def test_unknown_event_type_best_effort_skips_with_warning(self) -> None:
+        store = InMemoryEventStore()
+        store.append(_event(event_id="evt-1", event_type="INTAKE_PLANNED", payload=_intake_payload(), offset_seconds=0))
+        store.append(_event(event_id="evt-2", event_type="UNKNOWN", payload={}, offset_seconds=1))
+
+        result = ReplayEngine(store).replay("run-001", strict=False)
+
+        assert result.event_count == 2
+        assert any("Skipped unknown event type" in warning for warning in result.warnings)
+        assert "intake_plan" in result.state
+
+    def test_empty_event_store_returns_partial_with_warning(self) -> None:
+        store = InMemoryEventStore()
+
+        result = ReplayEngine(store).replay("missing-run")
+
+        assert result.completeness == "partial"
+        assert result.event_count == 0
+        assert result.state == {}
+        assert len(result.warnings) == 1
+        assert "No events found" in result.warnings[0]
+
+    def test_world_initialized_does_not_set_world_or_participants_in_state(self) -> None:
+        store = InMemoryEventStore()
+        store.append(_event(event_id="evt-1", event_type="WORLD_INITIALIZED", payload=_world_payload()))
+
+        result = ReplayEngine(store).replay("run-001")
+
+        assert "world" not in result.state
+        assert "participants" not in result.state
+
+    def test_world_initialized_extracts_summary_metadata(self) -> None:
+        store = InMemoryEventStore()
+        store.append(_event(event_id="evt-1", event_type="WORLD_INITIALIZED", payload=_world_payload()))
+
+        result = ReplayEngine(store).replay("run-001")
+
+        assert result.world_summary == _world_payload()["world_summary"]
+        assert result.participant_count == 12
+        assert result.anchor_period == "2025-12"
+
+    def test_replay_uses_timestamp_ordering(self) -> None:
+        store = InMemoryEventStore()
+        store.append(
+            _event(event_id="evt-2", event_type="SCENARIO_BUILT", payload=_scenario_payload(), offset_seconds=10)
+        )
+        store.append(_event(event_id="evt-1", event_type="INTAKE_PLANNED", payload=_intake_payload(), offset_seconds=1))
+
+        result = ReplayEngine(store).replay("run-001")
+
+        assert result.state["user_query"] == _intake_payload()["user_query"]
+        assert result.state["scenario"].scenario_name == "Stress Alpha"
+
+    def test_multiple_runs_only_replays_target_run(self) -> None:
+        store = InMemoryEventStore()
+        store.append(_event(event_id="evt-a", run_id="run-a", event_type="INTAKE_PLANNED", payload=_intake_payload()))
+        store.append(_event(event_id="evt-b", run_id="run-b", event_type="INTAKE_PLANNED", payload=_intake_payload()))
+
+        result = ReplayEngine(store).replay("run-b")
+
+        assert result.event_count == 1
+        assert result.state["user_query"] == _intake_payload()["user_query"]
+
+    def test_scenario_warnings_are_appended_to_state(self) -> None:
+        store = InMemoryEventStore()
+        store.append(
+            _event(event_id="evt-1", event_type="SCENARIO_BUILT", payload=_scenario_payload(warnings=["w1", "w2"]))
+        )
+
+        result = ReplayEngine(store).replay("run-001")
+
+        assert result.state["warnings"] == ["w1", "w2"]
+
+    def test_world_warnings_are_appended_to_state(self) -> None:
+        store = InMemoryEventStore()
+        store.append(
+            _event(event_id="evt-1", event_type="WORLD_INITIALIZED", payload=_world_payload(warnings=["world-warn"]))
+        )
+
+        result = ReplayEngine(store).replay("run-001")
+
+        assert result.state["warnings"] == ["world-warn"]
+
+    def test_result_warnings_include_state_and_replay_warnings(self) -> None:
+        store = InMemoryEventStore()
+        store.append(
+            _event(event_id="evt-1", event_type="SCENARIO_BUILT", payload=_scenario_payload(warnings=["state-warn"]))
+        )
+        store.append(_event(event_id="evt-2", event_type="UNKNOWN", payload={}, offset_seconds=1))
+
+        result = ReplayEngine(store).replay("run-001", strict=False)
+
+        assert result.warnings[0] == "state-warn"
+        assert any("Skipped unknown event type" in warning for warning in result.warnings)
+
+    def test_invalid_intake_payload_raises_replay_error(self) -> None:
+        store = InMemoryEventStore()
+        store.append(
+            _event(
+                event_id="evt-1",
+                event_type="INTAKE_PLANNED",
+                payload={"user_query": "q", "objective": "o", "analysis_mode": "baseline"},
+            )
+        )
+
+        with pytest.raises(ReplayError, match="Invalid INTAKE_PLANNED payload"):
+            ReplayEngine(store).replay("run-001")
+
+    def test_invalid_scenario_payload_raises_replay_error(self) -> None:
+        store = InMemoryEventStore()
+        bad_scenario = {"scenario_name": "bad"}
+        store.append(
+            _event(
+                event_id="evt-1",
+                event_type="SCENARIO_BUILT",
+                payload=_scenario_payload(scenario=bad_scenario),
+            )
+        )
+
+        with pytest.raises(ReplayError, match="Invalid SCENARIO_BUILT scenario payload"):
+            ReplayEngine(store).replay("run-001")
+
+    def test_missing_participant_roster_raises_replay_error(self) -> None:
+        store = InMemoryEventStore()
+        payload = _scenario_payload()
+        del payload["participant_roster"]
+        store.append(_event(event_id="evt-1", event_type="SCENARIO_BUILT", payload=payload))
+
+        with pytest.raises(ReplayError, match="missing participant_roster"):
+            ReplayEngine(store).replay("run-001")
+
+    def test_missing_max_rounds_raises_replay_error(self) -> None:
+        store = InMemoryEventStore()
+        payload = _scenario_payload()
+        del payload["max_rounds"]
+        store.append(_event(event_id="evt-1", event_type="SCENARIO_BUILT", payload=payload))
+
+        with pytest.raises(ReplayError, match="missing max_rounds"):
+            ReplayEngine(store).replay("run-001")
+
+    def test_non_list_warnings_in_payload_are_ignored(self) -> None:
+        store = InMemoryEventStore()
+        store.append(
+            _event(event_id="evt-1", event_type="SCENARIO_BUILT", payload=_scenario_payload(warnings="not-a-list"))
+        )
+
+        result = ReplayEngine(store).replay("run-001")
+
+        assert "warnings" not in result.state
+
+    def test_invalid_world_summary_shape_is_filtered(self) -> None:
+        store = InMemoryEventStore()
+        store.append(
+            _event(
+                event_id="evt-1",
+                event_type="WORLD_INITIALIZED",
+                payload=_world_payload(world_summary={"11680": {"median_price": 1_0}, "bad": 123}),
+            )
+        )
+
+        result = ReplayEngine(store).replay("run-001")
+
+        assert result.world_summary == {"11680": {"median_price": 10}}
+
+    def test_best_effort_with_unknown_event_can_still_be_partial(self) -> None:
+        store = InMemoryEventStore()
+        store.append(_event(event_id="evt-1", event_type="INTAKE_PLANNED", payload=_intake_payload()))
+        store.append(_event(event_id="evt-2", event_type="UNKNOWN", payload={}, offset_seconds=1))
+
+        result = ReplayEngine(store).replay("run-001", strict=False)
+
+        assert result.completeness == "partial"
+
+    def test_round_trip_event_backed_fields_match(self) -> None:
+        intake_payload = _intake_payload()
+        scenario_payload = _scenario_payload()
+        world_payload = _world_payload()
+
+        store = InMemoryEventStore()
+        store.append(_event(event_id="evt-1", event_type="INTAKE_PLANNED", payload=intake_payload, offset_seconds=0))
+        store.append(_event(event_id="evt-2", event_type="SCENARIO_BUILT", payload=scenario_payload, offset_seconds=1))
+        store.append(_event(event_id="evt-3", event_type="WORLD_INITIALIZED", payload=world_payload, offset_seconds=2))
+
+        result = ReplayEngine(store).replay("run-001")
+
+        assert result.state["intake_plan"] == intake_payload
+        assert result.state["participant_roster"] == scenario_payload["participant_roster"]
+        assert result.state["max_rounds"] == scenario_payload["max_rounds"]
+        assert result.world_summary == world_payload["world_summary"]
+        assert result.participant_count == world_payload["participant_count"]
+        assert result.anchor_period == world_payload["anchor_period"]
+
+    def test_latest_world_initialized_event_wins_for_metadata(self) -> None:
+        store = InMemoryEventStore()
+        store.append(
+            _event(event_id="evt-1", event_type="WORLD_INITIALIZED", payload=_world_payload(anchor_period="2025-11"))
+        )
+        store.append(
+            _event(
+                event_id="evt-2",
+                event_type="WORLD_INITIALIZED",
+                payload=_world_payload(anchor_period="2025-12", participant_count=33),
+                offset_seconds=1,
+            )
+        )
+
+        result = ReplayEngine(store).replay("run-001")
+
+        assert result.anchor_period == "2025-12"
+        assert result.participant_count == 33
+
+    def test_handlers_registry_contains_required_event_types(self) -> None:
+        assert set(HANDLERS.keys()) == {"INTAKE_PLANNED", "SCENARIO_BUILT", "WORLD_INITIALIZED"}
+
+    def test_replay_context_defaults_to_strict(self) -> None:
+        context = ReplayContext()
+
+        assert context.strict is True
+
+    def test_replay_context_can_disable_strict(self) -> None:
+        context = ReplayContext(strict=False)
+
+        assert context.strict is False


### PR DESCRIPTION
## Summary

Implements the **replay engine** — an offline event-folding utility that reads simulation events from an EventStore and reconstructs state from persisted facts only.

This is the **final PR for M5: Simulation Plane — Core Runtime**.

Closes #111

## Changes

### New: Replay Engine (`simulation/replay/engine.py`)
- **`ReplayEngine`** class with `replay(run_id, *, strict=True) -> ReplayResult`
- **`ReplayResult`** frozen dataclass: `state`, `completeness` (partial/full), `event_count`, `warnings`, `world_summary`, `participant_count`, `anchor_period`
- **`ReplayContext`** for config (strict vs best-effort mode)
- **`ReplayError`** custom exception for strict-mode failures

### Handler Registry
Pure function handlers for each supported event type:
- **`INTAKE_PLANNED`** → sets `intake_plan` and `user_query` in state
- **`SCENARIO_BUILT`** → validates and sets `scenario` (ScenarioSpec), `participant_roster`, `max_rounds`; appends warnings
- **`WORLD_INITIALIZED`** → summary-only (does NOT fabricate world/participants state); extracts metadata into ReplayResult fields; appends warnings

### Error Handling
- **Strict mode (default)**: Unknown event types raise `ReplayError`
- **Best-effort mode**: Unknown events skipped with warning recorded
- Invalid payloads → `ReplayError` with descriptive message
- Empty event store → partial result with warning

### Tests: 24 unit tests (`tests/unit/test_replay_engine.py`)
- Full 3-event replay → completeness=full
- Partial replays (intake only, missing events)
- Unknown event handling (strict + best-effort)
- Empty event store
- WORLD_INITIALIZED summary-only verification (no world/participants in state)
- Metadata extraction from WORLD_INITIALIZED
- Event timestamp ordering
- Multi-run isolation
- Invalid payload handling (bad intake, bad scenario, missing fields)
- Round-trip fidelity for event-backed fields
- Handler registry completeness

## Design Decisions

- **ReplayResult over bare state**: Explicit completeness tracking prevents partial replay masquerading as usable state
- **Summary-only for WORLD_INITIALIZED**: Full world/participant state is not recoverable from events alone; replay is honest about what it can reconstruct
- **No SnapshotReader dependency**: Pure event folding — no gold data access needed
- **Extensible handler dict**: New event types (M6+) just add entries to `HANDLERS`

## Test Results
```
747 passed, 1 warning
```

## Milestone

M5: Simulation Plane — Core Runtime (7 of 7 PRs — **FINAL**)