### PR TITLE
feat(demo): add end-to-end demo script and make target (#76)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ data/gold/**
 data/snapshots/**
 !data/.gitkeep
 eval_results/
+demo_output/
 
 # IDE
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint format test test-all test-contract clean help
+.PHONY: install lint format test test-all test-contract clean help demo
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -31,3 +31,6 @@ clean: ## Remove build artifacts
 	find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
 	find . -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
 	rm -rf dist/ build/ coverage.xml .coverage
+
+demo: ## Run end-to-end demo
+	bash scripts/demo.sh

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# younggeul v0.1 demo — end-to-end pipeline showcase
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+export PYTHONPATH="${REPO_ROOT}/core/src:${REPO_ROOT}/apps/kr-seoul-apartment/src:${PYTHONPATH:-}"
+
+echo "=== Younggeul v0.1 Demo ==="
+
+DEMO_DIR="${DEMO_DIR:-./demo_output}"
+mkdir -p "$DEMO_DIR"
+
+echo "[1/6] Ingesting fixture data..."
+python3 -m younggeul_app_kr_seoul_apartment.cli ingest --output-dir "$DEMO_DIR/pipeline"
+
+echo "[2/6] Publishing snapshot..."
+python3 -m younggeul_app_kr_seoul_apartment.cli snapshot publish --data-dir "$DEMO_DIR/pipeline" --snapshot-dir "$DEMO_DIR/snapshots"
+
+echo "[3/6] Running baseline forecast..."
+python3 -m younggeul_app_kr_seoul_apartment.cli baseline --snapshot-dir "$DEMO_DIR/snapshots" --output-dir "$DEMO_DIR/baseline"
+
+echo "[4/6] Running simulation (2 rounds)..."
+python3 -m younggeul_app_kr_seoul_apartment.cli simulate --query "서울 강남구 아파트 시장 전망" --max-rounds 2 --output-dir "$DEMO_DIR/simulation"
+
+echo "[5/6] Displaying simulation report..."
+REPORT_FILE=$(ls -t "$DEMO_DIR/simulation"/simulation_report_*.md 2>/dev/null | head -1)
+if [ -n "$REPORT_FILE" ]; then
+    python3 -m younggeul_app_kr_seoul_apartment.cli report --report-file "$REPORT_FILE"
+fi
+
+echo "[6/6] Running evaluation suite..."
+python3 -m younggeul_app_kr_seoul_apartment.cli eval --output-dir "$DEMO_DIR/eval" || echo "  (eval completed with warnings)"
+
+echo ""
+echo "=== Demo Complete ==="
+echo "Output directory: $DEMO_DIR"
+echo ""
+echo "Artifacts:"
+find "$DEMO_DIR" -type f | sort | sed 's/^/  /'


### PR DESCRIPTION
## Summary

- Add `scripts/demo.sh` — end-to-end demo running the full Younggeul pipeline (ingest → snapshot → baseline → simulate → report)
- Add `make demo` target for one-command demo execution
- Update `.gitignore` with `demo_output/` directory

Closes #76

## Details

The demo script exercises all CLI commands sequentially:
1. `younggeul ingest` — runs Bronze→Silver→Gold pipeline
2. `younggeul snapshot publish` — publishes a dataset snapshot
3. `younggeul baseline` — generates baseline forecast
4. `younggeul simulate` — runs 2-round simulation with Korean query
5. `younggeul report` — displays rendered markdown report
6. `younggeul eval` — runs evaluation suite

Verified locally: full demo completes successfully with all pipeline stages producing expected output.

## Checklist
- [x] Demo script runs end-to-end
- [x] Make target works
- [x] .gitignore updated