### PR TITLE
feat(observability): add OpenTelemetry tracing for simulation nodes

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timezone
-from typing import Any, Literal
+from typing import Any, Literal, cast
 from uuid import uuid4
 
 from langgraph.graph import END, START, StateGraph
@@ -31,8 +31,24 @@ from .nodes.round_summarizer import make_round_summarizer_node
 from .nodes.scenario_builder import make_scenario_builder_node
 from .nodes.world_initializer import make_world_initializer_node
 from .ports.snapshot_reader import SnapshotReader
+from .tracing import trace_node
 
 DEFAULT_MAX_ROUNDS = 3
+
+
+def _traced_node(
+    node_name: str,
+    node_fn: Any,
+) -> Any:
+    def wrapper(state: SimulationGraphState) -> dict[str, Any]:
+        run_meta = state.get("run_meta")
+        run_id = run_meta.run_id if run_meta is not None else None
+        round_no = state.get("round_no")
+
+        with trace_node(node_name, run_id=run_id, round_no=round_no):
+            return cast(dict[str, Any], node_fn(state))
+
+    return wrapper
 
 
 def build_simulation_graph(
@@ -69,17 +85,17 @@ def build_simulation_graph(
     citation_gate_node = make_citation_gate_node(_evidence_store, event_store)
     report_renderer_node = make_report_renderer_node(event_store)
 
-    graph.add_node("intake_planner", intake_planner_node)
-    graph.add_node("scenario_builder", scenario_builder_node)
-    graph.add_node("world_initializer", world_initializer_node)
-    graph.add_node("participant_decider", participant_decider_node)
-    graph.add_node("round_resolver", round_resolver_node)
-    graph.add_node("round_summarizer", round_summarizer_node)
-    graph.add_node("evidence_builder", evidence_builder_node)
-    graph.add_node("report_writer", report_writer_node)
-    graph.add_node("critic", _make_passthrough_stub(event_store, "critic"))
-    graph.add_node("citation_gate", citation_gate_node)
-    graph.add_node("report_renderer", report_renderer_node)
+    graph.add_node("intake_planner", _traced_node("intake_planner", intake_planner_node))
+    graph.add_node("scenario_builder", _traced_node("scenario_builder", scenario_builder_node))
+    graph.add_node("world_initializer", _traced_node("world_initializer", world_initializer_node))
+    graph.add_node("participant_decider", _traced_node("participant_decider", participant_decider_node))
+    graph.add_node("round_resolver", _traced_node("round_resolver", round_resolver_node))
+    graph.add_node("round_summarizer", _traced_node("round_summarizer", round_summarizer_node))
+    graph.add_node("evidence_builder", _traced_node("evidence_builder", evidence_builder_node))
+    graph.add_node("report_writer", _traced_node("report_writer", report_writer_node))
+    graph.add_node("critic", _traced_node("critic", _make_passthrough_stub(event_store, "critic")))
+    graph.add_node("citation_gate", _traced_node("citation_gate", citation_gate_node))
+    graph.add_node("report_renderer", _traced_node("report_renderer", report_renderer_node))
 
     graph.add_edge(START, "intake_planner")
     graph.add_edge("intake_planner", "scenario_builder")

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/tracing.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/tracing.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+from opentelemetry import trace
+from opentelemetry.trace import Span, Status, StatusCode, Tracer
+
+_TRACER_NAME = "younggeul.simulation"
+_initialized = False
+
+
+def _is_enabled() -> bool:
+    return os.environ.get("OTEL_ENABLED", "").lower() in ("true", "1", "yes")
+
+
+def init_tracing() -> None:
+    global _initialized
+
+    if _initialized or not _is_enabled():
+        return
+
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter, SpanExporter
+
+    provider = TracerProvider()
+    exporter: SpanExporter
+
+    otlp_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if otlp_endpoint:
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+        otlp_insecure = os.environ.get("OTEL_EXPORTER_OTLP_INSECURE", "").lower() in ("true", "1", "yes")
+        exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=otlp_insecure)
+    else:
+        exporter = ConsoleSpanExporter()
+
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    _initialized = True
+
+
+def get_tracer() -> Tracer:
+    return trace.get_tracer(_TRACER_NAME)
+
+
+@contextmanager
+def trace_node(
+    node_name: str,
+    *,
+    run_id: str | None = None,
+    round_no: int | None = None,
+    attributes: dict[str, Any] | None = None,
+) -> Iterator[Span]:
+    tracer = get_tracer()
+
+    span_attributes: dict[str, Any] = {"node.name": node_name}
+    if run_id is not None:
+        span_attributes["simulation.run_id"] = run_id
+    if round_no is not None:
+        span_attributes["simulation.round_no"] = round_no
+    if attributes is not None:
+        span_attributes.update(attributes)
+
+    with tracer.start_as_current_span(
+        f"simulation.node.{node_name}",
+        attributes=span_attributes,
+    ) as span:
+        try:
+            yield span
+        except Exception as exc:
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            span.record_exception(exc)
+            raise

--- a/apps/kr-seoul-apartment/tests/unit/test_tracing.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_tracing.py
@@ -1,0 +1,123 @@
+from importlib import import_module
+from unittest.mock import MagicMock, patch
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.trace import StatusCode
+
+event_store_module = import_module("younggeul_app_kr_seoul_apartment.simulation.event_store")
+graph_module = import_module("younggeul_app_kr_seoul_apartment.simulation.graph")
+graph_state_module = import_module("younggeul_app_kr_seoul_apartment.simulation.graph_state")
+simulation_state_module = import_module("younggeul_core.state.simulation")
+tracing_module = import_module("younggeul_app_kr_seoul_apartment.simulation.tracing")
+
+InMemoryEventStore = event_store_module.InMemoryEventStore
+ScenarioSpec = simulation_state_module.ScenarioSpec
+build_simulation_graph = graph_module.build_simulation_graph
+seed_graph_state = graph_state_module.seed_graph_state
+
+
+def _make_seed(run_id: str, *, max_rounds: int = 1) -> dict[str, object]:
+    state: dict[str, object] = seed_graph_state(
+        user_query="강남구 아파트 시장 시뮬레이션",
+        run_id=run_id,
+        run_name=f"run-{run_id}",
+        model_id="gpt-test",
+    )
+    state["max_rounds"] = max_rounds
+    return state
+
+
+def test_trace_node_context_manager_works_when_disabled() -> None:
+    with patch.dict("os.environ", {"OTEL_ENABLED": ""}, clear=False):
+        marker = []
+        with tracing_module.trace_node("intake_planner"):
+            marker.append("ok")
+
+    assert marker == ["ok"]
+
+
+def test_trace_node_captures_run_id_and_round_no() -> None:
+    with patch.dict("os.environ", {"OTEL_ENABLED": "true"}, clear=False):
+        span = MagicMock()
+        mock_cm = MagicMock()
+        mock_cm.__enter__.return_value = span
+        mock_cm.__exit__.return_value = False
+        tracer = MagicMock()
+        tracer.start_as_current_span.return_value = mock_cm
+
+        with patch.object(tracing_module, "get_tracer", return_value=tracer):
+            with tracing_module.trace_node("scenario_builder", run_id="run-123", round_no=2):
+                pass
+
+    _, kwargs = tracer.start_as_current_span.call_args
+    assert kwargs["attributes"]["node.name"] == "scenario_builder"
+    assert kwargs["attributes"]["simulation.run_id"] == "run-123"
+    assert kwargs["attributes"]["simulation.round_no"] == 2
+
+
+def test_trace_node_records_exception_on_error() -> None:
+    with patch.dict("os.environ", {"OTEL_ENABLED": "true"}, clear=False):
+        span = MagicMock()
+        mock_cm = MagicMock()
+        mock_cm.__enter__.return_value = span
+        mock_cm.__exit__.return_value = False
+        tracer = MagicMock()
+        tracer.start_as_current_span.return_value = mock_cm
+
+        with patch.object(tracing_module, "get_tracer", return_value=tracer):
+            with pytest.raises(RuntimeError, match="boom"):
+                with tracing_module.trace_node("round_resolver"):
+                    raise RuntimeError("boom")
+
+    span.record_exception.assert_called_once()
+    status = span.set_status.call_args.args[0]
+    assert status.status_code == StatusCode.ERROR
+    assert status.description == "boom"
+
+
+def test_get_tracer_returns_tracer() -> None:
+    tracer = tracing_module.get_tracer()
+    assert isinstance(tracer, trace.Tracer)
+
+
+def test_init_tracing_is_safe_when_disabled() -> None:
+    tracing_module._initialized = False
+    with patch.dict("os.environ", {"OTEL_ENABLED": ""}, clear=False):
+        tracing_module.init_tracing()
+
+    assert tracing_module._initialized is False
+
+
+def test_init_tracing_is_idempotent() -> None:
+    tracing_module._initialized = False
+    with (
+        patch.dict("os.environ", {"OTEL_ENABLED": "true"}, clear=False),
+        patch("opentelemetry.sdk.trace.TracerProvider") as tracer_provider_cls,
+        patch("opentelemetry.sdk.trace.export.BatchSpanProcessor") as batch_processor_cls,
+        patch("opentelemetry.sdk.trace.export.ConsoleSpanExporter") as console_exporter_cls,
+        patch("opentelemetry.trace.set_tracer_provider") as set_provider,
+    ):
+        provider = tracer_provider_cls.return_value
+        batch_processor = batch_processor_cls.return_value
+        console_exporter = console_exporter_cls.return_value
+
+        tracing_module.init_tracing()
+        tracing_module.init_tracing()
+
+    tracer_provider_cls.assert_called_once()
+    batch_processor_cls.assert_called_once_with(console_exporter)
+    provider.add_span_processor.assert_called_once_with(batch_processor)
+    set_provider.assert_called_once_with(provider)
+    assert tracing_module._initialized is True
+
+
+def test_graph_runs_with_tracing_wrapper() -> None:
+    store = InMemoryEventStore()
+    graph = build_simulation_graph(store)
+
+    final = graph.invoke(_make_seed("run-tracing", max_rounds=2))
+
+    assert final["intake_plan"]["planner_status"] == "stub"
+    assert isinstance(final["scenario"], ScenarioSpec)
+    assert final["round_no"] == 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,14 @@ dev = [
   "mypy",
   "pre-commit",
   "pandas-stubs",
+  "opentelemetry-api>=1.20",
+  "opentelemetry-sdk>=1.20",
+  "opentelemetry-exporter-otlp-proto-grpc>=1.20",
+]
+observability = [
+  "opentelemetry-api>=1.20",
+  "opentelemetry-sdk>=1.20",
+  "opentelemetry-exporter-otlp-proto-grpc>=1.20",
 ]
 kr-seoul-apartment = [
   "PublicDataReader>=1.1",


### PR DESCRIPTION
## Summary
- Adds OpenTelemetry tracing module for simulation graph nodes
- Gated by `OTEL_ENABLED` env var — disabled by default with zero overhead
- All simulation nodes wrapped with trace spans (run_id, round_no correlation)
- Supports OTLP exporter for production and console exporter for local dev
- 7+ unit tests covering tracing paths

Closes #69