### PR TITLE
ci: activate release and deploy-docs workflows (#77)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,12 +1,45 @@
 name: Deploy Documentation
-# Stub — activate in M10-05
 on:
   push:
+    branches: [main]
     tags:
       - "v*"
   workflow_dispatch:
+
+permissions:
+  pages: write
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: true
+
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Stub — activate in milestone M10 (v0.1 Release)"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v4
+      - name: Install docs dependencies
+        run: uv pip install --system -e ".[docs]"
+      - name: Build docs
+        run: mkdocs build --strict
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,65 @@
 name: Release
-# Stub — activate in M10-05
 on:
   push:
     tags:
       - "v*"
+
+permissions:
+  contents: write
+
 jobs:
-  release:
+  check:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Stub — activate in milestone M10 (v0.1 Release)"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v4
+      - name: Install dependencies
+        run: uv pip install --system -e ".[dev,kr-seoul-apartment]"
+      - name: Lint
+        run: |
+          ruff check .
+          ruff format --check .
+          mypy core/src/ apps/kr-seoul-apartment/src/
+      - name: Test
+        run: pytest -m "not slow and not integration" --cov
+
+  build:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v4
+      - name: Install build tools
+        run: uv pip install --system build
+      - name: Build package
+        run: python -m build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  github-release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ data/snapshots/**
 eval_results/
 demo_output/
 
+# Docs build
+site/
+
 # IDE
 .vscode/
 .idea/


### PR DESCRIPTION
## Summary

- Activate `release.yml`: lint/test gate → build package → create GitHub Release with artifacts on `v*` tag push
- Activate `deploy-docs.yml`: build MkDocs site → deploy to GitHub Pages on push to main or `v*` tag
- Add `site/` to `.gitignore` (mkdocs build output)

Closes #77

## Release Workflow (`release.yml`)

Triggered by pushing a `v*` tag (e.g., `v0.1.0`):

1. **check**: Install deps, run ruff + mypy + pytest
2. **build**: Build wheel and sdist with `python -m build`
3. **github-release**: Create GitHub Release with auto-generated release notes and attach dist artifacts

## Deploy Docs Workflow (`deploy-docs.yml`)

Triggered by push to `main` or `v*` tag, or manual `workflow_dispatch`:

1. **build**: Install docs deps, run `mkdocs build --strict`, upload pages artifact
2. **deploy**: Deploy to GitHub Pages via `actions/deploy-pages@v4`

## Checklist
- [x] release.yml activated with lint/test/build/release jobs
- [x] deploy-docs.yml activated with build/deploy jobs
- [x] site/ added to .gitignore
- [x] No duplicate YAML keys