### PR TITLE
feat(simulation): wire round loop with continue/stop gate (#117)

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph.py
@@ -10,7 +10,6 @@ from langgraph.graph.state import CompiledStateGraph
 from younggeul_core.state.simulation import (
     ParticipantState,
     ReportClaim,
-    RoundOutcome,
     ScenarioSpec,
     SegmentState,
     SnapshotRef,
@@ -19,7 +18,10 @@ from younggeul_core.state.simulation import (
 from .events import EventStore, SimulationEvent
 from .graph_state import SimulationGraphState
 from .llm.ports import StructuredLLM
+from .nodes.continue_gate import should_continue
 from .nodes.intake_planner import make_intake_planner_node
+from .nodes.participant_decider import make_participant_decider_node
+from .nodes.round_resolver import make_round_resolver_node
 from .nodes.scenario_builder import make_scenario_builder_node
 from .nodes.world_initializer import make_world_initializer_node
 from .ports.snapshot_reader import SnapshotReader
@@ -51,11 +53,14 @@ def build_simulation_graph(
         if snapshot_reader is not None
         else _make_world_initializer_stub(event_store, default_max_rounds)
     )
+    participant_decider_node = make_participant_decider_node(event_store)
+    round_resolver_node = make_round_resolver_node(event_store)
 
     graph.add_node("intake_planner", intake_planner_node)
     graph.add_node("scenario_builder", scenario_builder_node)
     graph.add_node("world_initializer", world_initializer_node)
-    graph.add_node("round_runner", _make_round_runner_stub(event_store))
+    graph.add_node("participant_decider", participant_decider_node)
+    graph.add_node("round_resolver", round_resolver_node)
     graph.add_node("report_writer", _make_report_writer_stub(event_store))
     graph.add_node("critic", _make_passthrough_stub(event_store, "critic"))
     graph.add_node("citation_gate", _make_passthrough_stub(event_store, "citation_gate"))
@@ -65,17 +70,18 @@ def build_simulation_graph(
     graph.add_edge("scenario_builder", "world_initializer")
     graph.add_conditional_edges(
         "world_initializer",
-        _should_continue,
+        _should_start_rounds,
         {
-            "round_runner": "round_runner",
+            "participant_decider": "participant_decider",
             "report_writer": "report_writer",
         },
     )
+    graph.add_edge("participant_decider", "round_resolver")
     graph.add_conditional_edges(
-        "round_runner",
-        _should_continue,
+        "round_resolver",
+        _route_after_resolve,
         {
-            "round_runner": "round_runner",
+            "participant_decider": "participant_decider",
             "report_writer": "report_writer",
         },
     )
@@ -86,10 +92,14 @@ def build_simulation_graph(
     return graph.compile()
 
 
-def _should_continue(state: SimulationGraphState) -> Literal["round_runner", "report_writer"]:
+def _should_start_rounds(state: SimulationGraphState) -> Literal["participant_decider", "report_writer"]:
     round_no = state.get("round_no", 0)
     max_rounds = state.get("max_rounds", DEFAULT_MAX_ROUNDS)
-    return "round_runner" if round_no < max_rounds else "report_writer"
+    return "participant_decider" if round_no < max_rounds else "report_writer"
+
+
+def _route_after_resolve(state: SimulationGraphState) -> Literal["participant_decider", "report_writer"]:
+    return "participant_decider" if should_continue(state) == "continue" else "report_writer"
 
 
 def _append_event(
@@ -165,7 +175,7 @@ def _make_world_initializer_stub(event_store: EventStore, default_max_rounds: in
                 current_median_price=2_000_000,
                 current_volume=100,
                 price_trend="flat",
-                sentiment_index=0.5,
+                sentiment_index=0.7,
                 supply_pressure=0.0,
             )
         }
@@ -173,11 +183,19 @@ def _make_world_initializer_stub(event_store: EventStore, default_max_rounds: in
             "p-001": ParticipantState(
                 participant_id="p-001",
                 role="buyer",
-                capital=1_000_000,
+                capital=1_000_000_000_000,
                 holdings=0,
                 sentiment="neutral",
                 risk_tolerance=0.5,
-            )
+            ),
+            "p-002": ParticipantState(
+                participant_id="p-002",
+                role="investor",
+                capital=0,
+                holdings=100,
+                sentiment="neutral",
+                risk_tolerance=0.5,
+            ),
         }
 
         event_id = _append_event(
@@ -196,25 +214,6 @@ def _make_world_initializer_stub(event_store: EventStore, default_max_rounds: in
             "governance_actions": {},
             "market_actions": {},
             "last_outcome": None,
-            "event_refs": [event_id],
-        }
-
-    return node
-
-
-def _make_round_runner_stub(event_store: EventStore) -> Any:
-    def node(state: SimulationGraphState) -> dict[str, Any]:
-        next_round = state.get("round_no", 0) + 1
-        event_id = _append_event(event_store, state, "ROUND_COMPLETED", round_no=next_round)
-        return {
-            "round_no": next_round,
-            "last_outcome": RoundOutcome(
-                round_no=next_round,
-                cleared_volume={"11680": 1},
-                price_changes={"11680": 0.0},
-                governance_applied=[],
-                market_actions_resolved=1,
-            ),
             "event_refs": [event_id],
         }
 

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/continue_gate.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/continue_gate.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from ..graph_state import SimulationGraphState
+
+
+def should_continue(state: SimulationGraphState) -> Literal["continue", "stop"]:
+    round_no = state.get("round_no", 0)
+    max_rounds = state.get("max_rounds", 3)
+
+    if round_no >= max_rounds:
+        return "stop"
+
+    last_outcome = state.get("last_outcome")
+    if last_outcome is not None and last_outcome.market_actions_resolved == 0:
+        return "stop"
+
+    return "continue"

--- a/apps/kr-seoul-apartment/tests/unit/test_continue_gate.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_continue_gate.py
@@ -1,0 +1,52 @@
+from younggeul_app_kr_seoul_apartment.simulation.nodes.continue_gate import should_continue
+from younggeul_core.state.simulation import RoundOutcome
+
+
+def _outcome(*, market_actions_resolved: int) -> RoundOutcome:
+    return RoundOutcome(
+        round_no=1,
+        cleared_volume={"11680": 1},
+        price_changes={"11680": 0.0},
+        governance_applied=[],
+        market_actions_resolved=market_actions_resolved,
+    )
+
+
+def test_continue_when_below_max_rounds() -> None:
+    state = {"round_no": 1, "max_rounds": 3}
+    assert should_continue(state) == "continue"
+
+
+def test_stop_when_max_rounds_reached() -> None:
+    state = {"round_no": 3, "max_rounds": 3}
+    assert should_continue(state) == "stop"
+
+
+def test_stop_when_exceeded_max_rounds() -> None:
+    state = {"round_no": 5, "max_rounds": 3}
+    assert should_continue(state) == "stop"
+
+
+def test_stop_when_market_frozen() -> None:
+    state = {"round_no": 1, "max_rounds": 5, "last_outcome": _outcome(market_actions_resolved=0)}
+    assert should_continue(state) == "stop"
+
+
+def test_continue_when_market_active() -> None:
+    state = {"round_no": 1, "max_rounds": 5, "last_outcome": _outcome(market_actions_resolved=3)}
+    assert should_continue(state) == "continue"
+
+
+def test_stop_zero_max_rounds() -> None:
+    state = {"round_no": 0, "max_rounds": 0}
+    assert should_continue(state) == "stop"
+
+
+def test_default_max_rounds() -> None:
+    state = {"round_no": 3}
+    assert should_continue(state) == "stop"
+
+
+def test_continue_with_no_last_outcome() -> None:
+    state = {"round_no": 1, "max_rounds": 5}
+    assert should_continue(state) == "continue"

--- a/apps/kr-seoul-apartment/tests/unit/test_graph.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_graph.py
@@ -57,8 +57,10 @@ def test_round_loop_executes_exactly_n_rounds(max_rounds: int) -> None:
 
     final = graph.invoke(_make_seed(run_id, max_rounds=max_rounds))
 
-    round_events = store.get_events_by_type(run_id, "ROUND_COMPLETED")
-    assert len(round_events) == max_rounds
+    decisions_events = store.get_events_by_type(run_id, "DECISIONS_MADE")
+    resolved_events = store.get_events_by_type(run_id, "ROUND_RESOLVED")
+    assert len(decisions_events) == max_rounds
+    assert len(resolved_events) == max_rounds
     assert final["round_no"] == max_rounds
 
 
@@ -69,7 +71,8 @@ def test_round_loop_zero_rounds_skips_to_report() -> None:
     final = graph.invoke(_make_seed("run-zero", max_rounds=0))
 
     assert final["round_no"] == 0
-    assert store.get_events_by_type("run-zero", "ROUND_COMPLETED") == []
+    assert store.get_events_by_type("run-zero", "DECISIONS_MADE") == []
+    assert store.get_events_by_type("run-zero", "ROUND_RESOLVED") == []
 
 
 def test_stubs_emit_events_to_store() -> None:
@@ -79,7 +82,7 @@ def test_stubs_emit_events_to_store() -> None:
 
     graph.invoke(_make_seed("run-event-count", max_rounds=max_rounds))
 
-    assert store.count("run-event-count") == 6 + max_rounds
+    assert store.count("run-event-count") == 6 + (2 * max_rounds)
 
 
 def test_event_types_emitted() -> None:
@@ -94,7 +97,8 @@ def test_event_types_emitted() -> None:
         "INTAKE_PLANNED",
         "SCENARIO_BUILT",
         "WORLD_INITIALIZED",
-        "ROUND_COMPLETED",
+        "DECISIONS_MADE",
+        "ROUND_RESOLVED",
         "REPORT_WRITTEN",
         "CRITIC",
         "CITATION_GATE",
@@ -134,21 +138,23 @@ def test_world_initializer_stub_sets_world_and_participants() -> None:
     assert final["world"]["11680"].gu_name == "강남구"
     assert "p-001" in final["participants"]
     assert final["participants"]["p-001"].role == "buyer"
+    assert "p-002" in final["participants"]
+    assert final["participants"]["p-002"].role == "investor"
 
 
-def test_round_runner_stub_increments_round_no() -> None:
+def test_round_loop_sets_round_no_after_n_rounds() -> None:
     store = InMemoryEventStore()
     graph = build_simulation_graph(store)
     run_id = "run-increment"
 
     final = graph.invoke(_make_seed(run_id, max_rounds=3))
 
-    round_events = store.get_events_by_type(run_id, "ROUND_COMPLETED")
-    assert [event.round_no for event in round_events] == [1, 2, 3]
+    resolved_events = store.get_events_by_type(run_id, "ROUND_RESOLVED")
+    assert [event.round_no for event in resolved_events] == [1, 2, 3]
     assert final["round_no"] == 3
 
 
-def test_round_runner_stub_sets_last_outcome() -> None:
+def test_round_loop_sets_last_outcome() -> None:
     store = InMemoryEventStore()
     graph = build_simulation_graph(store)
 
@@ -208,7 +214,8 @@ def test_mermaid_smoke() -> None:
     assert "intake_planner" in mermaid
     assert "scenario_builder" in mermaid
     assert "world_initializer" in mermaid
-    assert "round_runner" in mermaid
+    assert "participant_decider" in mermaid
+    assert "round_resolver" in mermaid
     assert "report_writer" in mermaid
     assert "critic" in mermaid
     assert "citation_gate" in mermaid
@@ -252,8 +259,8 @@ def test_multiple_runs_with_same_graph_independent() -> None:
     final_a = graph.invoke(_make_seed("run-a", max_rounds=1))
     final_b = graph.invoke(_make_seed("run-b", max_rounds=3))
 
-    assert store.count("run-a") == 7
-    assert store.count("run-b") == 9
+    assert store.count("run-a") == 8
+    assert store.count("run-b") == 12
     assert final_a["round_no"] == 1
     assert final_b["round_no"] == 3
     assert set(final_a["event_refs"]).isdisjoint(set(final_b["event_refs"]))


### PR DESCRIPTION
## Summary
- Replaced the `round_runner` stub loop with a real conditional round loop wired as `world_initializer -> participant_decider -> round_resolver` and route gating to either continue or stop.
- Added `should_continue` routing logic under `simulation/nodes/continue_gate.py` to stop on max rounds or frozen market (`market_actions_resolved == 0`).
- Updated graph tests for new node topology and event semantics (`DECISIONS_MADE`/`ROUND_RESOLVED`), and added dedicated unit tests for continue-gate behavior.

## Validation
- `python3 -m pytest apps/kr-seoul-apartment/tests/ -x -q`
- `python3 -m ruff format --check .`
- `python3 -m ruff check .`