### PR TITLE
docs: add MkDocs Material documentation site (#75)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint format test test-all test-contract clean help demo
+.PHONY: install lint format test test-all test-contract clean help demo docs docs-serve
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -34,3 +34,9 @@ clean: ## Remove build artifacts
 
 demo: ## Run end-to-end demo
 	bash scripts/demo.sh
+
+docs: ## Build documentation
+	mkdocs build
+
+docs-serve: ## Serve documentation locally
+	mkdocs serve

--- a/docs/architecture/data-plane.md
+++ b/docs/architecture/data-plane.md
@@ -1,0 +1,123 @@
+# Data Plane
+
+The data plane is a three-layer ETL pipeline that transforms raw Korean government API data into structured market metrics.
+
+## Layer Summary
+
+```
+MOLIT ──┐
+BOK  ───┼──► Bronze ──► Silver ──► Gold ──► Snapshot
+KOSTAT ─┘    (raw)     (typed)   (agg.)    (immutable)
+```
+
+---
+
+## Bronze Layer — Raw Connectors
+
+Each connector implements the `BronzeConnector` protocol:
+
+```python
+class BronzeConnector(Protocol):
+    def fetch(self, **kwargs) -> list[BronzeRecord]: ...
+```
+
+| Connector | Source | Record Type |
+|-----------|--------|-------------|
+| `MolitConnector` | MOLIT open API | `BronzeAptTransaction` |
+| `BokConnector` | BOK statistics API | `BronzeInterestRate` |
+| `KostatConnector` | KOSTAT migration data | `BronzeMigration` |
+
+Bronze records are stored as JSON with `raw_payload` preserving the original response.
+
+---
+
+## Silver Layer — Typed Models
+
+Silver models are Pydantic v2 models with strict validation:
+
+```
+BronzeAptTransaction  →  SilverAptTransaction
+BronzeInterestRate    →  SilverInterestRate
+BronzeMigration       →  SilverMigration
+```
+
+All Silver models include:
+
+- `source_id: str` — connector identifier
+- `source_url: str` — canonical URL for citation
+- `fetched_at: datetime` — ingestion timestamp
+
+---
+
+## Gold Layer — Aggregated Metrics
+
+Gold aggregates Silver records to `(gu, year_month)` granularity:
+
+```
+GoldDistrictMonthlyMetrics
+├── gu: str                     # District code (e.g., "11680")
+├── year_month: str             # "YYYY-MM"
+├── avg_price_krw: float
+├── median_price_krw: float
+├── transaction_count: int
+├── yoy_pct: float | None       # Year-over-year change
+└── mom_pct: float | None       # Month-over-month change
+```
+
+### Trend Enrichment
+
+YoY and MoM values are computed during Gold aggregation by joining current and prior-period records.
+
+---
+
+## Pipeline Composition
+
+```python
+from younggeul_app_kr_seoul_apartment.pipeline import run_pipeline
+
+result = run_pipeline(output_dir=Path("./output/pipeline"))
+```
+
+`run_pipeline()` orchestrates Bronze → Silver → Gold in sequence and writes output to disk.
+
+---
+
+## Snapshot System
+
+### Publishing
+
+```python
+from younggeul_core.storage import publish_snapshot
+
+manifest = publish_snapshot(
+    data_dir=Path("./output/pipeline"),
+    snapshot_dir=Path("./output/snapshots"),
+)
+```
+
+### Resolving
+
+```python
+from younggeul_core.storage import resolve_snapshot
+
+snapshot = resolve_snapshot(
+    snapshot_dir=Path("./output/snapshots"),
+    snapshot_id="snap_20260101_abc123",   # or None for latest
+)
+```
+
+Snapshots are verified on load — `SnapshotIntegrityError` is raised if any file hash mismatches.
+
+---
+
+## Baseline Forecaster
+
+A simple statistical model that produces a `BaselineForecast` from the latest Gold metrics:
+
+```python
+from younggeul_app_kr_seoul_apartment.pipeline import generate_baseline
+
+forecast = generate_baseline(snapshot=snapshot)
+```
+
+The baseline is deterministic: same snapshot → same forecast, always.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,80 @@
+# Architecture Overview
+
+Younggeul is organized into **three planes** that have strict dependency boundaries.
+
+## Three-Plane Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                        Data Plane                            │
+│  Bronze (raw) → Silver (typed) → Gold (aggregated)          │
+│  Snapshots (immutable, SHA-256)                              │
+└────────────────────────────┬─────────────────────────────────┘
+                             │ GoldDistrictMonthlyMetrics
+                             ▼
+┌──────────────────────────────────────────────────────────────┐
+│                     Simulation Plane                         │
+│  LangGraph graph  →  Event store  →  Evidence store         │
+│  Citation gate    →  Report renderer                         │
+└────────────────────────────┬─────────────────────────────────┘
+                             │ RenderedReport
+                             ▼
+┌──────────────────────────────────────────────────────────────┐
+│                     Evaluation Plane                         │
+│  pytest-based eval  →  Canonical scenarios  →  CI checks    │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Monorepo Layout
+
+```
+younggeul/
+├── core/                          # Shared domain types and protocols
+│   └── src/younggeul_core/
+│       ├── state/                 # Bronze/Silver/Gold/Simulation TypedDicts
+│       ├── storage/               # Snapshot protocol
+│       └── evidence/              # EvidenceRecord types
+├── apps/
+│   └── kr-seoul-apartment/        # Seoul apartment implementation
+│       └── src/younggeul_app_kr_seoul_apartment/
+│           ├── cli.py             # Click entry point
+│           ├── pipeline/          # Bronze→Silver→Gold connectors
+│           ├── simulation/        # LangGraph graph, nodes
+│           └── reporting/         # Citation gate, renderer
+├── docs/                          # Documentation (this site)
+├── eval_cases/                    # YAML eval fixtures
+├── scripts/                       # demo.sh
+├── mkdocs.yml
+└── pyproject.toml
+```
+
+---
+
+## Dependency Direction
+
+```
+younggeul_core  ←  younggeul_app_kr_seoul_apartment
+    (shared)           (Seoul-specific)
+```
+
+`core` has **no dependency** on any app. Apps depend on core but not on each other.
+
+---
+
+## Key Design Principles
+
+| Principle | What it means |
+|-----------|---------------|
+| **Deterministic data plane** | Same input → same output; no LLMs in ETL |
+| **No LLMs in ETL** | Bronze/Silver/Gold transformations are pure functions |
+| **Evidence-gated reporting** | Reports only publish if citation coverage ≥ 100% |
+| **Immutable snapshots** | Pipeline outputs are content-addressed and hash-verified |
+| **Contract-first** | Pydantic models define the schema; tests enforce it |
+
+See the individual architecture pages for deeper dives:
+
+- [Data Plane](data-plane.md)
+- [Simulation Plane](simulation-plane.md)
+- [Evidence-Gated Reporting](reporting.md)

--- a/docs/architecture/reporting.md
+++ b/docs/architecture/reporting.md
@@ -1,0 +1,100 @@
+# Evidence-Gated Reporting
+
+The reporting subsystem ensures every claim in a simulation report is backed by a verifiable evidence record from the data plane.
+
+## Pipeline Overview
+
+```
+evidence_builder ──► report_writer ──► citation_gate ──► report_renderer
+                                              │
+                                     PASS ───┘──── FAIL
+                                      │              │
+                               RenderedReport    Error raised
+                               published         (no report)
+```
+
+---
+
+## EvidenceRecord
+
+An `EvidenceRecord` links a simulation event to a specific Gold metric row:
+
+```python
+class EvidenceRecord(TypedDict):
+    evidence_id: str           # UUID
+    kind: EvidenceKind         # "price", "rate", "migration", "baseline"
+    source_id: str             # Connector ID (e.g., "molit_apt_v1")
+    source_url: str            # Canonical URL
+    gu: str                    # District code
+    year_month: str            # "YYYY-MM"
+    value: float               # The cited metric value
+    unit: str                  # "krw", "pct", "count"
+```
+
+### Evidence Kinds
+
+| Kind | Description |
+|------|-------------|
+| `price` | Average or median transaction price from Gold |
+| `rate` | BOK interest rate |
+| `migration` | KOSTAT net migration count |
+| `baseline` | Baseline forecast value |
+
+---
+
+## ReportClaim Lifecycle
+
+```
+PENDING ──► (citation_gate validates) ──► PASSED
+                                    └──► FAILED
+```
+
+```python
+class ReportClaim(TypedDict):
+    claim_id: str
+    text: str                  # Claim sentence in the report
+    evidence_ids: list[str]    # Must match EvidenceRecord IDs
+    status: Literal["pending", "passed", "failed"]
+```
+
+---
+
+## Citation Gate
+
+The citation gate iterates all `ReportClaim` objects and checks:
+
+1. `evidence_ids` is non-empty
+2. Each ID exists in the evidence store
+3. The evidence kind is appropriate for the claim context
+
+If **any** claim fails: `citation_gate_passed = False` and rendering is skipped (raises `CitationGateError`).
+
+Coverage is calculated as:
+
+```
+coverage_pct = (passed_claims / total_claims) * 100
+```
+
+For v0.1, the threshold is **100%** — all claims must pass.
+
+---
+
+## RenderedReport
+
+The final output is a `RenderedReport`:
+
+```python
+class RenderedReport(TypedDict):
+    report_id: str
+    simulation_id: str
+    query: str
+    markdown: str              # Human-readable Markdown report
+    json_payload: dict         # Structured data with claims + evidence
+    coverage_pct: float        # Citation coverage (100.0 for passing reports)
+    generated_at: str          # ISO-8601 timestamp
+```
+
+The `markdown` field is what `younggeul report` renders to the terminal.
+
+!!! note
+    A report that fails the citation gate is never written to disk. This ensures all persisted reports have 100% citation coverage.

--- a/docs/architecture/simulation-plane.md
+++ b/docs/architecture/simulation-plane.md
@@ -1,0 +1,114 @@
+# Simulation Plane
+
+The simulation plane executes a multi-agent market simulation using [LangGraph](https://github.com/langchain-ai/langgraph) and produces evidence-gated reports.
+
+## SimulationGraphState
+
+The entire simulation state is a `TypedDict` with append-only reducers for list fields:
+
+```python
+class SimulationGraphState(TypedDict):
+    query: str                              # User's market query
+    scenario: ScenarioContext               # Parsed scenario
+    snapshot_id: str                        # Input data snapshot
+    baseline: BaselineForecast              # Pre-computed baseline
+    rounds: Annotated[list[RoundResult], operator.add]
+    events: Annotated[list[MarketEvent], operator.add]
+    evidence: Annotated[list[EvidenceRecord], operator.add]
+    claims: Annotated[list[ReportClaim], operator.add]
+    report: RenderedReport | None
+    citation_gate_passed: bool
+```
+
+---
+
+## Node Implementations
+
+### `intake_planner`
+
+Parses the query to extract `target_gu`, `time_horizon`, and `scenario_type`.
+
+### `scenario_builder`
+
+Constructs a `ScenarioContext` from baseline data and query parameters.
+
+### `world_initializer`
+
+Initializes the event store and participant agent states.
+
+### Participant Nodes
+
+Each participant is a separate node that reads current market state and appends `MarketEvent` objects:
+
+```
+buyer_node → investor_node → tenant_node → landlord_node → broker_node
+```
+
+All run within the round loop. v0.1 uses deterministic stubs.
+
+### `round_resolver`
+
+Aggregates participant events into a `RoundResult` and updates market state.
+
+### `continue_check`
+
+A conditional edge function — returns `"next_round"` or `"finish"` based on round count and convergence.
+
+### `evidence_builder`
+
+Scans the event store and Gold metrics to construct `EvidenceRecord` objects for each data reference.
+
+### `report_writer`
+
+Drafts `ReportClaim` objects from the simulation result, linking each claim to evidence IDs.
+
+### `citation_gate`
+
+Validates that every `ReportClaim` has a matching `EvidenceRecord`. Sets `citation_gate_passed = True/False`.
+
+### `report_renderer`
+
+Renders the final `RenderedReport` containing:
+- `markdown: str` — Human-readable report
+- `json: dict` — Structured report with claim/evidence linkage
+
+---
+
+## Graph Wiring
+
+The graph is assembled in `graph.py`:
+
+```python
+builder = StateGraph(SimulationGraphState)
+builder.add_node("intake_planner", intake_planner)
+# ... all nodes ...
+builder.add_conditional_edges("continue_check", route_rounds)
+graph = builder.compile()
+```
+
+---
+
+## OTEL Tracing
+
+Each node is instrumented with OpenTelemetry spans:
+
+```python
+with tracer.start_as_current_span("node.intake_planner") as span:
+    span.set_attribute("query", state["query"])
+    # ... node logic
+```
+
+Traces are emitted to the configured OTEL exporter (stdout by default in v0.1).
+
+---
+
+## Node Factory Pattern
+
+Nodes that share structure (participants) are created via a factory:
+
+```python
+def make_participant_node(role: ParticipantRole) -> NodeFn:
+    def node(state: SimulationGraphState) -> SimulationGraphState:
+        ...
+    return node
+```

--- a/docs/getting-started/demo.md
+++ b/docs/getting-started/demo.md
@@ -1,0 +1,59 @@
+# Demo
+
+The Younggeul demo script runs a complete end-to-end pipeline in a single command, using fixture data.
+
+## Running the Demo
+
+=== "make"
+
+    ```bash
+    make demo
+    ```
+
+=== "bash"
+
+    ```bash
+    bash scripts/demo.sh
+    ```
+
+## What the Demo Does
+
+The demo executes six steps in sequence:
+
+| Step | Command | Description |
+|------|---------|-------------|
+| 1 | `younggeul ingest` | Run Bronze→Silver→Gold ETL with fixture data |
+| 2 | `younggeul snapshot publish` | Create an immutable SHA-256 snapshot |
+| 3 | `younggeul snapshot list` | List available snapshots |
+| 4 | `younggeul baseline` | Generate a statistical baseline forecast |
+| 5 | `younggeul simulate` | Run 2-round multi-agent simulation |
+| 6 | `younggeul report` | Render the generated report |
+
+## Expected Output
+
+After running the demo you will have:
+
+```
+output/
+├── pipeline/          # Bronze, Silver, Gold data files
+├── snapshots/         # Immutable snapshot with manifest.json
+├── baseline/          # Baseline forecast JSON
+└── simulation/        # Simulation report (.md) and state (.json)
+```
+
+The terminal will print a structured Markdown report with:
+
+- Market summary paragraph
+- Agent decision table (buyer, investor, tenant, landlord, broker)
+- Evidence citations for each claim
+
+## Customization
+
+Override the output directory via the `DEMO_DIR` environment variable:
+
+```bash
+DEMO_DIR=/tmp/my-demo bash scripts/demo.sh
+```
+
+!!! tip
+    The demo uses fixture data bundled in `apps/kr-seoul-apartment/`. No API key or network access is required.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,62 @@
+# Installation
+
+## Prerequisites
+
+- **Python 3.12+** — Younggeul uses modern typing features.
+- **[uv](https://github.com/astral-sh/uv)** (recommended) or `pip`.
+- **Git** to clone the repository.
+
+## Clone & Install
+
+=== "uv (recommended)"
+
+    ```bash
+    git clone https://github.com/yeongseon/younggeul.git
+    cd younggeul
+    uv pip install -e ".[dev,kr-seoul-apartment]"
+    ```
+
+=== "pip"
+
+    ```bash
+    git clone https://github.com/yeongseon/younggeul.git
+    cd younggeul
+    pip install -e ".[dev,kr-seoul-apartment]"
+    ```
+
+## Verify Installation
+
+```bash
+younggeul --version
+```
+
+Expected output:
+
+```
+younggeul, version 0.1.0
+```
+
+## Optional: MkDocs for Documentation
+
+To build or serve the documentation locally:
+
+```bash
+pip install -e ".[docs]"
+mkdocs serve
+```
+
+## Real Data Ingestion (Optional)
+
+By default, `younggeul ingest` uses **fixture data** bundled with the package — no API key needed.
+
+To ingest real MOLIT/BOK/KOSTAT data, you need a [PublicDataReader](https://github.com/WooilJeong/PublicDataReader) API key from [data.go.kr](https://www.data.go.kr).
+
+Set the key via environment variable before running `younggeul ingest`:
+
+```bash
+export PUBLIC_DATA_API_KEY="your-api-key-here"
+younggeul ingest --output-dir ./output/pipeline
+```
+
+!!! note
+    All tutorial examples use fixture data; no API key is required.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,100 @@
+# Quick Start
+
+This guide walks you through a complete simulation run using **fixture data** — no API key required.
+
+## Overview
+
+A full Younggeul pipeline has five stages:
+
+```
+ingest → snapshot → baseline → simulate → report
+```
+
+## Step 1 — Ingest Data
+
+Run the Bronze → Silver → Gold ETL pipeline against fixture data:
+
+```bash
+younggeul ingest --output-dir ./output/pipeline
+```
+
+Expected output:
+
+```
+[ingest] Running Bronze layer...  ✓
+[ingest] Running Silver layer...  ✓
+[ingest] Running Gold layer...    ✓
+[ingest] Written to ./output/pipeline
+```
+
+## Step 2 — Publish a Snapshot
+
+Create an immutable, SHA-256-verified snapshot from the pipeline output:
+
+```bash
+younggeul snapshot publish \
+  --data-dir ./output/pipeline \
+  --snapshot-dir ./output/snapshots
+```
+
+```
+[snapshot] Published snapshot: snap_20260101_abc123
+[snapshot] Manifest written to ./output/snapshots/snap_20260101_abc123/manifest.json
+```
+
+## Step 3 — Generate Baseline Forecast
+
+Produce a statistical baseline forecast from the latest snapshot:
+
+```bash
+younggeul baseline \
+  --snapshot-dir ./output/snapshots \
+  --output-dir ./output/baseline
+```
+
+## Step 4 — Run Simulation
+
+Launch a multi-agent simulation with a natural-language query:
+
+```bash
+younggeul simulate \
+  --query "서울 강남구 아파트 시장 전망" \
+  --max-rounds 2 \
+  --output-dir ./output/simulation
+```
+
+```
+[simulate] Loaded snapshot: snap_20260101_abc123
+[simulate] Round 1/2 complete
+[simulate] Round 2/2 complete
+[simulate] Citation gate: PASSED (coverage 100%)
+[simulate] Report written to ./output/simulation/simulation_report_*.md
+```
+
+## Step 5 — View the Report
+
+Render the simulation report to the terminal:
+
+```bash
+younggeul report --report-file ./output/simulation/simulation_report_*.md
+```
+
+## Step 6 — Run Evaluation
+
+Run the pytest-based evaluation suite against canonical scenarios:
+
+```bash
+younggeul eval --output-dir eval_results
+```
+
+## All-in-One (Demo Script)
+
+The above steps are bundled in the demo script:
+
+```bash
+make demo
+# or
+bash scripts/demo.sh
+```
+
+See [Demo](demo.md) for details.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1,0 +1,144 @@
+# CLI Reference
+
+Younggeul provides a single entry-point CLI powered by [Click](https://click.palletsprojects.com/).
+
+## Entry Point
+
+```bash
+younggeul [OPTIONS] COMMAND [ARGS]...
+# or
+python -m younggeul_app_kr_seoul_apartment.cli [OPTIONS] COMMAND [ARGS]...
+```
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `--output json` | Output format (currently `json` or default text) |
+| `--version` | Show version and exit |
+| `--help` | Show help message |
+
+---
+
+## Commands
+
+### `ingest`
+
+Run the Bronze → Silver → Gold data pipeline using fixture data.
+
+```bash
+younggeul ingest [--output-dir PATH]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--output-dir` | `./output/pipeline` | Directory to write pipeline output |
+
+**Example:**
+
+```bash
+younggeul ingest --output-dir ./output/pipeline
+```
+
+---
+
+### `snapshot`
+
+Snapshot management subcommand group.
+
+#### `snapshot publish`
+
+Create an immutable, SHA-256-verified dataset snapshot.
+
+```bash
+younggeul snapshot publish [--data-dir PATH] [--snapshot-dir PATH]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--data-dir` | `./output/pipeline` | Pipeline output directory to snapshot |
+| `--snapshot-dir` | `./output/snapshots` | Target directory for snapshots |
+
+#### `snapshot list`
+
+List all available snapshots.
+
+```bash
+younggeul snapshot list [--snapshot-dir PATH]
+```
+
+---
+
+### `baseline`
+
+Generate a statistical baseline forecast from the latest snapshot.
+
+```bash
+younggeul baseline [--snapshot-dir PATH] [--output-dir PATH]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--snapshot-dir` | `./output/snapshots` | Snapshot directory to read from |
+| `--output-dir` | `./output/baseline` | Directory to write baseline output |
+
+---
+
+### `simulate`
+
+Run a multi-agent LangGraph simulation.
+
+```bash
+younggeul simulate --query TEXT [--max-rounds INT] [--output-dir PATH]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--query` | *(required)* | Natural-language market query (Korean supported) |
+| `--max-rounds` | `3` | Maximum simulation rounds |
+| `--output-dir` | `./output/simulation` | Directory to write report and state |
+
+**Example:**
+
+```bash
+younggeul simulate \
+  --query "서울 강남구 아파트 시장 전망" \
+  --max-rounds 2 \
+  --output-dir ./output/simulation
+```
+
+---
+
+### `report`
+
+Display a rendered simulation report in the terminal.
+
+```bash
+younggeul report --report-file PATH
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--report-file` | *(required)* | Path to the `.md` report file |
+
+**Example:**
+
+```bash
+younggeul report --report-file ./output/simulation/simulation_report_*.md
+```
+
+---
+
+### `eval`
+
+Run the pytest-based evaluation suite against canonical eval scenarios.
+
+```bash
+younggeul eval [--output-dir PATH]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--output-dir` | `./eval_results` | Directory to write eval results |
+
+See [Evaluation](evaluation.md) for details on eval cases and categories.

--- a/docs/guide/data-pipeline.md
+++ b/docs/guide/data-pipeline.md
@@ -1,0 +1,86 @@
+# Data Pipeline
+
+The Younggeul data pipeline is a three-layer ETL process that transforms raw government API responses into aggregated market metrics.
+
+## Architecture
+
+```
+Data Sources           Bronze Layer       Silver Layer          Gold Layer
+(MOLIT, BOK,    →→→   (Raw JSON/CSV)  →  (Typed Pydantic)  →  (Aggregated)
+ KOSTAT)               per-source         per-domain            per gu/month
+```
+
+---
+
+## Bronze Layer
+
+The Bronze layer stores **raw, unmodified** API responses from official sources.
+
+| Source | Data Type | Description |
+|--------|-----------|-------------|
+| **MOLIT** | Apartment transactions | Real estate transaction prices from Ministry of Land |
+| **BOK** | Interest rates | Bank of Korea base rate time series |
+| **KOSTAT** | Migration data | Population migration between districts |
+
+Bronze records are written as-is — no transformation, no filtering. This ensures the raw source is always available for audit.
+
+---
+
+## Silver Layer
+
+The Silver layer converts Bronze records into **typed Pydantic models** with validated fields.
+
+| Model | Source | Key Fields |
+|-------|--------|------------|
+| `SilverAptTransaction` | MOLIT | district, year_month, area_m2, price_krw |
+| `SilverInterestRate` | BOK | date, rate_pct |
+| `SilverMigration` | KOSTAT | origin_gu, dest_gu, year_month, count |
+
+Each Silver record carries `source_id` and `source_url` metadata for citation tracking.
+
+---
+
+## Gold Layer
+
+The Gold layer produces **aggregated district-level monthly metrics**.
+
+| Model | Granularity | Key Fields |
+|-------|-------------|------------|
+| `GoldDistrictMonthlyMetrics` | gu × month | avg_price_krw, median_price_krw, transaction_count, yoy_pct, mom_pct |
+
+Gold records are the primary input to the simulation plane.
+
+### Trend Enrichment
+
+Gold metrics include YoY (year-over-year) and MoM (month-over-month) percentage changes calculated during aggregation.
+
+---
+
+## Snapshot System
+
+Snapshots provide **immutable, reproducible** pipeline outputs.
+
+```bash
+younggeul snapshot publish --data-dir ./output/pipeline --snapshot-dir ./output/snapshots
+```
+
+Each snapshot:
+- Has a unique ID (`snap_YYYYMMDD_<hash8>`)
+- Contains a `manifest.json` with SHA-256 hashes for all files
+- Is verified on load — any tampered file raises `SnapshotIntegrityError`
+
+```bash
+younggeul snapshot list --snapshot-dir ./output/snapshots
+```
+
+---
+
+## Baseline Forecaster
+
+The baseline module produces a simple **statistical forecast** from the latest Gold metrics, used as a starting point for simulation scenarios.
+
+```bash
+younggeul baseline --snapshot-dir ./output/snapshots --output-dir ./output/baseline
+```
+
+The baseline is a deterministic computation — given the same snapshot, it always produces the same output.

--- a/docs/guide/evaluation.md
+++ b/docs/guide/evaluation.md
@@ -1,0 +1,78 @@
+# Evaluation
+
+Younggeul uses a **pytest-based evaluation framework** to validate simulation quality, contract correctness, and behavioral properties.
+
+## Running Evaluations
+
+```bash
+# Via CLI
+younggeul eval --output-dir eval_results
+
+# Via pytest directly
+pytest -m eval -v
+```
+
+---
+
+## Eval Case Fixtures
+
+Eval cases are defined as **YAML fixtures** in `eval_cases/`:
+
+```
+eval_cases/
+├── gangnam_2round_bull.yaml
+├── seocho_0round_baseline.yaml
+└── gangnam_5round_stress.yaml
+```
+
+Each fixture specifies:
+
+```yaml
+name: gangnam_2round_bull
+query: "서울 강남구 아파트 상승 전망"
+max_rounds: 2
+expected:
+  citation_gate: passed
+  coverage_pct_min: 100
+  report_contains: ["강남구", "상승"]
+```
+
+---
+
+## Test Categories
+
+| Marker | Description |
+|--------|-------------|
+| `smoke` | Basic import and CLI invocation checks |
+| `contract` | Schema validation — Bronze/Silver/Gold/Evidence field contracts |
+| `behavioral` | Simulation output properties (citation coverage, report structure) |
+| `robustness` | Edge cases — empty input, zero rounds, missing data |
+
+---
+
+## Canonical Scenarios
+
+| Scenario | Query | Rounds | Purpose |
+|----------|-------|--------|---------|
+| `gangnam_2round_bull` | 서울 강남구 아파트 상승 전망 | 2 | Standard bullish scenario |
+| `seocho_0round_baseline` | 서울 서초구 아파트 기준선 | 0 | Baseline-only, no simulation rounds |
+| `gangnam_5round_stress` | 서울 강남구 아파트 하락 스트레스 | 5 | Stress test — maximum rounds |
+
+---
+
+## Nightly Evaluation
+
+A GitHub Actions workflow runs the full eval suite nightly against the `main` branch. Results are stored as workflow artifacts.
+
+See `.github/workflows/` for the CI configuration.
+
+---
+
+## Adding New Eval Cases
+
+1. Create a YAML file in `eval_cases/` following the fixture schema above.
+2. Add a corresponding test in `apps/kr-seoul-apartment/tests/eval/` using the `@pytest.mark.eval` marker.
+3. Run `pytest -m eval -v` to verify the new case passes.
+
+!!! tip
+    Use the `gangnam_2round_bull.yaml` fixture as a template for new scenarios.

--- a/docs/guide/simulation.md
+++ b/docs/guide/simulation.md
@@ -1,0 +1,88 @@
+# Simulation
+
+Younggeul's simulation plane is built on [LangGraph](https://github.com/langchain-ai/langgraph), a framework for building stateful, multi-actor graph workflows.
+
+## Overview
+
+A simulation takes a natural-language query (e.g., `"서울 강남구 아파트 시장 전망"`) and a set of Gold metrics as input, then produces a structured report with full evidence citations.
+
+```bash
+younggeul simulate \
+  --query "서울 강남구 아파트 시장 전망" \
+  --max-rounds 2 \
+  --output-dir ./output/simulation
+```
+
+---
+
+## Graph Topology
+
+```
+START
+  ↓
+intake_planner       # Parse query, identify target district/period
+  ↓
+scenario_builder     # Build scenario context from baseline forecast
+  ↓
+world_initializer    # Initialize participant agents and event store
+  ↓
+┌─── round loop (1..max_rounds) ─────────────────────┐
+│   participant_node  (buyer, investor, tenant,        │
+│                      landlord, broker)               │
+│       ↓                                              │
+│   round_resolver    # Aggregate decisions, update    │
+│                     # market state                   │
+│       ↓                                              │
+│   continue_check    # Decide whether to run more     │
+│                     # rounds                         │
+└────────────────────────────────────────────────────-─┘
+  ↓
+evidence_builder     # Collect evidence records from event store
+  ↓
+report_writer        # Draft report claims from simulation state
+  ↓
+citation_gate        # Validate each claim has a citation
+  ↓
+report_renderer      # Render final Markdown + JSON report
+  ↓
+END
+```
+
+---
+
+## Participant Agents
+
+v0.1 uses **deterministic stub agents** — no LLM calls are made during simulation. Each agent applies rule-based logic against the current market state.
+
+| Agent | Role | Decision Logic |
+|-------|------|----------------|
+| `buyer` | Prospective apartment buyer | Evaluates affordability vs. price trend |
+| `investor` | Real estate investor | Evaluates ROI based on YoY metrics |
+| `tenant` | Current renter | Evaluates rent-to-buy ratio |
+| `landlord` | Property owner | Evaluates rental yield |
+| `broker` | Market intermediary | Aggregates market signals |
+
+---
+
+## Simulation State
+
+The graph uses a `SimulationGraphState` TypedDict with list reducers for append-only fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `query` | `str` | Original simulation query |
+| `scenario` | `ScenarioContext` | Parsed scenario from intake_planner |
+| `rounds` | `list[RoundResult]` | Results per round (append-only) |
+| `events` | `list[MarketEvent]` | Event store (append-only) |
+| `evidence` | `list[EvidenceRecord]` | Evidence collected post-rounds |
+| `report` | `RenderedReport \| None` | Final rendered report |
+
+---
+
+## Node Types
+
+- **Deterministic nodes** — Pure functions, no external I/O (all v0.1 nodes)
+- **Stub nodes** — Placeholder logic returning canned responses, used while LLM integration is deferred
+
+!!! note
+    LLM-backed nodes are scoped to v0.2. All v0.1 simulation logic is deterministic and fully testable without network access.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,59 @@
+# Younggeul — 영끌 시뮬레이터
+
+[![CI](https://github.com/yeongseon/younggeul/actions/workflows/ci.yml/badge.svg)](https://github.com/yeongseon/younggeul/actions)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/yeongseon/younggeul/blob/main/LICENSE)
+[![Python](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
+
+**Younggeul** (영끌, *YOLO Mortgage Simulator*) is an open-source, agent-based Korean real estate simulation platform. It models Seoul apartment market dynamics through a deterministic data pipeline, a multi-agent LangGraph simulation, and evidence-gated reporting — every claim in a report is traceable to a real data source.
+
+## Why Younggeul?
+
+Korean housing discourse often mixes anecdote with data. Younggeul aims to make market analysis *auditable*: if a simulated agent says "prices are rising," the platform must produce a citation from an official dataset before that claim reaches the report.
+
+## Key Features
+
+| Feature | Description |
+|---|---|
+| **Evidence-Gated Reporting** | Every report claim must pass citation validation — no citation, no publication |
+| **Multi-Agent Simulation** | LangGraph-based graph with buyer, investor, tenant, landlord, and broker agents |
+| **Deterministic Data Pipeline** | Bronze → Silver → Gold ETL from MOLIT, BOK, and KOSTAT official sources |
+| **100% Citation Coverage** | All Silver/Gold records carry source metadata; reports fail if coverage drops below threshold |
+| **Immutable Snapshots** | SHA-256-verified dataset snapshots ensure reproducible simulation runs |
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                      younggeul CLI                       │
+└────────────┬─────────────────────────────┬──────────────┘
+             │                             │
+    ┌────────▼────────┐          ┌─────────▼────────┐
+    │   Data Plane    │          │ Simulation Plane  │
+    │                 │          │                   │
+    │  Bronze Layer   │          │  LangGraph Graph  │
+    │  (Raw API data) │          │  (Multi-agent)    │
+    │       ↓         │          │                   │
+    │  Silver Layer   │──────────▶  Evidence Store  │
+    │  (Pydantic)     │          │       ↓           │
+    │       ↓         │          │  Citation Gate    │
+    │  Gold Layer     │          │       ↓           │
+    │  (Aggregated)   │          │  Report Renderer  │
+    └────────┬────────┘          └───────────────────┘
+             │
+    ┌────────▼────────┐
+    │    Snapshots    │
+    │  (SHA-256 hash) │
+    └─────────────────┘
+```
+
+## Quick Links
+
+- **[Installation](getting-started/installation.md)** — Get up and running in minutes
+- **[Quick Start](getting-started/quickstart.md)** — Run your first simulation
+- **[CLI Reference](guide/cli.md)** — All commands explained
+- **[Architecture Overview](architecture/overview.md)** — How the pieces fit together
+- **[ADRs](adr/001-clean-room-development.md)** — Design decisions
+
+## v0.1 Scope
+
+v0.1 targets **Seoul apartment transactions only**, using fixture data so no API key is required for local development. Real data ingestion requires a [PublicDataReader](https://github.com/WooilJeong/PublicDataReader) API key from data.go.kr.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,53 @@
+# Release Notes
+
+## v0.1.0
+
+*Initial release — Seoul apartment simulation, evidence-gated reporting*
+
+### Data Plane
+
+- **Bronze → Silver → Gold pipeline** with connectors for MOLIT (apartment transactions), BOK (interest rates), and KOSTAT (migration data)
+- **Pydantic v2 models** for all Silver and Gold layers with strict validation
+- **Immutable snapshot system** — SHA-256 content-addressed dataset snapshots with manifest verification
+- **Trend enrichment** — YoY and MoM calculations on Gold aggregates
+- **Baseline forecaster** — deterministic statistical forecast from Gold metrics
+
+### Simulation Plane
+
+- **LangGraph-based multi-agent simulation** with configurable round count
+- **Five participant agents**: buyer, investor, tenant, landlord, broker (v0.1: deterministic stubs)
+- **Event store** and **evidence store** for traceability through the simulation
+- **SimulationGraphState** TypedDict with append-only reducers
+
+### Evidence-Gated Reporting
+
+- **Citation gate** — reports fail to publish if any claim lacks a citation
+- **100% coverage requirement** — all claims must be backed by Gold metric evidence
+- **EvidenceRecord** schema with source URL, kind, value, and unit
+- **RenderedReport** output in both Markdown and structured JSON
+
+### Evaluation
+
+- **pytest-based eval framework** with `@pytest.mark.eval` marker
+- **3 canonical scenarios**: `gangnam_2round_bull`, `seocho_0round_baseline`, `gangnam_5round_stress`
+- **YAML eval case fixtures** for reproducible scenario definitions
+- **Nightly CI workflow** running full eval suite
+
+### Observability
+
+- **OpenTelemetry tracing** on all simulation nodes
+- **CodeQL security scanning** in CI
+
+### CLI
+
+- **Click-based CLI** with 6 commands: `ingest`, `snapshot` (publish/list), `baseline`, `simulate`, `report`, `eval`
+- Entry point: `younggeul`
+
+### Demo
+
+- **End-to-end demo script** (`scripts/demo.sh` / `make demo`) using fixture data — no API key required
+
+---
+
+!!! note "Scope"
+    v0.1 covers **Seoul apartments only**. Features deferred to future releases include Web UI, LiteLLM OTEL integration, and Grafana dashboards.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,76 @@
+site_name: "Younggeul — 영끌 시뮬레이터"
+site_description: "Open-source, agent-based Korean real estate simulation platform"
+site_url: https://yeongseon.github.io/younggeul
+repo_url: https://github.com/yeongseon/younggeul
+repo_name: yeongseon/younggeul
+
+theme:
+  name: material
+  palette:
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - content.code.copy
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - toc:
+      permalink: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/yeongseon/younggeul
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Installation: getting-started/installation.md
+    - Quick Start: getting-started/quickstart.md
+    - Demo: getting-started/demo.md
+  - User Guide:
+    - CLI Reference: guide/cli.md
+    - Data Pipeline: guide/data-pipeline.md
+    - Simulation: guide/simulation.md
+    - Evaluation: guide/evaluation.md
+  - Architecture:
+    - Overview: architecture/overview.md
+    - Data Plane: architecture/data-plane.md
+    - Simulation Plane: architecture/simulation-plane.md
+    - Evidence-Gated Reporting: architecture/reporting.md
+  - ADRs:
+    - ADR-001 Clean-Room Development: adr/001-clean-room-development.md
+    - ADR-002 Monorepo Boundaries: adr/002-monorepo-boundaries.md
+    - ADR-003 Immutable Snapshots: adr/003-immutable-dataset-snapshots.md
+    - ADR-004 LangGraph Boundaries: adr/004-langgraph-boundaries.md
+    - ADR-005 Evidence-Gated Reporting: adr/005-evidence-gated-reporting.md
+    - ADR-006 Public Data Policy: adr/006-public-data-policy.md
+  - Release Notes: release-notes.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ kr-seoul-apartment = [
   "PublicDataReader>=1.1",
   "pandas>=2.0",
 ]
+docs = [
+  "mkdocs-material>=9.0",
+  "mkdocs>=1.5",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = [


### PR DESCRIPTION
## Summary

- Add MkDocs Material documentation site with 14 pages covering getting started, user guide, architecture, and ADRs
- Add `mkdocs.yml` with Material theme, dark/light toggle, search, and full navigation
- Add `docs` optional dependency group (`mkdocs-material>=9.0`, `mkdocs>=1.5`)
- Add `docs` and `docs-serve` Makefile targets

Closes #75

## Documentation Structure

```
docs/
├── index.md                    # Home page with badges, architecture diagram
├── getting-started/
│   ├── installation.md         # Prerequisites, pip/uv install
│   ├── quickstart.md           # Step-by-step first simulation
│   └── demo.md                 # make demo walkthrough
├── guide/
│   ├── cli.md                  # Full CLI reference (6 commands)
│   ├── data-pipeline.md        # Bronze/Silver/Gold pipeline
│   ├── simulation.md           # LangGraph simulation guide
│   └── evaluation.md           # pytest eval suite guide
├── architecture/
│   ├── overview.md             # Three-plane architecture
│   ├── data-plane.md           # Detailed data plane design
│   ├── simulation-plane.md     # Simulation plane internals
│   └── reporting.md            # Evidence-gated reporting pipeline
├── adr/                        # Existing ADRs (unchanged)
└── release-notes.md            # v0.1.0 release notes
```

## Checklist
- [x] All nav entries have corresponding files
- [x] Existing ADR files unchanged
- [x] PRD.md/TDD.md excluded from nav
- [x] No mermaid (plain ASCII diagrams)
- [x] Lint passes
- [x] All 1111 tests pass