### PR TITLE
feat(simulation): add round summarizer and replay handler updates (#118)

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph.py
@@ -1,19 +1,12 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timezone
+from importlib import import_module
 from typing import Any, Literal
 from uuid import uuid4
 
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.state import CompiledStateGraph
-
-from younggeul_core.state.simulation import (
-    ParticipantState,
-    ReportClaim,
-    ScenarioSpec,
-    SegmentState,
-    SnapshotRef,
-)
 
 from .events import EventStore, SimulationEvent
 from .graph_state import SimulationGraphState
@@ -22,11 +15,19 @@ from .nodes.continue_gate import should_continue
 from .nodes.intake_planner import make_intake_planner_node
 from .nodes.participant_decider import make_participant_decider_node
 from .nodes.round_resolver import make_round_resolver_node
+from .nodes.round_summarizer import make_round_summarizer_node
 from .nodes.scenario_builder import make_scenario_builder_node
 from .nodes.world_initializer import make_world_initializer_node
 from .ports.snapshot_reader import SnapshotReader
 
 DEFAULT_MAX_ROUNDS = 3
+
+simulation_state_module = import_module("younggeul_core.state.simulation")
+ParticipantState = simulation_state_module.ParticipantState
+ReportClaim = simulation_state_module.ReportClaim
+ScenarioSpec = simulation_state_module.ScenarioSpec
+SegmentState = simulation_state_module.SegmentState
+SnapshotRef = simulation_state_module.SnapshotRef
 
 
 def build_simulation_graph(
@@ -55,12 +56,14 @@ def build_simulation_graph(
     )
     participant_decider_node = make_participant_decider_node(event_store)
     round_resolver_node = make_round_resolver_node(event_store)
+    round_summarizer_node = make_round_summarizer_node(event_store)
 
     graph.add_node("intake_planner", intake_planner_node)
     graph.add_node("scenario_builder", scenario_builder_node)
     graph.add_node("world_initializer", world_initializer_node)
     graph.add_node("participant_decider", participant_decider_node)
     graph.add_node("round_resolver", round_resolver_node)
+    graph.add_node("round_summarizer", round_summarizer_node)
     graph.add_node("report_writer", _make_report_writer_stub(event_store))
     graph.add_node("critic", _make_passthrough_stub(event_store, "critic"))
     graph.add_node("citation_gate", _make_passthrough_stub(event_store, "citation_gate"))
@@ -73,7 +76,7 @@ def build_simulation_graph(
         _should_start_rounds,
         {
             "participant_decider": "participant_decider",
-            "report_writer": "report_writer",
+            "round_summarizer": "round_summarizer",
         },
     )
     graph.add_edge("participant_decider", "round_resolver")
@@ -82,9 +85,10 @@ def build_simulation_graph(
         _route_after_resolve,
         {
             "participant_decider": "participant_decider",
-            "report_writer": "report_writer",
+            "round_summarizer": "round_summarizer",
         },
     )
+    graph.add_edge("round_summarizer", "report_writer")
     graph.add_edge("report_writer", "critic")
     graph.add_edge("critic", "citation_gate")
     graph.add_edge("citation_gate", END)
@@ -92,14 +96,14 @@ def build_simulation_graph(
     return graph.compile()
 
 
-def _should_start_rounds(state: SimulationGraphState) -> Literal["participant_decider", "report_writer"]:
+def _should_start_rounds(state: SimulationGraphState) -> Literal["participant_decider", "round_summarizer"]:
     round_no = state.get("round_no", 0)
     max_rounds = state.get("max_rounds", DEFAULT_MAX_ROUNDS)
-    return "participant_decider" if round_no < max_rounds else "report_writer"
+    return "participant_decider" if round_no < max_rounds else "round_summarizer"
 
 
-def _route_after_resolve(state: SimulationGraphState) -> Literal["participant_decider", "report_writer"]:
-    return "participant_decider" if should_continue(state) == "continue" else "report_writer"
+def _route_after_resolve(state: SimulationGraphState) -> Literal["participant_decider", "round_summarizer"]:
+    return "participant_decider" if should_continue(state) == "continue" else "round_summarizer"
 
 
 def _append_event(

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/round_summarizer.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/round_summarizer.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from ..events import EventStore, SimulationEvent
+from ..graph_state import SimulationGraphState
+
+
+def make_round_summarizer_node(event_store: EventStore) -> Any:
+    def node(state: SimulationGraphState) -> dict[str, Any]:
+        run_meta = state.get("run_meta")
+        if run_meta is None:
+            raise ValueError("run_meta is required")
+
+        round_no = state.get("round_no", 0)
+        world = state.get("world") or {}
+        participants = state.get("participants") or {}
+        warnings = state.get("warnings") or []
+
+        world_summary: dict[str, dict[str, int]] = {}
+        for gu_code, segment in sorted(world.items()):
+            world_summary[gu_code] = {
+                "median_price": segment.current_median_price,
+                "volume": segment.current_volume,
+            }
+
+        role_summary: dict[str, dict[str, Any]] = {}
+        for participant in participants.values():
+            role = participant.role
+            if role not in role_summary:
+                role_summary[role] = {"count": 0, "total_capital": 0, "total_holdings": 0}
+            role_summary[role]["count"] += 1
+            role_summary[role]["total_capital"] += participant.capital
+            role_summary[role]["total_holdings"] += participant.holdings
+
+        payload = {
+            "total_rounds": round_no,
+            "world_summary": world_summary,
+            "participant_summary": role_summary,
+            "total_warnings": len(warnings) if isinstance(warnings, list) else 0,
+        }
+
+        event_id = str(uuid4())
+        event_store.append(
+            SimulationEvent(
+                event_id=event_id,
+                run_id=run_meta.run_id,
+                round_no=round_no,
+                event_type="SIMULATION_COMPLETED",
+                timestamp=datetime.now(timezone.utc),
+                payload=payload,
+            )
+        )
+
+        return {"event_refs": [event_id]}
+
+    return node

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/replay/engine.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/replay/engine.py
@@ -124,10 +124,73 @@ def _handle_world_initialized(
     return _append_warnings(state, _warning_list(event.payload))
 
 
+def _handle_decisions_made(
+    state: SimulationGraphState,
+    event: SimulationEvent,
+    context: ReplayContext,
+) -> SimulationGraphState:
+    _ = context
+    next_state = _copy_state(state)
+
+    round_no = event.payload.get("round_no")
+    if isinstance(round_no, int):
+        next_state["round_no"] = round_no
+
+    action_summary = event.payload.get("action_summary")
+    if isinstance(action_summary, dict):
+        next_state["market_actions"] = action_summary
+
+    return next_state
+
+
+def _handle_round_resolved(
+    state: SimulationGraphState,
+    event: SimulationEvent,
+    context: ReplayContext,
+) -> SimulationGraphState:
+    _ = context
+    next_state = _copy_state(state)
+
+    round_no = event.payload.get("round_no")
+    if isinstance(round_no, int):
+        next_state["round_no"] = round_no
+
+    transactions_count = event.payload.get("transactions_count")
+    summary = event.payload.get("summary")
+    if isinstance(transactions_count, int) and isinstance(summary, str):
+        simulation_mod = import_module("younggeul_core.state.simulation")
+        round_outcome = simulation_mod.RoundOutcome(
+            round_no=round_no if isinstance(round_no, int) else 0,
+            cleared_volume={},
+            price_changes={},
+            governance_applied=[],
+            market_actions_resolved=transactions_count,
+        )
+        next_state["last_outcome"] = round_outcome
+
+    return _append_warnings(next_state, _warning_list(event.payload))
+
+
+def _handle_simulation_completed(
+    state: SimulationGraphState,
+    event: SimulationEvent,
+    context: ReplayContext,
+) -> SimulationGraphState:
+    _ = context
+    next_state = _copy_state(state)
+    total_rounds = event.payload.get("total_rounds")
+    if isinstance(total_rounds, int):
+        next_state["round_no"] = total_rounds
+    return next_state
+
+
 HANDLERS: dict[str, EventHandler] = {
     "INTAKE_PLANNED": _handle_intake_planned,
     "SCENARIO_BUILT": _handle_scenario_built,
     "WORLD_INITIALIZED": _handle_world_initialized,
+    "DECISIONS_MADE": _handle_decisions_made,
+    "ROUND_RESOLVED": _handle_round_resolved,
+    "SIMULATION_COMPLETED": _handle_simulation_completed,
 }
 
 

--- a/apps/kr-seoul-apartment/tests/unit/test_graph.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_graph.py
@@ -1,16 +1,23 @@
 from datetime import timezone
+from importlib import import_module
 
 import pytest
 from langgraph.graph.state import CompiledStateGraph
 
-from younggeul_app_kr_seoul_apartment.simulation.event_store import InMemoryEventStore
-from younggeul_app_kr_seoul_apartment.simulation.graph import DEFAULT_MAX_ROUNDS, build_simulation_graph
-from younggeul_app_kr_seoul_apartment.simulation.graph_state import (
-    SimulationGraphState,
-    seed_graph_state,
-    to_simulation_state,
-)
-from younggeul_core.state.simulation import RoundOutcome, ScenarioSpec, SnapshotRef
+event_store_module = import_module("younggeul_app_kr_seoul_apartment.simulation.event_store")
+graph_module = import_module("younggeul_app_kr_seoul_apartment.simulation.graph")
+graph_state_module = import_module("younggeul_app_kr_seoul_apartment.simulation.graph_state")
+simulation_state_module = import_module("younggeul_core.state.simulation")
+
+InMemoryEventStore = event_store_module.InMemoryEventStore
+DEFAULT_MAX_ROUNDS = graph_module.DEFAULT_MAX_ROUNDS
+build_simulation_graph = graph_module.build_simulation_graph
+SimulationGraphState = graph_state_module.SimulationGraphState
+seed_graph_state = graph_state_module.seed_graph_state
+to_simulation_state = graph_state_module.to_simulation_state
+RoundOutcome = simulation_state_module.RoundOutcome
+ScenarioSpec = simulation_state_module.ScenarioSpec
+SnapshotRef = simulation_state_module.SnapshotRef
 
 
 def _make_seed(run_id: str, *, max_rounds: int | None = None) -> SimulationGraphState:
@@ -82,7 +89,7 @@ def test_stubs_emit_events_to_store() -> None:
 
     graph.invoke(_make_seed("run-event-count", max_rounds=max_rounds))
 
-    assert store.count("run-event-count") == 6 + (2 * max_rounds)
+    assert store.count("run-event-count") == 7 + (2 * max_rounds)
 
 
 def test_event_types_emitted() -> None:
@@ -99,6 +106,7 @@ def test_event_types_emitted() -> None:
         "WORLD_INITIALIZED",
         "DECISIONS_MADE",
         "ROUND_RESOLVED",
+        "SIMULATION_COMPLETED",
         "REPORT_WRITTEN",
         "CRITIC",
         "CITATION_GATE",
@@ -216,6 +224,7 @@ def test_mermaid_smoke() -> None:
     assert "world_initializer" in mermaid
     assert "participant_decider" in mermaid
     assert "round_resolver" in mermaid
+    assert "round_summarizer" in mermaid
     assert "report_writer" in mermaid
     assert "critic" in mermaid
     assert "citation_gate" in mermaid
@@ -259,8 +268,8 @@ def test_multiple_runs_with_same_graph_independent() -> None:
     final_a = graph.invoke(_make_seed("run-a", max_rounds=1))
     final_b = graph.invoke(_make_seed("run-b", max_rounds=3))
 
-    assert store.count("run-a") == 8
-    assert store.count("run-b") == 12
+    assert store.count("run-a") == 9
+    assert store.count("run-b") == 13
     assert final_a["round_no"] == 1
     assert final_b["round_no"] == 3
     assert set(final_a["event_refs"]).isdisjoint(set(final_b["event_refs"]))

--- a/apps/kr-seoul-apartment/tests/unit/test_replay_engine.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_replay_engine.py
@@ -23,6 +23,7 @@ IntakePlan = intake_module.IntakePlan
 ParticipantRosterSpec = roster_module.ParticipantRosterSpec
 RoleBucketSpec = roster_module.RoleBucketSpec
 ScenarioSpec = simulation_state_module.ScenarioSpec
+RoundOutcome = simulation_state_module.RoundOutcome
 
 
 def _event(
@@ -109,6 +110,41 @@ def _world_payload(**overrides: Any) -> dict[str, Any]:
     return payload
 
 
+def _decisions_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "round_no": 2,
+        "action_summary": {
+            "buyer-0001": {"action_type": "buy", "target": "11680"},
+            "investor-0001": {"action_type": "hold", "target": "11650"},
+        },
+        "total_actions": 2,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _round_resolved_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "round_no": 2,
+        "transactions_count": 3,
+        "summary": "Round 2 resolved with 3 transactions",
+        "warnings": ["resolver warning"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _simulation_completed_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "total_rounds": 4,
+        "world_summary": {"11680": {"median_price": 2_100_000, "volume": 110}},
+        "participant_summary": {"buyer": {"count": 1, "total_capital": 100, "total_holdings": 0}},
+        "total_warnings": 0,
+    }
+    payload.update(overrides)
+    return payload
+
+
 class TestReplayEngine:
     def test_replay_all_supported_events_returns_full_result(self) -> None:
         store = InMemoryEventStore()
@@ -129,6 +165,77 @@ class TestReplayEngine:
         assert result.world_summary is not None
         assert result.participant_count == 12
         assert result.anchor_period == "2025-12"
+
+    def test_decisions_made_handler_sets_round_no_and_market_actions_summary(self) -> None:
+        store = InMemoryEventStore()
+        store.append(
+            _event(event_id="evt-1", event_type="DECISIONS_MADE", payload=_decisions_payload(), offset_seconds=0)
+        )
+
+        result = ReplayEngine(store).replay("run-001")
+
+        assert result.state["round_no"] == 2
+        assert result.state["market_actions"] == _decisions_payload()["action_summary"]
+
+    def test_round_resolved_handler_sets_round_no_and_last_outcome(self) -> None:
+        store = InMemoryEventStore()
+        store.append(
+            _event(event_id="evt-1", event_type="ROUND_RESOLVED", payload=_round_resolved_payload(), offset_seconds=0)
+        )
+
+        result = ReplayEngine(store).replay("run-001")
+
+        assert result.state["round_no"] == 2
+        assert isinstance(result.state["last_outcome"], RoundOutcome)
+        assert result.state["last_outcome"].round_no == 2
+        assert result.state["last_outcome"].market_actions_resolved == 3
+        assert result.state["warnings"] == ["resolver warning"]
+
+    def test_simulation_completed_handler_sets_final_round_no(self) -> None:
+        store = InMemoryEventStore()
+        store.append(
+            _event(
+                event_id="evt-1",
+                event_type="SIMULATION_COMPLETED",
+                payload=_simulation_completed_payload(total_rounds=7),
+            )
+        )
+
+        result = ReplayEngine(store).replay("run-001")
+
+        assert result.state["round_no"] == 7
+
+    def test_replay_m6_event_stream_including_round_events_and_completion(self) -> None:
+        store = InMemoryEventStore()
+        store.append(_event(event_id="evt-1", event_type="INTAKE_PLANNED", payload=_intake_payload(), offset_seconds=0))
+        store.append(
+            _event(event_id="evt-2", event_type="SCENARIO_BUILT", payload=_scenario_payload(), offset_seconds=1)
+        )
+        store.append(
+            _event(event_id="evt-3", event_type="WORLD_INITIALIZED", payload=_world_payload(), offset_seconds=2)
+        )
+        store.append(
+            _event(event_id="evt-4", event_type="DECISIONS_MADE", payload=_decisions_payload(), offset_seconds=3)
+        )
+        store.append(
+            _event(event_id="evt-5", event_type="ROUND_RESOLVED", payload=_round_resolved_payload(), offset_seconds=4)
+        )
+        store.append(
+            _event(
+                event_id="evt-6",
+                event_type="SIMULATION_COMPLETED",
+                payload=_simulation_completed_payload(total_rounds=2),
+                offset_seconds=5,
+            )
+        )
+
+        result = ReplayEngine(store).replay("run-001", strict=True)
+
+        assert result.completeness == "full"
+        assert result.event_count == 6
+        assert result.state["round_no"] == 2
+        assert result.state["market_actions"] == _decisions_payload()["action_summary"]
+        assert isinstance(result.state["last_outcome"], RoundOutcome)
 
     def test_replay_intake_only_is_partial(self) -> None:
         store = InMemoryEventStore()
@@ -360,7 +467,14 @@ class TestReplayEngine:
         assert result.participant_count == 33
 
     def test_handlers_registry_contains_required_event_types(self) -> None:
-        assert set(HANDLERS.keys()) == {"INTAKE_PLANNED", "SCENARIO_BUILT", "WORLD_INITIALIZED"}
+        assert set(HANDLERS.keys()) == {
+            "INTAKE_PLANNED",
+            "SCENARIO_BUILT",
+            "WORLD_INITIALIZED",
+            "DECISIONS_MADE",
+            "ROUND_RESOLVED",
+            "SIMULATION_COMPLETED",
+        }
 
     def test_replay_context_defaults_to_strict(self) -> None:
         context = ReplayContext()

--- a/apps/kr-seoul-apartment/tests/unit/test_round_summarizer.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_round_summarizer.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+import pytest
+
+event_store_module = import_module("younggeul_app_kr_seoul_apartment.simulation.event_store")
+graph_state_module = import_module("younggeul_app_kr_seoul_apartment.simulation.graph_state")
+round_summarizer_module = import_module("younggeul_app_kr_seoul_apartment.simulation.nodes.round_summarizer")
+simulation_state_module = import_module("younggeul_core.state.simulation")
+
+InMemoryEventStore = event_store_module.InMemoryEventStore
+SimulationGraphState = graph_state_module.SimulationGraphState
+seed_graph_state = graph_state_module.seed_graph_state
+make_round_summarizer_node = round_summarizer_module.make_round_summarizer_node
+ParticipantState = simulation_state_module.ParticipantState
+SegmentState = simulation_state_module.SegmentState
+
+
+def _make_segment(**overrides: Any) -> SegmentState:
+    payload: dict[str, Any] = {
+        "gu_code": "11680",
+        "gu_name": "강남구",
+        "current_median_price": 2_000_000,
+        "current_volume": 120,
+        "price_trend": "flat",
+        "sentiment_index": 0.5,
+        "supply_pressure": 0.0,
+    }
+    payload.update(overrides)
+    return SegmentState(**payload)
+
+
+def _make_participant(**overrides: Any) -> ParticipantState:
+    payload: dict[str, Any] = {
+        "participant_id": "buyer-0001",
+        "role": "buyer",
+        "capital": 1_000,
+        "holdings": 1,
+        "sentiment": "neutral",
+        "risk_tolerance": 0.5,
+    }
+    payload.update(overrides)
+    return ParticipantState(**payload)
+
+
+def _base_state(run_id: str = "summary-run") -> SimulationGraphState:
+    state = seed_graph_state("질문", run_id, f"run-{run_id}", "gpt-test")
+    state["round_no"] = 2
+    state["world"] = {
+        "11680": _make_segment(gu_code="11680", gu_name="강남구", current_median_price=2_100_000, current_volume=111),
+        "11650": _make_segment(gu_code="11650", gu_name="서초구", current_median_price=1_800_000, current_volume=95),
+    }
+    state["participants"] = {
+        "buyer-0001": _make_participant(participant_id="buyer-0001", role="buyer", capital=1_000, holdings=1),
+        "buyer-0002": _make_participant(participant_id="buyer-0002", role="buyer", capital=2_000, holdings=0),
+        "investor-0001": _make_participant(participant_id="investor-0001", role="investor", capital=7_000, holdings=3),
+    }
+    state["warnings"] = ["w1", "w2"]
+    return state
+
+
+def test_emits_simulation_completed_event_and_returns_event_refs() -> None:
+    run_id = "emit-event"
+    store = InMemoryEventStore()
+    node = make_round_summarizer_node(store)
+
+    result = node(_base_state(run_id))
+    events = store.get_events_by_type(run_id, "SIMULATION_COMPLETED")
+
+    assert len(events) == 1
+    assert result["event_refs"] == [events[0].event_id]
+
+
+def test_world_summary_contains_per_gu_median_price_and_volume() -> None:
+    run_id = "world-summary"
+    store = InMemoryEventStore()
+    node = make_round_summarizer_node(store)
+
+    node(_base_state(run_id))
+    payload = store.get_events_by_type(run_id, "SIMULATION_COMPLETED")[0].payload
+
+    assert payload["world_summary"] == {
+        "11650": {"median_price": 1_800_000, "volume": 95},
+        "11680": {"median_price": 2_100_000, "volume": 111},
+    }
+
+
+def test_participant_summary_aggregates_by_role() -> None:
+    run_id = "participant-summary"
+    store = InMemoryEventStore()
+    node = make_round_summarizer_node(store)
+
+    node(_base_state(run_id))
+    payload = store.get_events_by_type(run_id, "SIMULATION_COMPLETED")[0].payload
+
+    assert payload["participant_summary"] == {
+        "buyer": {"count": 2, "total_capital": 3_000, "total_holdings": 1},
+        "investor": {"count": 1, "total_capital": 7_000, "total_holdings": 3},
+    }
+
+
+def test_event_payload_has_expected_top_level_fields() -> None:
+    run_id = "payload-fields"
+    store = InMemoryEventStore()
+    node = make_round_summarizer_node(store)
+
+    node(_base_state(run_id))
+    payload = store.get_events_by_type(run_id, "SIMULATION_COMPLETED")[0].payload
+
+    assert set(payload.keys()) == {"total_rounds", "world_summary", "participant_summary", "total_warnings"}
+    assert payload["total_rounds"] == 2
+
+
+def test_empty_world_and_participants_produce_empty_summaries() -> None:
+    run_id = "empty-state"
+    store = InMemoryEventStore()
+    node = make_round_summarizer_node(store)
+    state = _base_state(run_id)
+    state["world"] = {}
+    state["participants"] = {}
+
+    node(state)
+    payload = store.get_events_by_type(run_id, "SIMULATION_COMPLETED")[0].payload
+
+    assert payload["world_summary"] == {}
+    assert payload["participant_summary"] == {}
+
+
+def test_total_warnings_counts_warning_list_items() -> None:
+    run_id = "warning-count"
+    store = InMemoryEventStore()
+    node = make_round_summarizer_node(store)
+    state = _base_state(run_id)
+    state["warnings"] = ["w1", "w2", "w3"]
+
+    node(state)
+    payload = store.get_events_by_type(run_id, "SIMULATION_COMPLETED")[0].payload
+
+    assert payload["total_warnings"] == 3
+
+
+def test_non_list_warnings_default_to_zero_total_warnings() -> None:
+    run_id = "warning-shape"
+    store = InMemoryEventStore()
+    node = make_round_summarizer_node(store)
+    state = _base_state(run_id)
+    raw_state: dict[str, Any] = state
+    raw_state["warnings"] = "not-a-list"
+
+    node(state)
+    payload = store.get_events_by_type(run_id, "SIMULATION_COMPLETED")[0].payload
+
+    assert payload["total_warnings"] == 0
+
+
+def test_missing_run_meta_raises_value_error() -> None:
+    store = InMemoryEventStore()
+    node = make_round_summarizer_node(store)
+    state = _base_state("missing-run-meta")
+    del state["run_meta"]
+
+    with pytest.raises(ValueError, match="run_meta is required"):
+        node(state)


### PR DESCRIPTION
## Summary
- add a new `round_summarizer` node that emits `SIMULATION_COMPLETED` with per-gu world and per-role participant aggregates, plus warning/round totals
- update the replay engine to handle `DECISIONS_MADE`, `ROUND_RESOLVED`, and `SIMULATION_COMPLETED` while preserving existing completeness semantics for backward compatibility
- wire graph routing through `round_summarizer` before `report_writer`, and update unit tests for summarizer behavior, replay handlers, and topology/event-count expectations

## Validation
- `python3 -m ruff format .`
- `python3 -m ruff check . --fix`
- `python3 -m pytest apps/kr-seoul-apartment/tests/ -x -q`