### PR TITLE
D1-02: Backfill missing docstrings in public app modules

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py
@@ -1,3 +1,5 @@
+"""CLI entrypoints for ingest, snapshot, baseline, and simulation workflows."""
+
 from __future__ import annotations
 
 import json
@@ -192,6 +194,7 @@ def _extract_rendered_report(
 @click.option("--version", is_flag=True, is_eager=True, callback=_emit_version, expose_value=False)
 @click.pass_context
 def main(ctx: click.Context, output: str) -> None:
+    """Run the top-level Younggeul CLI group."""
     ctx.ensure_object(dict)
     ctx.obj["output"] = output
 
@@ -205,6 +208,7 @@ def main(ctx: click.Context, output: str) -> None:
 )
 @click.pass_context
 def ingest_command(ctx: click.Context, output_dir: Path) -> None:
+    """Ingest fixture Bronze data and write Gold JSONL output."""
     try:
         bronze = _fixture_bronze_input()
         result = run_pipeline(bronze)
@@ -245,6 +249,7 @@ def ingest_command(ctx: click.Context, output_dir: Path) -> None:
 
 @main.group("snapshot")
 def snapshot_group() -> None:
+    """Manage dataset snapshots used by downstream commands."""
     pass
 
 
@@ -262,6 +267,7 @@ def snapshot_group() -> None:
 )
 @click.pass_context
 def snapshot_publish_command(ctx: click.Context, data_dir: Path, snapshot_dir: Path) -> None:
+    """Publish a snapshot from Gold JSONL files in a data directory."""
     try:
         gold_rows = _load_gold_rows(data_dir)
         snapshot_ref = publish_snapshot(gold_rows, snapshot_dir)
@@ -295,6 +301,7 @@ def snapshot_publish_command(ctx: click.Context, data_dir: Path, snapshot_dir: P
 )
 @click.pass_context
 def snapshot_list_command(ctx: click.Context, snapshot_dir: Path) -> None:
+    """List available dataset snapshots from the snapshot directory."""
     try:
         items: list[dict[str, Any]] = []
         if snapshot_dir.exists():
@@ -362,6 +369,7 @@ def snapshot_list_command(ctx: click.Context, snapshot_dir: Path) -> None:
 )
 @click.pass_context
 def baseline_command(ctx: click.Context, snapshot_id: str, snapshot_dir: Path, output_dir: Path) -> None:
+    """Generate baseline forecasts from a stored snapshot."""
     try:
         manifest, metrics = resolve_snapshot(snapshot_id, snapshot_dir)
         snapshot_ref = _snapshot_ref_from_manifest(manifest)
@@ -402,6 +410,7 @@ def baseline_command(ctx: click.Context, snapshot_id: str, snapshot_dir: Path, o
 )
 @click.pass_context
 def simulate_command(ctx: click.Context, query: str, max_rounds: int, run_name: str, output_dir: Path) -> None:
+    """Run the simulation graph and save a rendered Markdown report."""
     try:
         event_store = InMemoryEventStore()
         evidence_store = InMemoryEvidenceStore()
@@ -438,6 +447,7 @@ def simulate_command(ctx: click.Context, query: str, max_rounds: int, run_name: 
 @click.option("--report-file", type=click.Path(path_type=Path, dir_okay=False), required=True)
 @click.pass_context
 def report_command(ctx: click.Context, report_file: Path) -> None:
+    """Print an existing report file to the selected output format."""
     try:
         if not report_file.exists() or not report_file.is_file():
             raise click.ClickException(f"Report file not found: {report_file}")
@@ -454,6 +464,7 @@ def report_command(ctx: click.Context, report_file: Path) -> None:
 @click.option("--output-dir", type=str, default="eval_results", show_default=True)
 @click.pass_context
 def eval_command(ctx: click.Context, output_dir: str) -> None:
+    """Execute eval-marked tests and persist evaluation summaries."""
     try:
         base_dir = Path(output_dir)
         base_dir.mkdir(parents=True, exist_ok=True)

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/connectors/bok.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/connectors/bok.py
@@ -171,7 +171,14 @@ class BokInterestRateConnector:
         self._now_fn = now_fn
 
     def fetch(self, request: BokInterestRateRequest) -> ConnectorResult[BronzeInterestRate]:
-        """Fetch interest rate data for one series over a date range."""
+        """Fetch interest rate data for one series over a date range.
+
+        Args:
+            request: Partition-scoped BOK query configuration.
+
+        Returns:
+            Connector result containing Bronze interest-rate records and ingest manifest.
+        """
         now = self._now_fn()
 
         def _call_api() -> pd.DataFrame:

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/connectors/kostat.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/connectors/kostat.py
@@ -192,7 +192,14 @@ class KostatMigrationConnector:
         self._now_fn = now_fn
 
     def fetch(self, request: KostatMigrationRequest) -> ConnectorResult[BronzeMigration]:
-        """Fetch migration data for one month (all 시도 regions)."""
+        """Fetch migration data for one month (all 시도 regions).
+
+        Args:
+            request: Partition-scoped KOSTAT query configuration.
+
+        Returns:
+            Connector result containing Bronze migration records and ingest manifest.
+        """
         now = self._now_fn()
 
         def _call_api() -> pd.DataFrame:

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/connectors/molit.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/connectors/molit.py
@@ -171,7 +171,14 @@ class MolitAptConnector:
         self._now_fn = now_fn
 
     def fetch(self, request: MolitAptRequest) -> ConnectorResult[BronzeAptTransaction]:
-        """Fetch apartment transactions for one sigungu + one month."""
+        """Fetch apartment transactions for one sigungu + one month.
+
+        Args:
+            request: Partition-scoped MOLIT query configuration.
+
+        Returns:
+            Connector result containing Bronze apartment records and ingest manifest.
+        """
         now = self._now_fn()
 
         # Retry wraps only the API call; rate limit inside retried callable

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/forecaster.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/forecaster.py
@@ -1,3 +1,5 @@
+"""Baseline forecasting and report generation for district-level Gold metrics."""
+
 from __future__ import annotations
 
 import json
@@ -21,6 +23,14 @@ def _next_period(period: str) -> str:
 
 
 def forecast_baseline(metrics: list[GoldDistrictMonthlyMetrics]) -> list[BaselineForecast]:
+    """Generate one-step baseline forecasts per district.
+
+    Args:
+        metrics: Historical district monthly metrics used for trend scoring.
+
+    Returns:
+        Baseline forecast rows, one per district when input data exists.
+    """
     if not metrics:
         return []
 
@@ -102,6 +112,16 @@ def generate_baseline_report(
     forecasts: list[BaselineForecast],
     output_dir: Path,
 ) -> Path:
+    """Write a baseline forecast report JSON file.
+
+    Args:
+        snapshot_ref: Snapshot metadata used to label the report.
+        forecasts: Forecast rows to include in the report payload.
+        output_dir: Directory where the report file will be written.
+
+    Returns:
+        Path to the generated report file.
+    """
     output_dir.mkdir(parents=True, exist_ok=True)
     report_path = output_dir / f"baseline_report_{snapshot_ref.dataset_snapshot_id[:12]}.json"
 

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/pipeline.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/pipeline.py
@@ -1,3 +1,5 @@
+"""End-to-end deterministic Bronze-to-Gold data pipeline for Seoul apartment data."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -45,6 +47,12 @@ def run_pipeline(bronze: BronzeInput) -> PipelineResult:
     """Execute the full Bronze → Silver → Gold data pipeline.
 
     All transforms are deterministic (ADR-004). No LLMs, no side effects.
+
+    Args:
+        bronze: Raw Bronze layer records grouped by domain.
+
+    Returns:
+        Combined Silver and Gold outputs produced from the provided Bronze input.
     """
     # Silver layer
     silver_apt = normalize_apt_batch(bronze.apt_transactions)

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/domain/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/domain/__init__.py
@@ -1,1 +1,3 @@
+"""Domain helpers for scenario normalization and resolution."""
+
 from __future__ import annotations

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/domain/gu_resolver.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/domain/gu_resolver.py
@@ -1,3 +1,5 @@
+"""Utilities for resolving Seoul district identifiers from user hints."""
+
 from __future__ import annotations
 
 SEOUL_GU_MAP: dict[str, str] = {
@@ -34,6 +36,15 @@ def resolve_gu_codes(
     geography_hint: str | None,
     available_gu_codes: list[str],
 ) -> tuple[list[str], list[str]]:
+    """Resolve target district codes from a free-form geography hint.
+
+    Args:
+        geography_hint: Free-form district hint from the user query.
+        available_gu_codes: District codes available in snapshot coverage.
+
+    Returns:
+        A tuple of resolved district codes and warning messages.
+    """
     if geography_hint is None:
         return list(available_gu_codes), []
 

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/domain/shock_catalog.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/domain/shock_catalog.py
@@ -1,3 +1,7 @@
+# pyright: reportMissingImports=false
+
+"""Shock catalog helpers for scenario shock normalization and expansion."""
+
 from __future__ import annotations
 
 from typing import Literal, TypedDict
@@ -72,6 +76,14 @@ KOREAN_SHOCK_ALIASES: dict[str, str] = {
 
 
 def normalize_shock_key(raw: str) -> str | None:
+    """Normalize a user-provided shock key to a supported catalog key.
+
+    Args:
+        raw: Raw shock key or alias from user or model output.
+
+    Returns:
+        The canonical shock key when supported, otherwise ``None``.
+    """
     candidate = raw.strip().lower()
     if candidate in SUPPORTED_SHOCK_KEYS:
         return candidate
@@ -86,6 +98,17 @@ def expand_shock(
     start_period: str,
     end_period: str | None,
 ) -> Shock:
+    """Expand a catalog shock key into a simulation Shock object.
+
+    Args:
+        key: Canonical shock key present in the supported catalog.
+        target_gus: Target district codes affected by the shock.
+        start_period: Scenario start period in YYYY-MM format.
+        end_period: Scenario end period in YYYY-MM format.
+
+    Returns:
+        A normalized simulation shock definition.
+    """
     del start_period
     del end_period
     template = SUPPORTED_SHOCK_KEYS[key]

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/event_store.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/event_store.py
@@ -1,3 +1,5 @@
+"""Event store implementations for in-memory and file-backed persistence."""
+
 from __future__ import annotations
 
 import json
@@ -9,32 +11,71 @@ from .events import EventStore, SimulationEvent
 
 
 class InMemoryEventStore(EventStore):
+    """Thread-safe in-memory event store grouped by run ID."""
+
     def __init__(self) -> None:
         self._events_by_run: dict[str, list[SimulationEvent]] = defaultdict(list)
         self._lock = threading.Lock()
 
     def append(self, event: SimulationEvent) -> None:
+        """Append an event to the in-memory store.
+
+        Args:
+            event: Event to persist.
+        """
         with self._lock:
             self._events_by_run[event.run_id].append(event)
 
     def get_events(self, run_id: str) -> list[SimulationEvent]:
+        """Return all events for a run sorted by timestamp.
+
+        Args:
+            run_id: Simulation run identifier.
+
+        Returns:
+            Events associated with the run.
+        """
         with self._lock:
             events = list(self._events_by_run.get(run_id, []))
         return sorted(events, key=lambda event: event.timestamp)
 
     def get_events_by_type(self, run_id: str, event_type: str) -> list[SimulationEvent]:
+        """Return events for a run filtered by event type.
+
+        Args:
+            run_id: Simulation run identifier.
+            event_type: Event type to filter by.
+
+        Returns:
+            Matching events sorted by timestamp.
+        """
         return [event for event in self.get_events(run_id) if event.event_type == event_type]
 
     def count(self, run_id: str) -> int:
+        """Count events recorded for a run.
+
+        Args:
+            run_id: Simulation run identifier.
+
+        Returns:
+            Number of stored events.
+        """
         with self._lock:
             return len(self._events_by_run.get(run_id, []))
 
     def clear(self, run_id: str) -> None:
+        """Remove all events for a run.
+
+        Args:
+            run_id: Simulation run identifier.
+        """
         with self._lock:
             self._events_by_run.pop(run_id, None)
 
 
 class FileEventStore(EventStore):
+    """JSONL-backed event store with one file per run."""
+
     def __init__(self, base_dir: Path) -> None:
         self._base_dir = base_dir
         self._base_dir.mkdir(parents=True, exist_ok=True)
@@ -44,12 +85,25 @@ class FileEventStore(EventStore):
         return self._base_dir / f"{run_id}.jsonl"
 
     def append(self, event: SimulationEvent) -> None:
+        """Append an event as a JSON line to the run file.
+
+        Args:
+            event: Event to persist.
+        """
         line = event.model_dump_json()
         with self._lock:
             with self._run_path(event.run_id).open("a", encoding="utf-8") as file:
                 file.write(f"{line}\n")
 
     def get_events(self, run_id: str) -> list[SimulationEvent]:
+        """Load all events for a run sorted by timestamp.
+
+        Args:
+            run_id: Simulation run identifier.
+
+        Returns:
+            Parsed events for the run.
+        """
         run_path = self._run_path(run_id)
         if not run_path.exists():
             return []
@@ -66,9 +120,26 @@ class FileEventStore(EventStore):
         return sorted(events, key=lambda event: event.timestamp)
 
     def get_events_by_type(self, run_id: str, event_type: str) -> list[SimulationEvent]:
+        """Return events for a run filtered by event type.
+
+        Args:
+            run_id: Simulation run identifier.
+            event_type: Event type to filter by.
+
+        Returns:
+            Matching events sorted by timestamp.
+        """
         return [event for event in self.get_events(run_id) if event.event_type == event_type]
 
     def count(self, run_id: str) -> int:
+        """Count persisted events for a run.
+
+        Args:
+            run_id: Simulation run identifier.
+
+        Returns:
+            Number of events in the run file.
+        """
         run_path = self._run_path(run_id)
         if not run_path.exists():
             return 0
@@ -77,6 +148,11 @@ class FileEventStore(EventStore):
             return sum(1 for _ in file)
 
     def clear(self, run_id: str) -> None:
+        """Delete the persisted event file for a run.
+
+        Args:
+            run_id: Simulation run identifier.
+        """
         run_path = self._run_path(run_id)
         with self._lock:
             if run_path.exists():

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/events.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/events.py
@@ -1,3 +1,5 @@
+"""Shared event and event-store interfaces for simulation runs."""
+
 from __future__ import annotations
 
 from datetime import datetime

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/evidence/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/evidence/__init__.py
@@ -1,3 +1,5 @@
+"""Evidence storage abstractions used by simulation reporting."""
+
 from __future__ import annotations
 
 from .store import EvidenceRecord, EvidenceStore, InMemoryEvidenceStore

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py
@@ -1,3 +1,5 @@
+"""Evidence record schemas and in-memory storage interface."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -7,6 +9,19 @@ from pydantic import BaseModel, Field
 
 
 class EvidenceRecord(BaseModel, frozen=True):
+    """Immutable evidence payload linked to simulation subjects.
+
+    Attributes:
+        evidence_id: Unique evidence identifier.
+        kind: Evidence category used by report generation.
+        subject_type: Subject domain type for the evidence.
+        subject_id: Subject identifier within the subject type.
+        round_no: Simulation round associated with this evidence.
+        payload: Structured evidence payload.
+        source_event_ids: Event IDs used to derive the evidence.
+        created_at: Evidence creation timestamp.
+    """
+
     evidence_id: str
     kind: str
     subject_type: str
@@ -18,6 +33,8 @@ class EvidenceRecord(BaseModel, frozen=True):
 
 
 class EvidenceStore(Protocol):
+    """Protocol for evidence storage backends."""
+
     def add(self, record: EvidenceRecord) -> None: ...
 
     def get(self, evidence_id: str) -> EvidenceRecord | None: ...
@@ -32,24 +49,64 @@ class EvidenceStore(Protocol):
 
 
 class InMemoryEvidenceStore:
+    """In-memory evidence store keyed by evidence ID."""
+
     def __init__(self) -> None:
         self._records: dict[str, EvidenceRecord] = {}
 
     def add(self, record: EvidenceRecord) -> None:
+        """Insert a new evidence record.
+
+        Args:
+            record: Evidence record to store.
+
+        Raises:
+            ValueError: When the evidence ID already exists.
+        """
         if record.evidence_id in self._records:
             raise ValueError(f"Duplicate evidence_id: {record.evidence_id}")
         self._records[record.evidence_id] = record
 
     def get(self, evidence_id: str) -> EvidenceRecord | None:
+        """Return one evidence record by ID.
+
+        Args:
+            evidence_id: Evidence identifier.
+
+        Returns:
+            Matching evidence record when present, else ``None``.
+        """
         return self._records.get(evidence_id)
 
     def get_all(self) -> list[EvidenceRecord]:
+        """Return all stored evidence records.
+
+        Returns:
+            Stored records in insertion order.
+        """
         return list(self._records.values())
 
     def get_by_kind(self, kind: str) -> list[EvidenceRecord]:
+        """Return records matching an evidence kind.
+
+        Args:
+            kind: Evidence kind to filter by.
+
+        Returns:
+            Matching evidence records.
+        """
         return [record for record in self._records.values() if record.kind == kind]
 
     def get_by_subject(self, subject_type: str, subject_id: str) -> list[EvidenceRecord]:
+        """Return records matching a specific subject.
+
+        Args:
+            subject_type: Subject type to filter by.
+            subject_id: Subject identifier to filter by.
+
+        Returns:
+            Matching evidence records.
+        """
         return [
             record
             for record in self._records.values()
@@ -57,4 +114,9 @@ class InMemoryEvidenceStore:
         ]
 
     def count(self) -> int:
+        """Return the number of stored evidence records.
+
+        Returns:
+            Total evidence record count.
+        """
         return len(self._records)

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph.py
@@ -1,3 +1,7 @@
+# pyright: reportMissingImports=false
+
+"""Simulation graph construction and default node wiring."""
+
 from __future__ import annotations
 
 from datetime import date, datetime, timezone
@@ -59,6 +63,18 @@ def build_simulation_graph(
     snapshot_reader: SnapshotReader | None = None,
     evidence_store: EvidenceStore | None = None,
 ) -> CompiledStateGraph[Any, Any, Any, Any]:
+    """Build and compile the LangGraph simulation workflow.
+
+    Args:
+        event_store: Event persistence backend.
+        default_max_rounds: Fallback round limit when not provided by state.
+        structured_llm: Optional structured LLM transport for planning nodes.
+        snapshot_reader: Optional snapshot access port for data-backed nodes.
+        evidence_store: Optional evidence store implementation.
+
+    Returns:
+        A compiled simulation state graph.
+    """
     graph = StateGraph(SimulationGraphState)
     _evidence_store = evidence_store or InMemoryEvidenceStore()
 

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph_state.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/graph_state.py
@@ -1,3 +1,7 @@
+# pyright: reportMissingImports=false
+
+"""Graph-state schema helpers for simulation orchestration."""
+
 from __future__ import annotations
 
 import operator
@@ -21,6 +25,8 @@ from younggeul_core.state.simulation import (
 
 
 class SimulationGraphState(TypedDict, total=False):
+    """Mutable state payload passed between simulation graph nodes."""
+
     user_query: str
     intake_plan: dict[str, Any]
     participant_roster: dict[str, Any]
@@ -73,6 +79,17 @@ _REQUIRED_INITIALIZED_KEYS = {
 
 
 def seed_graph_state(user_query: str, run_id: str, run_name: str, model_id: str) -> SimulationGraphState:
+    """Create an initial graph state for a simulation run.
+
+    Args:
+        user_query: Original user query for the simulation.
+        run_id: Stable run identifier.
+        run_name: Human-readable run name.
+        model_id: Model identifier used for the run.
+
+    Returns:
+        Seed graph state with run metadata and empty accumulators.
+    """
     return {
         "user_query": user_query,
         "run_meta": RunMeta(
@@ -89,6 +106,17 @@ def seed_graph_state(user_query: str, run_id: str, run_name: str, model_id: str)
 
 
 def to_simulation_state(graph_state: SimulationGraphState) -> SimulationState:
+    """Convert initialized graph state into a validated SimulationState.
+
+    Args:
+        graph_state: Graph state to convert.
+
+    Returns:
+        Validated simulation state payload.
+
+    Raises:
+        ValueError: When required fields are missing or schema validation fails.
+    """
     if not validate_initialized_state(graph_state):
         raise ValueError("Simulation graph state is not initialized")
 
@@ -101,5 +129,13 @@ def to_simulation_state(graph_state: SimulationGraphState) -> SimulationState:
 
 
 def validate_initialized_state(graph_state: SimulationGraphState) -> bool:
+    """Check whether required graph-state fields are initialized.
+
+    Args:
+        graph_state: Graph state to validate.
+
+    Returns:
+        ``True`` when all required initialized keys are present and non-null.
+    """
     state_dict: dict[str, object] = dict(graph_state)
     return all(key in state_dict and state_dict[key] is not None for key in _REQUIRED_INITIALIZED_KEYS)

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/__init__.py
@@ -1,1 +1,3 @@
+"""LLM integration layer for structured simulation generation."""
+
 from __future__ import annotations

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py
@@ -1,3 +1,5 @@
+"""LiteLLM adapter that validates structured JSON responses."""
+
 from __future__ import annotations
 
 import json
@@ -12,14 +14,20 @@ T = TypeVar("T", bound=BaseModel)
 
 
 class StructuredLLMTransportError(RuntimeError):
+    """Raised when transport-level LLM invocation fails."""
+
     pass
 
 
 class StructuredLLMResponseError(ValueError):
+    """Raised when LLM output is empty, invalid, or schema-incompatible."""
+
     pass
 
 
 class LiteLLMStructuredLLM:
+    """Structured LLM transport backed by the LiteLLM completion API."""
+
     def __init__(self, model: str, **default_kwargs: Any) -> None:
         self.model = model
         self._default_kwargs = default_kwargs
@@ -31,6 +39,20 @@ class LiteLLMStructuredLLM:
         response_model: type[T],
         temperature: float = 0.0,
     ) -> T:
+        """Generate and validate a structured response from LiteLLM.
+
+        Args:
+            messages: Ordered chat messages sent to the model.
+            response_model: Pydantic model used as the response schema.
+            temperature: Sampling temperature for generation.
+
+        Returns:
+            Parsed and validated response model instance.
+
+        Raises:
+            StructuredLLMTransportError: When the model call fails.
+            StructuredLLMResponseError: When output content is invalid.
+        """
         litellm = import_module("litellm")
 
         schema = response_model.model_json_schema()

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/ports.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/ports.py
@@ -1,3 +1,5 @@
+"""Protocol contracts for structured LLM integrations."""
+
 from __future__ import annotations
 
 from typing import Literal, Protocol, Sequence, TypeVar
@@ -9,15 +11,36 @@ T = TypeVar("T", bound=BaseModel)
 
 
 class LLMMessage(TypedDict):
+    """Single chat message passed to structured LLM backends.
+
+    Attributes:
+        role: Message role in the chat transcript.
+        content: Message content text.
+    """
+
     role: Literal["system", "user", "assistant"]
     content: str
 
 
 class StructuredLLM(Protocol):
+    """Interface for schema-constrained LLM generation."""
+
     def generate_structured(
         self,
         *,
         messages: Sequence[LLMMessage],
         response_model: type[T],
         temperature: float = 0.0,
-    ) -> T: ...
+    ) -> T:
+        """Generate a response and validate it against a model schema.
+
+        Args:
+            messages: Ordered input messages.
+            response_model: Pydantic model expected from the response.
+            temperature: Sampling temperature for model inference.
+
+        Returns:
+            Parsed response model instance.
+        """
+
+        ...

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/__init__.py
@@ -1,1 +1,3 @@
+"""LangGraph node factories used by the simulation workflow."""
+
 from __future__ import annotations

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/citation_gate_node.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/citation_gate_node.py
@@ -1,5 +1,7 @@
 # pyright: reportMissingImports=false
 
+"""Citation gate node that verifies report claims against evidence."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -33,6 +35,19 @@ def _matches_subject(
 
 
 def make_citation_gate_node(evidence_store: EvidenceStore, event_store: EventStore) -> Any:
+    """Create the citation gate node for the simulation graph.
+
+    The citation gate node validates generated claims against evidence records and
+    emits citation gate outcomes.
+
+    Args:
+        evidence_store: Evidence storage used to resolve evidence IDs.
+        event_store: Event store used to publish citation gate events.
+
+    Returns:
+        A LangGraph-compatible node function.
+    """
+
     def node(state: SimulationGraphState) -> dict[str, Any]:
         run_meta = state.get("run_meta")
         if run_meta is None:

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/continue_gate.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/continue_gate.py
@@ -1,3 +1,5 @@
+"""Round-loop continuation gate for simulation execution."""
+
 from __future__ import annotations
 
 from typing import Literal
@@ -6,6 +8,14 @@ from ..graph_state import SimulationGraphState
 
 
 def should_continue(state: SimulationGraphState) -> Literal["continue", "stop"]:
+    """Determine whether the simulation should proceed to another round.
+
+    Args:
+        state: Current simulation graph state.
+
+    Returns:
+        ``"continue"`` when another round should run, otherwise ``"stop"``.
+    """
     round_no = state.get("round_no", 0)
     max_rounds = state.get("max_rounds", 3)
 

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/evidence_builder.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/evidence_builder.py
@@ -1,3 +1,5 @@
+"""Evidence builder node that materializes report evidence records."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -9,6 +11,18 @@ from ..graph_state import SimulationGraphState
 
 
 def make_evidence_builder_node(evidence_store: EvidenceStore) -> Any:
+    """Create the evidence builder node for the simulation graph.
+
+    The evidence builder node derives evidence records from final world state,
+    participant state, and outcomes for downstream report generation.
+
+    Args:
+        evidence_store: Evidence storage backend used to persist records.
+
+    Returns:
+        A LangGraph-compatible node function.
+    """
+
     def node(state: SimulationGraphState) -> dict[str, Any]:
         run_meta = state.get("run_meta")
         if run_meta is None:

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/intake_planner.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/intake_planner.py
@@ -1,3 +1,5 @@
+"""Intake planner node for extracting structured simulation intent."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -29,6 +31,19 @@ def make_intake_planner_node(
     event_store: EventStore,
     structured_llm: StructuredLLM,
 ) -> Any:
+    """Create the intake planner node for the simulation graph.
+
+    The intake planner node transforms a raw user query into a validated intake
+    plan that downstream nodes can consume.
+
+    Args:
+        event_store: Event store used to publish intake planning events.
+        structured_llm: Structured LLM transport used to produce the intake plan.
+
+    Returns:
+        A LangGraph-compatible node function.
+    """
+
     def node(state: SimulationGraphState) -> dict[str, Any]:
         from datetime import datetime, timezone
         from uuid import uuid4

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/participant_decider.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/participant_decider.py
@@ -1,3 +1,5 @@
+"""Participant decision node for producing market action proposals."""
+
 from __future__ import annotations
 
 # pyright: reportMissingImports=false
@@ -73,6 +75,18 @@ def make_participant_decider_node(
     *,
     policy_registry: Callable[[str], ParticipantPolicy] | None = None,
 ) -> Any:
+    """Create the participant decider node for the simulation graph.
+
+    The participant decider node applies role policies to generate per-
+    participant market actions for the current round.
+
+    Args:
+        event_store: Event store used to publish decision events.
+        policy_registry: Optional role-to-policy resolver.
+
+    Returns:
+        A LangGraph-compatible node function.
+    """
     policy_lookup = policy_registry or get_default_policy
 
     def node(state: SimulationGraphState) -> dict[str, Any]:

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/report_renderer.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/report_renderer.py
@@ -1,3 +1,5 @@
+"""Report renderer node that converts claims into final markdown output."""
+
 from __future__ import annotations
 
 # pyright: reportMissingImports=false
@@ -24,6 +26,18 @@ _SECTION_TITLES: dict[str, str] = {
 
 
 def make_report_renderer_node(event_store: EventStore) -> Any:
+    """Create the report renderer node for the simulation graph.
+
+    The report renderer node organizes validated claims into report sections and
+    emits a rendered report event.
+
+    Args:
+        event_store: Event store used to publish report rendering events.
+
+    Returns:
+        A LangGraph-compatible node function.
+    """
+
     def node(state: SimulationGraphState) -> dict[str, Any]:
         run_meta = state.get("run_meta")
         if run_meta is None:

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/report_writer.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/report_writer.py
@@ -1,5 +1,7 @@
 # pyright: reportMissingImports=false
 
+"""Report writer node that transforms evidence into report claims."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -50,6 +52,19 @@ def _claim_json(
 
 
 def make_report_writer_node(evidence_store: EvidenceStore, event_store: EventStore) -> Any:
+    """Create the report writer node for the simulation graph.
+
+    The report writer node composes citation-ready report claims from evidence
+    records and current simulation state.
+
+    Args:
+        evidence_store: Evidence store used to query generated evidence.
+        event_store: Event store used to publish report writing events.
+
+    Returns:
+        A LangGraph-compatible node function.
+    """
+
     def node(state: SimulationGraphState) -> dict[str, Any]:
         run_meta = state.get("run_meta")
         if run_meta is None:

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/round_resolver.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/round_resolver.py
@@ -1,3 +1,5 @@
+"""Round resolver node that applies actions and updates world state."""
+
 from __future__ import annotations
 
 # pyright: reportMissingImports=false
@@ -48,6 +50,18 @@ def _copy_segment(
 
 
 def make_round_resolver_node(event_store: EventStore) -> Any:
+    """Create the round resolver node for the simulation graph.
+
+    The round resolver node validates participant actions, resolves simulated
+    transactions, and emits a round outcome event.
+
+    Args:
+        event_store: Event store used to publish round resolution events.
+
+    Returns:
+        A LangGraph-compatible node function.
+    """
+
     def node(state: SimulationGraphState) -> dict[str, Any]:
         run_meta = state.get("run_meta")
         if run_meta is None:

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/round_summarizer.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/round_summarizer.py
@@ -1,3 +1,5 @@
+"""Round summarizer node that emits final simulation summary metrics."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -9,6 +11,18 @@ from ..graph_state import SimulationGraphState
 
 
 def make_round_summarizer_node(event_store: EventStore) -> Any:
+    """Create the round summarizer node for the simulation graph.
+
+    The round summarizer node aggregates final world and participant snapshots
+    into a simulation completion event.
+
+    Args:
+        event_store: Event store used to publish completion summaries.
+
+    Returns:
+        A LangGraph-compatible node function.
+    """
+
     def node(state: SimulationGraphState) -> dict[str, Any]:
         run_meta = state.get("run_meta")
         if run_meta is None:

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/scenario_builder.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/scenario_builder.py
@@ -1,3 +1,7 @@
+# pyright: reportMissingImports=false
+
+"""Scenario builder node for assembling scenario and roster inputs."""
+
 from __future__ import annotations
 
 from datetime import date, datetime, timezone
@@ -23,6 +27,14 @@ _SENTIMENT_SET = {"bearish", "neutral", "bullish"}
 
 
 class ScenarioSelection(BaseModel):
+    """Structured LLM output used to select shocks and participant buckets.
+
+    Attributes:
+        scenario_name: Human-readable scenario name.
+        selected_shock_keys: Shock catalog keys selected for the scenario.
+        roster_buckets: Role bucket specifications for participant generation.
+    """
+
     model_config = ConfigDict(frozen=True)
 
     scenario_name: str
@@ -31,6 +43,16 @@ class ScenarioSelection(BaseModel):
 
 
 def compute_max_rounds(horizon_months: int, shock_count: int, analysis_mode: str) -> int:
+    """Compute the simulation round limit from intake characteristics.
+
+    Args:
+        horizon_months: Requested simulation horizon in months.
+        shock_count: Number of selected shocks.
+        analysis_mode: Intake analysis mode.
+
+    Returns:
+        Bounded max round count for the simulation.
+    """
     base = ceil(horizon_months / 3)
     if shock_count >= 2:
         base += 1
@@ -183,6 +205,20 @@ def make_scenario_builder_node(
     structured_llm: StructuredLLM,
     snapshot_reader: SnapshotReader,
 ) -> Any:
+    """Create the scenario builder node for the simulation graph.
+
+    The scenario builder node resolves target districts, selects shocks, builds
+    a participant roster, and emits a scenario-built event.
+
+    Args:
+        event_store: Event store used to publish scenario construction events.
+        structured_llm: Structured LLM transport used for scenario selection.
+        snapshot_reader: Snapshot reader used to obtain coverage constraints.
+
+    Returns:
+        A LangGraph-compatible node function.
+    """
+
     def node(state: SimulationGraphState) -> dict[str, Any]:
         intake_plan_raw = state.get("intake_plan")
         if intake_plan_raw is None:

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/world_initializer.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/world_initializer.py
@@ -1,3 +1,7 @@
+# pyright: reportMissingImports=false
+
+"""World initializer node for seeding simulation world and participants."""
+
 from __future__ import annotations
 
 import hashlib
@@ -159,6 +163,19 @@ def make_world_initializer_node(
     event_store: EventStore,
     snapshot_reader: SnapshotReader,
 ) -> Any:
+    """Create the world initializer node for the simulation graph.
+
+    The world initializer node builds initial segment and participant states from
+    snapshot-backed metrics, then emits initialization metadata.
+
+    Args:
+        event_store: Event store used to publish initialization events.
+        snapshot_reader: Snapshot reader used to retrieve baseline data.
+
+    Returns:
+        A LangGraph-compatible node function.
+    """
+
     def node(state: SimulationGraphState) -> dict[str, Any]:
         scenario = state.get("scenario")
         if scenario is None:

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/policies/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/policies/__init__.py
@@ -1,3 +1,5 @@
+"""Participant policy interfaces and default heuristic implementations."""
+
 from __future__ import annotations
 
 from .heuristic import BrokerPolicy, BuyerPolicy, InvestorPolicy, LandlordPolicy, TenantPolicy

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/policies/heuristic.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/policies/heuristic.py
@@ -1,3 +1,5 @@
+"""Heuristic participant policies for simulation action selection."""
+
 from __future__ import annotations
 
 # pyright: reportMissingImports=false
@@ -37,7 +39,18 @@ def _proposal(
 
 
 class BuyerPolicy(ParticipantPolicy):
+    """Policy for primary buyers reacting to sentiment and trend."""
+
     def decide(self, participant: ParticipantState, context: DecisionContext) -> ActionProposal:
+        """Choose a buyer action for the current round.
+
+        Args:
+            participant: Buyer participant state.
+            context: Decision context for this round.
+
+        Returns:
+            Action proposal for the buyer.
+        """
         segment = context.segment
         should_buy = segment.sentiment_index > 0.5 and segment.price_trend != "down" and participant.capital > 0
         intensity = participant.risk_tolerance * segment.sentiment_index
@@ -62,7 +75,18 @@ class BuyerPolicy(ParticipantPolicy):
 
 
 class InvestorPolicy(ParticipantPolicy):
+    """Policy for investors balancing momentum and downside risk."""
+
     def decide(self, participant: ParticipantState, context: DecisionContext) -> ActionProposal:
+        """Choose an investor action for the current round.
+
+        Args:
+            participant: Investor participant state.
+            context: Decision context for this round.
+
+        Returns:
+            Action proposal for the investor.
+        """
         segment = context.segment
 
         if segment.price_trend == "up" and segment.sentiment_index > 0.6:
@@ -96,7 +120,18 @@ class InvestorPolicy(ParticipantPolicy):
 
 
 class TenantPolicy(ParticipantPolicy):
+    """Policy for tenants in v0.1, currently non-trading."""
+
     def decide(self, participant: ParticipantState, context: DecisionContext) -> ActionProposal:
+        """Choose a tenant action for the current round.
+
+        Args:
+            participant: Tenant participant state.
+            context: Decision context for this round.
+
+        Returns:
+            Action proposal for the tenant.
+        """
         return _proposal(
             participant=participant,
             context=context,
@@ -107,7 +142,18 @@ class TenantPolicy(ParticipantPolicy):
 
 
 class LandlordPolicy(ParticipantPolicy):
+    """Policy for landlords focusing on risk-off selling signals."""
+
     def decide(self, participant: ParticipantState, context: DecisionContext) -> ActionProposal:
+        """Choose a landlord action for the current round.
+
+        Args:
+            participant: Landlord participant state.
+            context: Decision context for this round.
+
+        Returns:
+            Action proposal for the landlord.
+        """
         sentiment_index = context.segment.sentiment_index
         intensity = (1.0 - sentiment_index) * participant.risk_tolerance
 
@@ -130,7 +176,18 @@ class LandlordPolicy(ParticipantPolicy):
 
 
 class BrokerPolicy(ParticipantPolicy):
+    """Policy for brokers in v0.1, currently non-trading."""
+
     def decide(self, participant: ParticipantState, context: DecisionContext) -> ActionProposal:
+        """Choose a broker action for the current round.
+
+        Args:
+            participant: Broker participant state.
+            context: Decision context for this round.
+
+        Returns:
+            Action proposal for the broker.
+        """
         return _proposal(
             participant=participant,
             context=context,

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/policies/protocol.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/policies/protocol.py
@@ -1,3 +1,5 @@
+"""Protocol definition for participant action policies."""
+
 from __future__ import annotations
 
 # pyright: reportMissingImports=false
@@ -11,4 +13,17 @@ from ..schemas.round import DecisionContext
 
 @runtime_checkable
 class ParticipantPolicy(Protocol):
-    def decide(self, participant: ParticipantState, context: DecisionContext) -> ActionProposal: ...
+    """Interface for role-specific participant decision policies."""
+
+    def decide(self, participant: ParticipantState, context: DecisionContext) -> ActionProposal:
+        """Return an action proposal for a participant in context.
+
+        Args:
+            participant: Participant state to decide for.
+            context: Round decision context.
+
+        Returns:
+            Proposed participant action.
+        """
+
+        ...

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/policies/registry.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/policies/registry.py
@@ -1,3 +1,5 @@
+"""Registry for resolving default participant policies by role."""
+
 from __future__ import annotations
 
 from .heuristic import BrokerPolicy, BuyerPolicy, InvestorPolicy, LandlordPolicy, TenantPolicy
@@ -13,6 +15,17 @@ _POLICY_MAP: dict[str, ParticipantPolicy] = {
 
 
 def get_default_policy(role: str) -> ParticipantPolicy:
+    """Return the default policy instance for a participant role.
+
+    Args:
+        role: Participant role key.
+
+    Returns:
+        Policy instance for the role.
+
+    Raises:
+        ValueError: When no default policy is registered for the role.
+    """
     policy = _POLICY_MAP.get(role)
     if policy is None:
         raise ValueError(f"No default policy for role: {role}")

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/ports/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/ports/__init__.py
@@ -1,1 +1,3 @@
+"""External data-access ports consumed by simulation nodes."""
+
 from __future__ import annotations

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/ports/snapshot_reader.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/ports/snapshot_reader.py
@@ -1,3 +1,7 @@
+# pyright: reportMissingImports=false
+
+"""Protocols for reading snapshot coverage, metrics, and forecasts."""
+
 from __future__ import annotations
 
 from typing import Protocol, Sequence, runtime_checkable
@@ -9,6 +13,16 @@ from younggeul_core.state.simulation import SnapshotRef
 
 
 class SnapshotCoverage(BaseModel):
+    """Coverage metadata describing data available in a snapshot.
+
+    Attributes:
+        available_gu_codes: District codes available in the snapshot.
+        available_gu_names: Mapping of district code to district name.
+        min_period: Earliest available period in YYYY-MM format.
+        max_period: Latest available period in YYYY-MM format.
+        record_count: Number of source records represented.
+    """
+
     model_config = ConfigDict(frozen=True)
 
     available_gu_codes: list[str]
@@ -20,16 +34,50 @@ class SnapshotCoverage(BaseModel):
 
 @runtime_checkable
 class SnapshotReader(Protocol):
-    def get_coverage(self, snapshot: SnapshotRef) -> SnapshotCoverage: ...
+    """Interface for reading simulation input data from snapshots."""
+
+    def get_coverage(self, snapshot: SnapshotRef) -> SnapshotCoverage:
+        """Return available geography and period coverage for a snapshot.
+
+        Args:
+            snapshot: Snapshot reference to inspect.
+
+        Returns:
+            Snapshot coverage metadata.
+        """
+
+        ...
 
     def get_latest_metrics(
         self,
         snapshot: SnapshotRef,
         gu_codes: Sequence[str] | None = None,
-    ) -> list[GoldDistrictMonthlyMetrics]: ...
+    ) -> list[GoldDistrictMonthlyMetrics]:
+        """Return latest district metrics for selected districts.
+
+        Args:
+            snapshot: Snapshot reference to read from.
+            gu_codes: Optional district codes to filter by.
+
+        Returns:
+            Latest district metrics from the snapshot.
+        """
+
+        ...
 
     def get_baseline_forecasts(
         self,
         snapshot: SnapshotRef,
         gu_codes: Sequence[str] | None = None,
-    ) -> list[BaselineForecast]: ...
+    ) -> list[BaselineForecast]:
+        """Return baseline forecasts for selected districts.
+
+        Args:
+            snapshot: Snapshot reference to read from.
+            gu_codes: Optional district codes to filter by.
+
+        Returns:
+            Baseline forecasts from the snapshot.
+        """
+
+        ...

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/replay/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/replay/__init__.py
@@ -1,3 +1,5 @@
+"""Replay engine exports for reconstructing simulation state from events."""
+
 from __future__ import annotations
 
 from .engine import HANDLERS, ReplayContext, ReplayEngine, ReplayError, ReplayResult

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/replay/engine.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/replay/engine.py
@@ -1,3 +1,5 @@
+"""Replay engine for rebuilding simulation state from emitted events."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -13,6 +15,18 @@ from ..schemas.intake import IntakePlan
 
 @dataclass(frozen=True)
 class ReplayResult:
+    """Replay output containing reconstructed state and summary metadata.
+
+    Attributes:
+        state: Reconstructed simulation graph state.
+        completeness: Replay completeness level.
+        event_count: Number of processed events.
+        warnings: Replay warnings accumulated during processing.
+        world_summary: World summary extracted from initialization event.
+        participant_count: Participant count extracted from initialization event.
+        anchor_period: Anchor period extracted from initialization event.
+    """
+
     state: SimulationGraphState
     completeness: Literal["partial", "full"]
     event_count: int
@@ -24,10 +38,18 @@ class ReplayResult:
 
 @dataclass(frozen=True)
 class ReplayContext:
+    """Replay options controlling strictness and error handling.
+
+    Attributes:
+        strict: Whether unknown event types should raise replay errors.
+    """
+
     strict: bool = True
 
 
 class ReplayError(Exception):
+    """Raised when replay cannot process an event payload."""
+
     pass
 
 
@@ -195,10 +217,24 @@ HANDLERS: dict[str, EventHandler] = {
 
 
 class ReplayEngine:
+    """Engine that replays simulation events into a graph-state snapshot."""
+
     def __init__(self, event_store: EventStore) -> None:
         self._event_store = event_store
 
     def replay(self, run_id: str, *, strict: bool = True) -> ReplayResult:
+        """Replay a simulation run from stored events.
+
+        Args:
+            run_id: Simulation run identifier to replay.
+            strict: Whether unknown event types should raise errors.
+
+        Returns:
+            Replay result with reconstructed state and replay metadata.
+
+        Raises:
+            ReplayError: When replay fails under strict processing.
+        """
         context = ReplayContext(strict=strict)
         events = self._event_store.get_events(run_id)
 

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/__init__.py
@@ -1,1 +1,3 @@
+"""Simulation schema models for planning, rounds, and reporting."""
+
 from __future__ import annotations

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/intake.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/intake.py
@@ -1,3 +1,5 @@
+"""Intake planning schema for simulation query interpretation."""
+
 from __future__ import annotations
 
 from typing import Literal
@@ -6,6 +8,22 @@ from pydantic import BaseModel, Field
 
 
 class IntakePlan(BaseModel, frozen=True):
+    """Structured intake output produced from user simulation intent.
+
+    Attributes:
+        user_query: Original user query text.
+        objective: Primary simulation objective summary.
+        analysis_mode: Requested analysis mode.
+        geography_hint: Optional district hint from the query.
+        segment_hint: Optional property segment hint.
+        horizon_months: Requested simulation horizon in months.
+        requested_shocks: Requested shock labels from the query.
+        participant_focus: Participant groups to emphasize.
+        constraints: Explicit user constraints.
+        assumptions: User-provided assumptions.
+        ambiguities: Unresolved ambiguities from intake parsing.
+    """
+
     user_query: str
     objective: str
     analysis_mode: Literal["baseline", "stress", "compare"]

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/participant_roster.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/participant_roster.py
@@ -1,3 +1,5 @@
+"""Participant roster schemas for deterministic agent generation."""
+
 from __future__ import annotations
 
 from typing import Literal
@@ -6,6 +8,20 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class RoleBucketSpec(BaseModel):
+    """Role bucket definition used when creating participants.
+
+    Attributes:
+        role: Participant role represented by the bucket.
+        count: Number of participants to generate for the role.
+        capital_min_multiplier: Minimum capital multiplier vs reference price.
+        capital_max_multiplier: Maximum capital multiplier vs reference price.
+        holdings_min: Minimum initial holdings.
+        holdings_max: Maximum initial holdings.
+        risk_min: Minimum risk tolerance.
+        risk_max: Maximum risk tolerance.
+        sentiment_bias: Initial sentiment bias for generated participants.
+    """
+
     model_config = ConfigDict(frozen=True)
 
     role: Literal["buyer", "investor", "tenant", "landlord", "broker"]
@@ -20,6 +36,13 @@ class RoleBucketSpec(BaseModel):
 
 
 class ParticipantRosterSpec(BaseModel):
+    """Roster specification describing participant generation inputs.
+
+    Attributes:
+        seed: Deterministic seed component for roster generation.
+        buckets: Role buckets to materialize into participants.
+    """
+
     model_config = ConfigDict(frozen=True)
 
     seed: str

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/report.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/report.py
@@ -1,3 +1,5 @@
+"""Schemas for rendered report entries, sections, and documents."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -6,6 +8,17 @@ from pydantic import BaseModel
 
 
 class RenderedClaimEntry(BaseModel, frozen=True):
+    """Rendered claim row included in a report section.
+
+    Attributes:
+        claim_id: Claim identifier.
+        claim_type: Claim category.
+        statement: Human-readable claim statement.
+        metrics: Optional structured metrics for the claim.
+        evidence_count: Number of supporting evidence items.
+        gate_status: Citation gate status for the claim.
+    """
+
     claim_id: str
     claim_type: str
     statement: str
@@ -15,6 +28,15 @@ class RenderedClaimEntry(BaseModel, frozen=True):
 
 
 class RenderedSection(BaseModel, frozen=True):
+    """Rendered report section grouping related claims.
+
+    Attributes:
+        section_key: Section key used for ordering and routing.
+        title: Section display title.
+        claims: Claims included in the section.
+        claim_count: Number of claims in the section.
+    """
+
     section_key: str
     title: str
     claims: list[RenderedClaimEntry]
@@ -22,6 +44,19 @@ class RenderedSection(BaseModel, frozen=True):
 
 
 class RenderedReport(BaseModel, frozen=True):
+    """Fully rendered simulation report output.
+
+    Attributes:
+        run_id: Simulation run identifier.
+        round_no: Final round number represented by the report.
+        rendered_at: Report generation timestamp.
+        total_claims: Number of total generated claims.
+        passed_claims: Number of claims that passed citation checks.
+        failed_claims: Number of claims that failed citation checks.
+        sections: Rendered report sections.
+        markdown: Full markdown rendering of the report.
+    """
+
     run_id: str
     round_no: int
     rendered_at: datetime

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/round.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/schemas/round.py
@@ -1,3 +1,5 @@
+"""Round-resolution schemas and action validation helpers."""
+
 from __future__ import annotations
 
 # pyright: reportMissingImports=false
@@ -10,6 +12,17 @@ V01_ACTION_TYPES: frozenset[str] = frozenset({"buy", "sell", "hold"})
 
 
 class DecisionContext(BaseModel, frozen=True):
+    """Context provided to participant policies for round decisions.
+
+    Attributes:
+        round_no: Current round number.
+        segment: Target segment state for decisioning.
+        scenario: Active simulation scenario.
+        last_outcome: Previous round outcome when available.
+        active_shocks: Active shocks affecting the round.
+        governance_modifiers: Governance modifiers applied to decisions.
+    """
+
     round_no: int = Field(ge=0)
     segment: SegmentState
     scenario: ScenarioSpec
@@ -19,6 +32,16 @@ class DecisionContext(BaseModel, frozen=True):
 
 
 class SegmentDelta(BaseModel, frozen=True):
+    """Resolved changes applied to a segment during a round.
+
+    Attributes:
+        gu_code: Segment district code.
+        price_change_pct: Relative median-price change for the segment.
+        volume_change: Net volume change for the segment.
+        new_median_price: Updated median price after resolution.
+        new_volume: Updated volume after resolution.
+    """
+
     gu_code: str
     price_change_pct: float
     volume_change: int
@@ -28,12 +51,33 @@ class SegmentDelta(BaseModel, frozen=True):
     @field_validator("price_change_pct")
     @classmethod
     def validate_price_change_pct(cls, value: float) -> float:
+        """Validate price change bounds for v0.1 resolver outputs.
+
+        Args:
+            value: Candidate price change percentage.
+
+        Returns:
+            Validated price change percentage.
+
+        Raises:
+            ValueError: When the percentage is outside allowed bounds.
+        """
         if not -0.05 <= value <= 0.05:
             raise ValueError("price_change_pct must be between -0.05 and 0.05")
         return value
 
 
 class ParticipantDelta(BaseModel, frozen=True):
+    """Resolved capital and holdings changes for one participant.
+
+    Attributes:
+        participant_id: Participant identifier.
+        capital_change: Capital delta applied in this round.
+        holdings_change: Holdings delta applied in this round.
+        new_capital: Participant capital after applying changes.
+        new_holdings: Participant holdings after applying changes.
+    """
+
     participant_id: str
     capital_change: int
     holdings_change: int
@@ -42,6 +86,16 @@ class ParticipantDelta(BaseModel, frozen=True):
 
 
 class RoundResolvedPayload(BaseModel, frozen=True):
+    """Event payload describing outcomes of one resolved round.
+
+    Attributes:
+        round_no: Resolved round number.
+        segment_deltas: Segment-level deltas keyed by district code.
+        participant_deltas: Participant-level deltas keyed by participant ID.
+        transactions_count: Number of resolved transactions.
+        summary: Human-readable round summary.
+    """
+
     round_no: int = Field(ge=0)
     segment_deltas: dict[str, SegmentDelta]
     participant_deltas: dict[str, ParticipantDelta]
@@ -50,5 +104,13 @@ class RoundResolvedPayload(BaseModel, frozen=True):
 
 
 def validate_v01_action(action: ActionProposal) -> None:
+    """Validate that an action uses one of the supported v0.1 action types.
+
+    Args:
+        action: Action proposal to validate.
+
+    Raises:
+        ValueError: When the action type is not supported in v0.1.
+    """
     if action.action_type not in V01_ACTION_TYPES:
         raise ValueError(f"Unsupported v0.1 action_type: {action.action_type}")

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/tracing.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/tracing.py
@@ -1,3 +1,5 @@
+"""Tracing initialization and span helpers for simulation nodes."""
+
 from __future__ import annotations
 
 import os
@@ -16,6 +18,8 @@ def _is_enabled() -> bool:
 
 
 def init_tracing() -> None:
+    """Initialize OpenTelemetry tracing when OTEL is enabled."""
+
     global _initialized
 
     if _initialized or not _is_enabled():
@@ -42,6 +46,11 @@ def init_tracing() -> None:
 
 
 def get_tracer() -> Tracer:
+    """Return the simulation tracer instance.
+
+    Returns:
+        OpenTelemetry tracer for simulation spans.
+    """
     return trace.get_tracer(_TRACER_NAME)
 
 
@@ -53,6 +62,17 @@ def trace_node(
     round_no: int | None = None,
     attributes: dict[str, Any] | None = None,
 ) -> Iterator[Span]:
+    """Create a tracing span around simulation node execution.
+
+    Args:
+        node_name: Name of the node being traced.
+        run_id: Optional simulation run identifier.
+        round_no: Optional simulation round number.
+        attributes: Optional additional span attributes.
+
+    Yields:
+        Active span context for the node execution block.
+    """
     tracer = get_tracer()
 
     span_attributes: dict[str, Any] = {"node.name": node_name}

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/snapshot.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/snapshot.py
@@ -1,3 +1,5 @@
+"""Snapshot publishing and resolution helpers for Gold district metrics."""
+
 from __future__ import annotations
 
 import hashlib
@@ -47,6 +49,15 @@ def _load_manifest(manifest_path: Path) -> SnapshotManifest:
 
 
 def publish_snapshot(gold_rows: list[GoldDistrictMonthlyMetrics], base_dir: Path) -> SnapshotRef:
+    """Publish Gold metrics as an immutable dataset snapshot.
+
+    Args:
+        gold_rows: Gold district monthly metric rows to persist.
+        base_dir: Root directory where snapshot folders are stored.
+
+    Returns:
+        Reference metadata for the newly published snapshot.
+    """
     sorted_rows = _sorted_gold_rows(gold_rows)
     jsonl_content = _jsonl_bytes(sorted_rows)
     table_hash = hashlib.sha256(jsonl_content).hexdigest()
@@ -84,6 +95,19 @@ def publish_snapshot(gold_rows: list[GoldDistrictMonthlyMetrics], base_dir: Path
 
 
 def resolve_snapshot(snapshot_id: str, base_dir: Path) -> tuple[SnapshotManifest, list[GoldDistrictMonthlyMetrics]]:
+    """Resolve a snapshot manifest and its Gold rows.
+
+    Args:
+        snapshot_id: Snapshot identifier or ``"latest"``.
+        base_dir: Root directory containing snapshot folders.
+
+    Returns:
+        The validated snapshot manifest and parsed Gold metric rows.
+
+    Raises:
+        FileNotFoundError: If the requested snapshot cannot be found.
+        ValueError: If manifest or table integrity checks fail.
+    """
     if snapshot_id == "latest":
         latest_manifest: SnapshotManifest | None = None
         latest_snapshot_dir: Path | None = None

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/__init__.py
@@ -1,1 +1,1 @@
-# transforms package
+"""Transform layer modules for Bronze-to-Silver-to-Gold normalization."""

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/gold_district.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/gold_district.py
@@ -1,3 +1,5 @@
+"""Gold aggregation from Silver transactions, rates, and migration."""
+
 from __future__ import annotations
 
 from collections import defaultdict
@@ -56,6 +58,16 @@ def aggregate_district_monthly(
     interest_rates: list[SilverInterestRate] | None = None,
     migrations: list[SilverMigration] | None = None,
 ) -> list[GoldDistrictMonthlyMetrics]:
+    """Aggregate district-level monthly Gold metrics.
+
+    Args:
+        transactions: Silver apartment transactions to aggregate.
+        interest_rates: Optional Silver interest-rate rows used for enrichment.
+        migrations: Optional Silver migration rows used for enrichment.
+
+    Returns:
+        District monthly Gold metrics derived from the provided Silver inputs.
+    """
     grouped = _group_transactions(transactions)
     if not grouped:
         return []

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/gold_enrichment.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/gold_enrichment.py
@@ -1,3 +1,5 @@
+"""Gold trend enrichment helpers for district monthly metrics."""
+
 from __future__ import annotations
 
 from younggeul_core.state.gold import GoldDistrictMonthlyMetrics
@@ -32,6 +34,12 @@ def enrich_district_monthly_trends(
 
     Requires metrics sorted by (gu_code, period). Returns new list with
     trend fields populated where prior period data exists.
+
+    Args:
+        metrics: District monthly metrics to enrich with trend percentages.
+
+    Returns:
+        New metric rows with MoM and YoY trend fields populated when possible.
     """
     sorted_metrics = sorted(metrics, key=lambda metric: (metric.gu_code, metric.period))
     lookup = {(metric.gu_code, metric.period): metric for metric in sorted_metrics}

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py
@@ -1,3 +1,5 @@
+"""Silver normalization for apartment transaction Bronze records."""
+
 from __future__ import annotations
 
 from datetime import date
@@ -37,6 +39,14 @@ SEOUL_GU_CODES: dict[str, str] = {
 
 
 def parse_deal_amount(raw: str | None) -> int | None:
+    """Parse 거래금액 text into KRW integer value.
+
+    Args:
+        raw: Raw deal amount string from Bronze data.
+
+    Returns:
+        Parsed amount in KRW, or ``None`` when parsing fails.
+    """
     if raw is None:
         return None
     cleaned = raw.replace(",", "").strip()
@@ -50,6 +60,16 @@ def parse_deal_amount(raw: str | None) -> int | None:
 
 
 def parse_deal_date(year: str | None, month: str | None, day: str | None) -> date | None:
+    """Parse year, month, and day strings into a date.
+
+    Args:
+        year: Raw year value.
+        month: Raw month value.
+        day: Raw day value.
+
+    Returns:
+        Parsed transaction date, or ``None`` if invalid.
+    """
     y = parse_int(year)
     m = parse_int(month)
     d = parse_int(day)
@@ -62,6 +82,14 @@ def parse_deal_date(year: str | None, month: str | None, day: str | None) -> dat
 
 
 def parse_int(raw: str | None) -> int | None:
+    """Parse a stripped string into an integer.
+
+    Args:
+        raw: Raw numeric string.
+
+    Returns:
+        Parsed integer value, or ``None`` if invalid.
+    """
     if raw is None:
         return None
     cleaned = raw.strip()
@@ -74,6 +102,14 @@ def parse_int(raw: str | None) -> int | None:
 
 
 def parse_decimal(raw: str | None) -> Decimal | None:
+    """Parse a stripped string into a Decimal.
+
+    Args:
+        raw: Raw decimal string.
+
+    Returns:
+        Parsed decimal value, or ``None`` if invalid.
+    """
     if raw is None:
         return None
     cleaned = raw.strip()
@@ -86,24 +122,56 @@ def parse_decimal(raw: str | None) -> Decimal | None:
 
 
 def derive_gu_code(sgg_code: str | None) -> str | None:
+    """Resolve a Seoul 구 code from the provided sigungu code.
+
+    Args:
+        sgg_code: Raw sigungu code.
+
+    Returns:
+        Valid Seoul 구 code, or ``None`` when not supported.
+    """
     if sgg_code in SEOUL_GU_CODES:
         return sgg_code
     return None
 
 
 def derive_gu_name(gu_code: str | None) -> str | None:
+    """Resolve a Seoul 구 name from a 구 code.
+
+    Args:
+        gu_code: Seoul 구 code.
+
+    Returns:
+        Matched 구 name, or ``None`` when unknown.
+    """
     if gu_code is None:
         return None
     return SEOUL_GU_CODES.get(gu_code)
 
 
 def is_cancelled(cancel_deal_type: str | None) -> bool:
+    """Determine whether a transaction is marked as canceled.
+
+    Args:
+        cancel_deal_type: Raw cancel marker from Bronze data.
+
+    Returns:
+        ``True`` when cancellation marker is present, otherwise ``False``.
+    """
     if cancel_deal_type is None:
         return False
     return bool(cancel_deal_type.strip())
 
 
 def generate_transaction_id(bronze: BronzeAptTransaction) -> str:
+    """Generate a deterministic transaction identifier.
+
+    Args:
+        bronze: Source Bronze apartment transaction record.
+
+    Returns:
+        SHA-256 hash-based transaction identifier.
+    """
     payload = [
         {
             "sgg_code": bronze.sgg_code,
@@ -120,6 +188,15 @@ def generate_transaction_id(bronze: BronzeAptTransaction) -> str:
 
 
 def compute_quality_score(bronze: BronzeAptTransaction, silver_fields: dict[str, object]) -> SilverDataQualityScore:
+    """Compute Silver data quality scores for one transaction.
+
+    Args:
+        bronze: Source Bronze apartment transaction record.
+        silver_fields: Parsed Silver field values used for scoring.
+
+    Returns:
+        Completeness, consistency, and overall quality score values.
+    """
     _ = bronze
 
     completeness_fields = (
@@ -184,6 +261,14 @@ def _parse_cancel_date(raw: str | None) -> date | None:
 
 
 def normalize_apt_transaction(bronze: BronzeAptTransaction) -> SilverAptTransaction | None:
+    """Normalize one Bronze apartment transaction into Silver shape.
+
+    Args:
+        bronze: Source Bronze apartment transaction record.
+
+    Returns:
+        Normalized Silver apartment transaction, or ``None`` if invalid.
+    """
     gu_code = derive_gu_code(bronze.sgg_code)
     if gu_code is None:
         return None
@@ -241,6 +326,14 @@ def normalize_apt_transaction(bronze: BronzeAptTransaction) -> SilverAptTransact
 
 
 def normalize_batch(records: list[BronzeAptTransaction]) -> list[SilverAptTransaction]:
+    """Normalize a batch of Bronze apartment transactions.
+
+    Args:
+        records: Bronze apartment transaction records.
+
+    Returns:
+        Successfully normalized Silver apartment transactions.
+    """
     normalized: list[SilverAptTransaction] = []
     for record in records:
         silver = normalize_apt_transaction(record)

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/silver_macro.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/silver_macro.py
@@ -1,3 +1,5 @@
+"""Silver normalization for macroeconomic Bronze records."""
+
 from __future__ import annotations
 
 import re
@@ -11,6 +13,14 @@ _PERIOD_PATTERN = re.compile(r"^\d{4}-(0[1-9]|1[0-2])$")
 
 
 def parse_date(raw: str | None) -> date | None:
+    """Parse an ISO-formatted date string.
+
+    Args:
+        raw: Raw date string.
+
+    Returns:
+        Parsed date value, or ``None`` when invalid.
+    """
     if raw is None:
         return None
     cleaned = raw.strip()
@@ -23,6 +33,14 @@ def parse_date(raw: str | None) -> date | None:
 
 
 def parse_decimal_2dp(raw: str | None) -> Decimal | None:
+    """Parse decimal text and quantize to two decimal places.
+
+    Args:
+        raw: Raw decimal value string.
+
+    Returns:
+        Parsed and quantized decimal value, or ``None`` if invalid.
+    """
     if raw is None:
         return None
     cleaned = raw.strip()
@@ -35,6 +53,14 @@ def parse_decimal_2dp(raw: str | None) -> Decimal | None:
 
 
 def parse_count(raw: str | None) -> int | None:
+    """Parse count text that may include comma separators.
+
+    Args:
+        raw: Raw count string.
+
+    Returns:
+        Parsed integer count, or ``None`` when parsing fails.
+    """
     if raw is None:
         return None
     cleaned = raw.replace(",", "").strip()
@@ -47,6 +73,15 @@ def parse_count(raw: str | None) -> int | None:
 
 
 def build_period(year: str | None, month: str | None) -> str | None:
+    """Build a ``YYYY-MM`` period string from year and month fields.
+
+    Args:
+        year: Raw year string.
+        month: Raw month string.
+
+    Returns:
+        Validated period string, or ``None`` when input is invalid.
+    """
     if year is None or month is None:
         return None
     year_clean = year.strip()
@@ -60,6 +95,14 @@ def build_period(year: str | None, month: str | None) -> str | None:
 
 
 def normalize_interest_rate(bronze: BronzeInterestRate) -> SilverInterestRate | None:
+    """Normalize one Bronze interest-rate record.
+
+    Args:
+        bronze: Source Bronze interest-rate record.
+
+    Returns:
+        Normalized Silver interest-rate record, or ``None`` if invalid.
+    """
     rate_date = parse_date(bronze.date)
     if rate_date is None:
         return None
@@ -82,6 +125,14 @@ def normalize_interest_rate(bronze: BronzeInterestRate) -> SilverInterestRate | 
 
 
 def normalize_migration(bronze: BronzeMigration) -> SilverMigration | None:
+    """Normalize one Bronze migration record.
+
+    Args:
+        bronze: Source Bronze migration record.
+
+    Returns:
+        Normalized Silver migration record, or ``None`` if invalid.
+    """
     period = build_period(bronze.year, bronze.month)
     if period is None:
         return None
@@ -113,6 +164,14 @@ def normalize_migration(bronze: BronzeMigration) -> SilverMigration | None:
 
 
 def normalize_interest_rate_batch(records: list[BronzeInterestRate]) -> list[SilverInterestRate]:
+    """Normalize a batch of Bronze interest-rate records.
+
+    Args:
+        records: Bronze interest-rate records to normalize.
+
+    Returns:
+        Successfully normalized Silver interest-rate records.
+    """
     normalized: list[SilverInterestRate] = []
     for record in records:
         silver = normalize_interest_rate(record)
@@ -122,6 +181,14 @@ def normalize_interest_rate_batch(records: list[BronzeInterestRate]) -> list[Sil
 
 
 def normalize_migration_batch(records: list[BronzeMigration]) -> list[SilverMigration]:
+    """Normalize a batch of Bronze migration records.
+
+    Args:
+        records: Bronze migration records to normalize.
+
+    Returns:
+        Successfully normalized Silver migration records.
+    """
     normalized: list[SilverMigration] = []
     for record in records:
         silver = normalize_migration(record)

--- a/core/src/younggeul_core/connectors/rate_limit.py
+++ b/core/src/younggeul_core/connectors/rate_limit.py
@@ -24,7 +24,15 @@ class RateLimiter:
 
     @property
     def min_interval(self) -> float:
-        """Return the configured minimum interval in seconds."""
+        """Return the configured minimum interval in seconds.
+
+        Args:
+            None: This property does not accept parameters.
+
+        Returns:
+            The minimum interval value in seconds.
+        """
+
         return self._min_interval
 
     def wait(self) -> None:

--- a/core/src/younggeul_core/evidence/__init__.py
+++ b/core/src/younggeul_core/evidence/__init__.py
@@ -1,3 +1,5 @@
+"""Public evidence schemas and SQL table definitions."""
+
 from younggeul_core.evidence.schemas import ClaimRecord, EvidenceRecord, GateResult
 from younggeul_core.evidence.sql import CLAIMS_TABLE_SQL, EVIDENCE_TABLE_SQL, GATE_RESULTS_TABLE_SQL
 

--- a/core/src/younggeul_core/evidence/schemas.py
+++ b/core/src/younggeul_core/evidence/schemas.py
@@ -1,3 +1,5 @@
+"""Pydantic schemas for evidence, claims, and gate evaluation records."""
+
 from datetime import datetime
 import re
 from typing import Any, Literal
@@ -9,6 +11,21 @@ _SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 class EvidenceRecord(BaseModel):
+    """Represent a single evidence item backing a generated claim.
+
+    Attributes:
+        evidence_id: Unique identifier for the evidence record.
+        dataset_snapshot_id: Snapshot identifier tied to the evidence source.
+        source_table: Source table name where the value originated.
+        source_row_hash: SHA-256 hash for the source row.
+        field_name: Name of the source field.
+        field_value: Serialized field value used as evidence.
+        field_type: Logical type of the evidence value.
+        gu_code: Optional district code associated with the evidence.
+        period: Optional reporting period associated with the evidence.
+        created_at: Timestamp when the evidence record was created.
+    """
+
     evidence_id: str
     dataset_snapshot_id: str
     source_table: str
@@ -25,18 +42,56 @@ class EvidenceRecord(BaseModel):
     @field_validator("evidence_id")
     @classmethod
     def validate_evidence_id_uuid(cls, value: str) -> str:
+        """Validate that evidence_id is a UUID string.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         UUID(value)
         return value
 
     @field_validator("dataset_snapshot_id", "source_row_hash")
     @classmethod
     def validate_sha256_hex(cls, value: str) -> str:
+        """Validate that hash-like fields are lowercase SHA-256 hex.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         if not _SHA256_HEX_RE.fullmatch(value):
             raise ValueError("must be a 64-character lowercase hex SHA-256 string")
         return value
 
 
 class ClaimRecord(BaseModel):
+    """Represent a report claim and its evidence review state.
+
+    Attributes:
+        claim_id: Unique identifier for the claim.
+        run_id: Identifier of the simulation or report run.
+        claim_json: Structured claim payload.
+        evidence_ids: Evidence identifiers referenced by the claim.
+        gate_status: Current gate status for claim verification.
+        gate_checked_at: Timestamp when the gate was last checked.
+        repair_count: Number of repair attempts applied to the claim.
+        repair_notes: Optional notes describing repairs.
+        created_at: Timestamp when the claim record was created.
+    """
+
     claim_id: str
     run_id: str
     claim_json: dict[str, Any]
@@ -52,18 +107,52 @@ class ClaimRecord(BaseModel):
     @field_validator("claim_id", "run_id")
     @classmethod
     def validate_uuid(cls, value: str) -> str:
+        """Validate that UUID-based identifiers are valid UUID strings.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         UUID(value)
         return value
 
     @field_validator("repair_count")
     @classmethod
     def validate_repair_count(cls, value: int) -> int:
+        """Validate that repair_count does not exceed the allowed limit.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         if value > 2:
             raise ValueError("repair_count must be <= 2")
         return value
 
 
 class GateResult(BaseModel):
+    """Represent the verification outcome for a claim's evidence set.
+
+    Attributes:
+        claim_id: Identifier of the evaluated claim.
+        status: Final gate outcome for the claim.
+        checked_evidence_ids: Evidence identifiers checked by the gate.
+        mismatches: Details of detected mismatches.
+        checked_at: Timestamp when gate evaluation completed.
+    """
+
     claim_id: str
     status: Literal["passed", "failed"]
     checked_evidence_ids: list[str]
@@ -75,5 +164,17 @@ class GateResult(BaseModel):
     @field_validator("claim_id")
     @classmethod
     def validate_claim_id_uuid(cls, value: str) -> str:
+        """Validate that claim_id is a UUID string.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         UUID(value)
         return value

--- a/core/src/younggeul_core/evidence/sql.py
+++ b/core/src/younggeul_core/evidence/sql.py
@@ -1,3 +1,5 @@
+"""SQL DDL statements for evidence-related storage tables."""
+
 EVIDENCE_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS evidence_records (
     evidence_id TEXT PRIMARY KEY,

--- a/core/src/younggeul_core/state/__init__.py
+++ b/core/src/younggeul_core/state/__init__.py
@@ -1,3 +1,5 @@
+"""Public state schemas for bronze, silver, gold, and simulation layers."""
+
 from .bronze import (
     BronzeAptTransaction,
     BronzeIngestManifest,

--- a/core/src/younggeul_core/state/bronze.py
+++ b/core/src/younggeul_core/state/bronze.py
@@ -1,3 +1,5 @@
+"""Bronze-layer schemas for raw ingested housing-related source data."""
+
 from datetime import datetime
 from typing import Literal
 
@@ -5,6 +7,14 @@ from pydantic import BaseModel, ConfigDict
 
 
 class BronzeIngestMeta(BaseModel):
+    """Capture shared metadata for bronze ingestion records.
+
+    Attributes:
+        ingest_timestamp: Timestamp when the record was ingested.
+        source_id: Identifier of the ingestion source.
+        raw_response_hash: Optional hash of the raw upstream response.
+    """
+
     model_config = ConfigDict(str_strip_whitespace=True, frozen=True)
 
     ingest_timestamp: datetime
@@ -13,6 +23,43 @@ class BronzeIngestMeta(BaseModel):
 
 
 class BronzeAptTransaction(BronzeIngestMeta):
+    """Represent a raw apartment transaction payload from source systems.
+
+    Attributes:
+        deal_amount: Raw deal amount string value.
+        build_year: Raw building completion year.
+        deal_year: Raw deal year value.
+        deal_month: Raw deal month value.
+        deal_day: Raw deal day value.
+        dong: Raw legal-dong name.
+        apt_name: Raw apartment complex name.
+        floor: Raw floor value.
+        area_exclusive: Raw exclusive area value.
+        jibun: Raw lot-based address.
+        regional_code: Raw regional code.
+        apt_dong: Raw apartment building-dong descriptor.
+        road_name: Raw road-name address text.
+        road_name_bonbun: Raw road-name main number.
+        road_name_bubun: Raw road-name sub number.
+        road_name_code: Raw road-name code.
+        road_name_seq: Raw road-name sequence value.
+        road_name_basement: Raw basement flag.
+        bonbun: Raw lot main number.
+        bubun: Raw lot sub number.
+        land_code: Raw land category code.
+        serial_number: Raw source serial number.
+        cancel_deal_type: Raw cancellation type flag.
+        cancel_deal_day: Raw cancellation date string.
+        req_gbn: Raw request category code.
+        rdealer_lawdnm: Raw registered dealer legal-dong name.
+        dealer_type: Raw dealer type value.
+        buyer_gbn: Raw buyer category value.
+        seller_gbn: Raw seller category value.
+        registration_date: Raw registration date string.
+        sgg_code: Raw sigungu code.
+        umd_code: Raw eupmyeondong code.
+    """
+
     model_config = ConfigDict(str_strip_whitespace=True, frozen=True)
 
     deal_amount: str | None = None
@@ -50,6 +97,15 @@ class BronzeAptTransaction(BronzeIngestMeta):
 
 
 class BronzeInterestRate(BronzeIngestMeta):
+    """Represent a raw interest rate observation from ingest sources.
+
+    Attributes:
+        date: Raw date string for the rate observation.
+        rate_type: Raw rate type label.
+        rate_value: Raw rate value string.
+        unit: Raw unit text for the rate value.
+    """
+
     model_config = ConfigDict(str_strip_whitespace=True, frozen=True)
 
     date: str | None = None
@@ -59,6 +115,18 @@ class BronzeInterestRate(BronzeIngestMeta):
 
 
 class BronzeMigration(BronzeIngestMeta):
+    """Represent a raw migration record from a source feed.
+
+    Attributes:
+        year: Raw year value.
+        month: Raw month value.
+        region_code: Raw region code.
+        region_name: Raw region name.
+        in_count: Raw inbound migration count.
+        out_count: Raw outbound migration count.
+        net_count: Raw net migration count.
+    """
+
     model_config = ConfigDict(str_strip_whitespace=True, frozen=True)
 
     year: str | None = None
@@ -71,6 +139,14 @@ class BronzeMigration(BronzeIngestMeta):
 
 
 class BronzeLegalDistrictCode(BronzeIngestMeta):
+    """Represent a raw legal district code row from source data.
+
+    Attributes:
+        code: Raw district code.
+        name: Raw district name.
+        is_active: Raw active-status flag.
+    """
+
     model_config = ConfigDict(str_strip_whitespace=True, frozen=True)
 
     code: str | None = None
@@ -79,6 +155,19 @@ class BronzeLegalDistrictCode(BronzeIngestMeta):
 
 
 class BronzeIngestManifest(BaseModel):
+    """Summarize metadata for a single bronze ingestion batch.
+
+    Attributes:
+        manifest_id: Unique identifier for the manifest record.
+        source_id: Identifier of the ingested source.
+        api_endpoint: Endpoint used for ingestion.
+        request_params: Request parameters used for the ingestion call.
+        response_count: Number of records returned by the source.
+        ingested_at: Timestamp when ingestion completed.
+        status: Final ingestion status.
+        error_message: Optional ingestion error details.
+    """
+
     model_config = ConfigDict(str_strip_whitespace=True, frozen=True)
 
     manifest_id: str

--- a/core/src/younggeul_core/state/gold.py
+++ b/core/src/younggeul_core/state/gold.py
@@ -1,3 +1,5 @@
+"""Gold-layer schemas for aggregated district and complex metrics."""
+
 from decimal import Decimal
 from typing import ClassVar, Literal
 
@@ -5,6 +7,28 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class GoldDistrictMonthlyMetrics(BaseModel):
+    """Represent monthly district-level aggregate housing metrics.
+
+    Attributes:
+        gu_code: District code.
+        gu_name: District name.
+        period: Target year-month period.
+        sale_count: Number of sales in the period.
+        avg_price: Average transaction price.
+        median_price: Median transaction price.
+        min_price: Minimum transaction price.
+        max_price: Maximum transaction price.
+        price_per_pyeong_avg: Average price per pyeong.
+        yoy_price_change: Year-over-year price change ratio.
+        mom_price_change: Month-over-month price change ratio.
+        yoy_volume_change: Year-over-year sales volume change ratio.
+        mom_volume_change: Month-over-month sales volume change ratio.
+        avg_area_m2: Average exclusive area in square meters.
+        base_interest_rate: Base interest rate for the period.
+        net_migration: Net migration count for the district.
+        dataset_snapshot_id: Optional source snapshot identifier.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     gu_code: str
@@ -27,6 +51,20 @@ class GoldDistrictMonthlyMetrics(BaseModel):
 
 
 class GoldComplexMonthlyMetrics(BaseModel):
+    """Represent monthly aggregate transaction metrics per apartment complex.
+
+    Attributes:
+        complex_id: Unique complex identifier.
+        gu_code: District code where the complex is located.
+        period: Target year-month period.
+        sale_count: Number of complex-level sales in the period.
+        avg_price: Average transaction price.
+        median_price: Median transaction price.
+        min_price: Minimum transaction price.
+        max_price: Maximum transaction price.
+        price_per_pyeong_avg: Average price per pyeong.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     complex_id: str
@@ -41,6 +79,20 @@ class GoldComplexMonthlyMetrics(BaseModel):
 
 
 class BaselineForecast(BaseModel):
+    """Represent baseline directional forecasts for district housing markets.
+
+    Attributes:
+        gu_code: District code.
+        gu_name: District name.
+        target_period: Forecast target year-month period.
+        direction: Predicted direction of price movement.
+        direction_confidence: Confidence score for the direction prediction.
+        predicted_volume: Optional predicted transaction volume.
+        predicted_median_price: Optional predicted median transaction price.
+        model_name: Name of the model producing the forecast.
+        features_used: Feature names used by the model.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     gu_code: str
@@ -56,6 +108,18 @@ class BaselineForecast(BaseModel):
     @field_validator("direction_confidence")
     @classmethod
     def validate_direction_confidence(cls, value: float) -> float:
+        """Validate that direction_confidence is between 0.0 and 1.0.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         if not 0.0 <= value <= 1.0:
             raise ValueError("direction_confidence must be between 0.0 and 1.0")
         return value

--- a/core/src/younggeul_core/state/silver.py
+++ b/core/src/younggeul_core/state/silver.py
@@ -1,3 +1,5 @@
+"""Silver-layer schemas for cleaned and typed intermediate datasets."""
+
 from datetime import date, datetime
 from decimal import Decimal
 from typing import ClassVar, Literal
@@ -6,6 +8,14 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class SilverDataQualityScore(BaseModel):
+    """Represent quality scoring dimensions for cleaned records.
+
+    Attributes:
+        completeness: Completeness score.
+        consistency: Consistency score.
+        overall: Overall quality score.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     completeness: float
@@ -15,12 +25,48 @@ class SilverDataQualityScore(BaseModel):
     @field_validator("completeness", "consistency", "overall")
     @classmethod
     def validate_score_range(cls, value: float) -> float:
+        """Validate that quality scores are within 0.0 to 100.0.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         if not 0.0 <= value <= 100.0:
             raise ValueError("score must be between 0.0 and 100.0")
         return value
 
 
 class SilverAptTransaction(BaseModel):
+    """Represent a normalized apartment transaction record.
+
+    Attributes:
+        transaction_id: Unique transaction identifier.
+        deal_amount: Final transaction amount.
+        deal_date: Transaction date.
+        build_year: Building completion year.
+        dong_code: Legal-dong code.
+        dong_name: Legal-dong name.
+        gu_code: District code.
+        gu_name: District name.
+        apt_name: Apartment complex name.
+        floor: Floor number.
+        area_exclusive_m2: Exclusive area in square meters.
+        jibun: Optional lot-based address.
+        road_name: Optional road-name address.
+        is_cancelled: Whether the transaction was cancelled.
+        cancel_date: Optional cancellation date.
+        deal_type: Optional transaction type label.
+        source_id: Source identifier for the ingestion feed.
+        ingest_timestamp: Timestamp when data was ingested.
+        quality_score: Optional quality assessment for the record.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     transaction_id: str
@@ -45,6 +91,16 @@ class SilverAptTransaction(BaseModel):
 
 
 class SilverInterestRate(BaseModel):
+    """Represent a normalized interest rate observation.
+
+    Attributes:
+        rate_date: Observation date.
+        rate_type: Interest rate type label.
+        rate_value: Interest rate value.
+        source_id: Source identifier for the observation.
+        ingest_timestamp: Timestamp when data was ingested.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     rate_date: date
@@ -55,6 +111,19 @@ class SilverInterestRate(BaseModel):
 
 
 class SilverMigration(BaseModel):
+    """Represent normalized migration statistics for a period and region.
+
+    Attributes:
+        period: Target year-month period.
+        region_code: Region code.
+        region_name: Region name.
+        in_count: Inbound migration count.
+        out_count: Outbound migration count.
+        net_count: Net migration count.
+        source_id: Source identifier for the data.
+        ingest_timestamp: Timestamp when data was ingested.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     period: str = Field(pattern=r"^\d{4}-(0[1-9]|1[0-2])$")
@@ -68,6 +137,19 @@ class SilverMigration(BaseModel):
 
 
 class SilverComplexBridge(BaseModel):
+    """Map apartment complex identifiers to location reference fields.
+
+    Attributes:
+        complex_id: Complex identifier.
+        dong_code: Legal-dong code.
+        jibun: Optional lot-based address.
+        road_name: Optional road-name address.
+        apt_name: Apartment complex name.
+        build_year: Optional building completion year.
+        matched_at: Timestamp when the bridge record was matched.
+        match_method: Strategy used to resolve the complex mapping.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     complex_id: str

--- a/core/src/younggeul_core/state/simulation.py
+++ b/core/src/younggeul_core/state/simulation.py
@@ -1,3 +1,5 @@
+"""Simulation state schemas for scenarios, rounds, and report artifacts."""
+
 from datetime import date, datetime
 from typing import ClassVar, Literal, TypedDict
 
@@ -5,6 +7,16 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 
 class RunMeta(BaseModel):
+    """Store metadata describing a simulation run.
+
+    Attributes:
+        run_id: Unique run identifier.
+        run_name: Human-readable run name.
+        created_at: Timestamp when the run was created.
+        model_id: Identifier of the model used for the run.
+        config_hash: Optional hash of the run configuration.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     run_id: str
@@ -15,6 +27,14 @@ class RunMeta(BaseModel):
 
 
 class SnapshotRef(BaseModel):
+    """Reference an input dataset snapshot used in a run.
+
+    Attributes:
+        dataset_snapshot_id: Snapshot identifier.
+        created_at: Timestamp when the snapshot was created.
+        table_count: Number of tables included in the snapshot.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     dataset_snapshot_id: str
@@ -24,6 +44,18 @@ class SnapshotRef(BaseModel):
     @field_validator("dataset_snapshot_id")
     @classmethod
     def validate_dataset_snapshot_id(cls, value: str) -> str:
+        """Validate that dataset_snapshot_id is a 64-character hex string.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         if len(value) != 64:
             raise ValueError("dataset_snapshot_id must be exactly 64 hex characters")
         if any(character not in "0123456789abcdefABCDEF" for character in value):
@@ -32,6 +64,15 @@ class SnapshotRef(BaseModel):
 
 
 class Shock(BaseModel):
+    """Describe an exogenous shock applied to a simulation scenario.
+
+    Attributes:
+        shock_type: Shock category applied in the simulation.
+        description: Human-readable description of the shock.
+        magnitude: Signed intensity of the shock.
+        target_segments: Segment identifiers targeted by the shock.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     shock_type: Literal["interest_rate", "regulation", "supply", "demand", "external"]
@@ -42,12 +83,34 @@ class Shock(BaseModel):
     @field_validator("magnitude")
     @classmethod
     def validate_magnitude(cls, value: float) -> float:
+        """Validate that magnitude is between -1.0 and 1.0.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         if not -1.0 <= value <= 1.0:
             raise ValueError("magnitude must be between -1.0 and 1.0")
         return value
 
 
 class ScenarioSpec(BaseModel):
+    """Define scenario boundaries and shocks for a simulation run.
+
+    Attributes:
+        scenario_name: Name of the scenario.
+        target_gus: District codes targeted by the scenario.
+        target_period_start: Scenario start date.
+        target_period_end: Scenario end date.
+        shocks: Shocks to apply during the scenario.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     scenario_name: str
@@ -58,12 +121,36 @@ class ScenarioSpec(BaseModel):
 
     @model_validator(mode="after")
     def validate_target_period(self) -> "ScenarioSpec":
+        """Validate that the scenario end date is not earlier than the start date.
+
+        Args:
+            self: The instance to validate.
+
+        Returns:
+            The validated instance.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         if self.target_period_end < self.target_period_start:
             raise ValueError("target_period_end must be greater than or equal to target_period_start")
         return self
 
 
 class SegmentState(BaseModel):
+    """Capture market state metrics for a district segment.
+
+    Attributes:
+        gu_code: District code.
+        gu_name: District name.
+        current_median_price: Current median price.
+        current_volume: Current transaction volume.
+        price_trend: Current directional price trend.
+        sentiment_index: Sentiment score for the segment.
+        supply_pressure: Supply pressure indicator.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     gu_code: str
@@ -77,6 +164,18 @@ class SegmentState(BaseModel):
     @field_validator("sentiment_index")
     @classmethod
     def validate_sentiment_index(cls, value: float) -> float:
+        """Validate that sentiment_index is between 0.0 and 1.0.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         if not 0.0 <= value <= 1.0:
             raise ValueError("sentiment_index must be between 0.0 and 1.0")
         return value
@@ -84,12 +183,35 @@ class SegmentState(BaseModel):
     @field_validator("supply_pressure")
     @classmethod
     def validate_supply_pressure(cls, value: float) -> float:
+        """Validate that supply_pressure is between -1.0 and 1.0.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         if not -1.0 <= value <= 1.0:
             raise ValueError("supply_pressure must be between -1.0 and 1.0")
         return value
 
 
 class ParticipantState(BaseModel):
+    """Represent simulation participant positions and preferences.
+
+    Attributes:
+        participant_id: Unique participant identifier.
+        role: Role assigned to the participant.
+        capital: Available capital.
+        holdings: Number of held units or positions.
+        sentiment: Participant sentiment state.
+        risk_tolerance: Participant risk tolerance score.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     participant_id: str
@@ -102,12 +224,36 @@ class ParticipantState(BaseModel):
     @field_validator("risk_tolerance")
     @classmethod
     def validate_risk_tolerance(cls, value: float) -> float:
+        """Validate that risk_tolerance is between 0.0 and 1.0.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         if not 0.0 <= value <= 1.0:
             raise ValueError("risk_tolerance must be between 0.0 and 1.0")
         return value
 
 
 class ActionProposal(BaseModel):
+    """Represent a participant or governance action proposed for a round.
+
+    Attributes:
+        agent_id: Identifier of the proposing agent.
+        round_no: Target round number.
+        action_type: Action category proposed by the agent.
+        target_segment: Segment targeted by the action.
+        confidence: Confidence score for the proposal.
+        reasoning_summary: Short explanation for the proposed action.
+        proposed_value: Optional structured payload with action details.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     agent_id: str
@@ -121,12 +267,34 @@ class ActionProposal(BaseModel):
     @field_validator("confidence")
     @classmethod
     def validate_confidence(cls, value: float) -> float:
+        """Validate that confidence is between 0.0 and 1.0.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         if not 0.0 <= value <= 1.0:
             raise ValueError("confidence must be between 0.0 and 1.0")
         return value
 
 
 class RoundOutcome(BaseModel):
+    """Summarize resolved outcomes for a completed simulation round.
+
+    Attributes:
+        round_no: Round number.
+        cleared_volume: Cleared transaction volume by segment.
+        price_changes: Price changes by segment.
+        governance_applied: Governance actions applied during resolution.
+        market_actions_resolved: Count of resolved market actions.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     round_no: int
@@ -137,6 +305,16 @@ class RoundOutcome(BaseModel):
 
 
 class ReportClaim(BaseModel):
+    """Represent a generated report claim tied to evidence and gating.
+
+    Attributes:
+        claim_id: Unique claim identifier.
+        claim_json: Structured claim payload.
+        evidence_ids: Evidence identifiers supporting the claim.
+        gate_status: Current gate status for the claim.
+        repair_count: Number of applied repair attempts.
+    """
+
     model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True)
 
     claim_id: str
@@ -148,12 +326,43 @@ class ReportClaim(BaseModel):
     @field_validator("repair_count")
     @classmethod
     def validate_repair_count(cls, value: int) -> int:
+        """Validate that repair_count does not exceed the retry limit.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         if value > 2:
             raise ValueError("repair_count must be less than or equal to 2")
         return value
 
 
 class SimulationState(TypedDict):
+    """Define the mutable state container used across simulation rounds.
+
+    Attributes:
+        run_meta: Metadata for the current run.
+        snapshot: Input dataset snapshot reference.
+        scenario: Active scenario definition.
+        round_no: Current round number.
+        max_rounds: Maximum number of rounds.
+        world: Segment state indexed by segment identifier.
+        participants: Participant state indexed by participant identifier.
+        governance_actions: Governance proposals indexed by action key.
+        market_actions: Market proposals indexed by action key.
+        last_outcome: Most recent round outcome if available.
+        event_refs: Event reference identifiers.
+        evidence_refs: Evidence reference identifiers.
+        report_claims: Report claims generated so far.
+        warnings: Collected warning messages.
+    """
+
     run_meta: RunMeta
     snapshot: SnapshotRef
     scenario: ScenarioSpec

--- a/core/src/younggeul_core/storage/snapshot.py
+++ b/core/src/younggeul_core/storage/snapshot.py
@@ -1,3 +1,5 @@
+"""Snapshot manifest schemas and helpers for dataset integrity checks."""
+
 import hashlib
 import re
 from datetime import datetime
@@ -9,6 +11,17 @@ _SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 class SnapshotTableEntry(BaseModel):
+    """Describe one table included in a dataset snapshot.
+
+    Attributes:
+        table_name: Logical table name.
+        table_hash: SHA-256 hash of the table content.
+        record_count: Number of records in the table.
+        schema_version: Schema version used for this table.
+        source_uri: Optional source URI for table provenance.
+        file_format: Storage format for the table export.
+    """
+
     table_name: str
     table_hash: str
     record_count: int = Field(ge=0)
@@ -21,12 +34,36 @@ class SnapshotTableEntry(BaseModel):
     @field_validator("table_hash")
     @classmethod
     def validate_table_hash(cls, value: str) -> str:
+        """Validate that table_hash is a lowercase SHA-256 hex string.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         if not _SHA256_HEX_RE.fullmatch(value):
             raise ValueError("table_hash must be a 64-character lowercase hex SHA-256 string")
         return value
 
 
 class SnapshotManifest(BaseModel):
+    """Represent a full dataset snapshot manifest and derived aggregates.
+
+    Attributes:
+        dataset_snapshot_id: Unique snapshot identifier.
+        created_at: Timestamp when the snapshot was created.
+        description: Optional snapshot description.
+        table_entries: Table-level entries included in the snapshot.
+        source_ids: Source identifiers contributing to the snapshot.
+        ingestion_started_at: Optional ingestion start timestamp.
+        ingestion_completed_at: Optional ingestion completion timestamp.
+    """
+
     dataset_snapshot_id: str
     created_at: datetime
     description: str | None = None
@@ -40,6 +77,18 @@ class SnapshotManifest(BaseModel):
     @field_validator("dataset_snapshot_id")
     @classmethod
     def validate_dataset_snapshot_id(cls, value: str) -> str:
+        """Validate that dataset_snapshot_id is lowercase SHA-256 hex.
+
+        Args:
+            value: The value to validate.
+
+        Returns:
+            The validated value.
+
+        Raises:
+            ValueError: If validation fails.
+        """
+
         if not _SHA256_HEX_RE.fullmatch(value):
             raise ValueError("dataset_snapshot_id must be a 64-character lowercase hex SHA-256 string")
         return value
@@ -47,23 +96,56 @@ class SnapshotManifest(BaseModel):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def table_hashes(self) -> dict[str, str]:
+        """Return table hashes indexed by table name.
+
+        Returns:
+            Mapping of table names to table hashes.
+        """
+
         return {entry.table_name: entry.table_hash for entry in self.table_entries}
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def record_counts(self) -> dict[str, int]:
+        """Return record counts indexed by table name.
+
+        Returns:
+            Mapping of table names to record counts.
+        """
+
         return {entry.table_name: entry.record_count for entry in self.table_entries}
 
     @computed_field  # type: ignore[prop-decorator]
     @property
     def total_records(self) -> int:
+        """Return the total number of records across all tables.
+
+        Returns:
+            Sum of all table record counts.
+        """
+
         return sum(entry.record_count for entry in self.table_entries)
 
     def validate_integrity(self) -> bool:
+        """Validate that manifest content reproduces dataset_snapshot_id.
+
+        Returns:
+            True when computed and declared snapshot IDs match.
+        """
+
         computed_id = self.compute_snapshot_id(self.table_hashes)
         return computed_id == self.dataset_snapshot_id
 
     def get_table(self, name: str) -> SnapshotTableEntry | None:
+        """Return a table entry by name when present.
+
+        Args:
+            name: Table name to look up.
+
+        Returns:
+            Matching table entry, or None when no entry exists.
+        """
+
         for entry in self.table_entries:
             if entry.table_name == name:
                 return entry
@@ -71,6 +153,15 @@ class SnapshotManifest(BaseModel):
 
     @classmethod
     def compute_snapshot_id(cls, table_hashes: dict[str, str]) -> str:
+        """Compute a deterministic snapshot ID from table hashes.
+
+        Args:
+            table_hashes: Mapping of table names to table hashes.
+
+        Returns:
+            SHA-256 digest representing the ordered table hash set.
+        """
+
         items = sorted(table_hashes.items(), key=lambda item: item[0])
         joined = "".join(f"{table_name}:{table_hash}" for table_name, table_hash in items)
         return hashlib.sha256(joined.encode("utf-8")).hexdigest()

--- a/docs/api-audit.md
+++ b/docs/api-audit.md
@@ -8,12 +8,12 @@
 
 | Metric | Count |
 |--------|-------|
-| ✅ Full docstring | 46 |
-| ⚠️ Partial docstring | 20 |
-| ❌ Missing docstring | 223 |
+| ✅ Full docstring | 272 |
+| ⚠️ Partial docstring | 17 |
+| ❌ Missing docstring | 0 |
 | **Total** | **289** |
-| **Coverage (full)** | **15.9%** |
-| **Coverage (full+partial)** | **22.8%** |
+| **Coverage (full)** | **94.1%** |
+| **Coverage (full+partial)** | **100.0%** |
 
 ## Per-Module Breakdown
 
@@ -27,19 +27,19 @@
 | `core.connectors.hashing` | 2 | 2 | 0 | 0 | 100% |
 | `core.connectors.manifest` | 2 | 2 | 0 | 0 | 100% |
 | `core.connectors.protocol` | 4 | 4 | 0 | 0 | 100% |
-| `core.connectors.rate_limit` | 5 | 4 | 1 | 0 | 80% |
+| `core.connectors.rate_limit` | 5 | 5 | 0 | 0 | 100% |
 | `core.connectors.retry` | 4 | 4 | 0 | 0 | 100% |
-| `core.evidence` | 1 | 0 | 0 | 1 | 0% |
-| `core.evidence.schemas` | 9 | 0 | 0 | 9 | 0% |
-| `core.evidence.sql` | 1 | 0 | 0 | 1 | 0% |
+| `core.evidence` | 1 | 1 | 0 | 0 | 100% |
+| `core.evidence.schemas` | 9 | 9 | 0 | 0 | 100% |
+| `core.evidence.sql` | 1 | 1 | 0 | 0 | 100% |
 | `core.runtime` | 1 | 1 | 0 | 0 | 100% |
-| `core.state` | 1 | 0 | 0 | 1 | 0% |
-| `core.state.bronze` | 7 | 0 | 0 | 7 | 0% |
-| `core.state.gold` | 5 | 0 | 0 | 5 | 0% |
-| `core.state.silver` | 7 | 0 | 0 | 7 | 0% |
-| `core.state.simulation` | 19 | 0 | 0 | 19 | 0% |
+| `core.state` | 1 | 1 | 0 | 0 | 100% |
+| `core.state.bronze` | 7 | 7 | 0 | 0 | 100% |
+| `core.state.gold` | 5 | 5 | 0 | 0 | 100% |
+| `core.state.silver` | 7 | 7 | 0 | 0 | 100% |
+| `core.state.simulation` | 19 | 19 | 0 | 0 | 100% |
 | `core.storage` | 1 | 1 | 0 | 0 | 100% |
-| `core.storage.snapshot` | 11 | 0 | 0 | 11 | 0% |
+| `core.storage.snapshot` | 11 | 11 | 0 | 0 | 100% |
 
 ### App (`younggeul_app_kr_seoul_apartment`)
 
@@ -47,63 +47,63 @@
 |--------|-------|---------|------------|------------|----------|
 | `younggeul_app_kr_seoul_apartment` | 1 | 1 | 0 | 0 | 100% |
 | `app.canonical` | 1 | 1 | 0 | 0 | 100% |
-| `app.cli` | 10 | 0 | 0 | 10 | 0% |
+| `app.cli` | 10 | 2 | 8 | 0 | 20% |
 | `app.connectors` | 1 | 1 | 0 | 0 | 100% |
-| `app.connectors.bok` | 4 | 3 | 1 | 0 | 75% |
-| `app.connectors.kostat` | 4 | 3 | 1 | 0 | 75% |
-| `app.connectors.molit` | 4 | 3 | 1 | 0 | 75% |
+| `app.connectors.bok` | 4 | 4 | 0 | 0 | 100% |
+| `app.connectors.kostat` | 4 | 4 | 0 | 0 | 100% |
+| `app.connectors.molit` | 4 | 4 | 0 | 0 | 100% |
 | `app.entity_resolution` | 1 | 1 | 0 | 0 | 100% |
 | `app.eval` | 1 | 1 | 0 | 0 | 100% |
 | `app.features` | 1 | 1 | 0 | 0 | 100% |
-| `app.forecaster` | 3 | 0 | 0 | 3 | 0% |
-| `app.pipeline` | 5 | 3 | 1 | 1 | 60% |
+| `app.forecaster` | 3 | 3 | 0 | 0 | 100% |
+| `app.pipeline` | 5 | 5 | 0 | 0 | 100% |
 | `app.policies` | 1 | 1 | 0 | 0 | 100% |
 | `app.reports` | 1 | 1 | 0 | 0 | 100% |
 | `app.simulation` | 1 | 1 | 0 | 0 | 100% |
-| `app.simulation.domain` | 1 | 0 | 0 | 1 | 0% |
-| `app.simulation.domain.gu_resolver` | 2 | 0 | 0 | 2 | 0% |
-| `app.simulation.domain.shock_catalog` | 3 | 0 | 0 | 3 | 0% |
-| `app.simulation.event_store` | 13 | 0 | 0 | 13 | 0% |
-| `app.simulation.events` | 8 | 2 | 5 | 1 | 25% |
-| `app.simulation.evidence` | 1 | 0 | 0 | 1 | 0% |
-| `app.simulation.evidence.store` | 16 | 2 | 4 | 10 | 12% |
-| `app.simulation.graph` | 2 | 0 | 0 | 2 | 0% |
-| `app.simulation.graph_state` | 5 | 0 | 0 | 5 | 0% |
-| `app.simulation.llm` | 1 | 0 | 0 | 1 | 0% |
-| `app.simulation.llm.litellm_adapter` | 5 | 0 | 0 | 5 | 0% |
-| `app.simulation.llm.ports` | 4 | 0 | 1 | 3 | 0% |
-| `app.simulation.nodes` | 1 | 0 | 0 | 1 | 0% |
-| `app.simulation.nodes.citation_gate_node` | 2 | 0 | 0 | 2 | 0% |
-| `app.simulation.nodes.continue_gate` | 2 | 0 | 0 | 2 | 0% |
-| `app.simulation.nodes.evidence_builder` | 2 | 0 | 0 | 2 | 0% |
-| `app.simulation.nodes.intake_planner` | 2 | 0 | 0 | 2 | 0% |
-| `app.simulation.nodes.participant_decider` | 2 | 0 | 0 | 2 | 0% |
-| `app.simulation.nodes.report_renderer` | 2 | 0 | 0 | 2 | 0% |
-| `app.simulation.nodes.report_writer` | 2 | 0 | 0 | 2 | 0% |
-| `app.simulation.nodes.round_resolver` | 2 | 0 | 0 | 2 | 0% |
-| `app.simulation.nodes.round_summarizer` | 2 | 0 | 0 | 2 | 0% |
-| `app.simulation.nodes.scenario_builder` | 4 | 0 | 0 | 4 | 0% |
-| `app.simulation.nodes.world_initializer` | 2 | 0 | 0 | 2 | 0% |
-| `app.simulation.policies` | 1 | 0 | 0 | 1 | 0% |
-| `app.simulation.policies.heuristic` | 11 | 0 | 0 | 11 | 0% |
-| `app.simulation.policies.protocol` | 3 | 0 | 1 | 2 | 0% |
-| `app.simulation.policies.registry` | 2 | 0 | 0 | 2 | 0% |
-| `app.simulation.ports` | 1 | 0 | 0 | 1 | 0% |
-| `app.simulation.ports.snapshot_reader` | 6 | 0 | 3 | 3 | 0% |
-| `app.simulation.replay` | 1 | 0 | 0 | 1 | 0% |
-| `app.simulation.replay.engine` | 6 | 0 | 0 | 6 | 0% |
-| `app.simulation.schemas` | 1 | 0 | 0 | 1 | 0% |
-| `app.simulation.schemas.intake` | 2 | 0 | 0 | 2 | 0% |
-| `app.simulation.schemas.participant_roster` | 3 | 0 | 0 | 3 | 0% |
-| `app.simulation.schemas.report` | 4 | 0 | 0 | 4 | 0% |
-| `app.simulation.schemas.round` | 7 | 0 | 0 | 7 | 0% |
-| `app.simulation.tracing` | 4 | 0 | 0 | 4 | 0% |
-| `app.snapshot` | 3 | 0 | 0 | 3 | 0% |
-| `app.transforms` | 1 | 0 | 0 | 1 | 0% |
-| `app.transforms.gold_district` | 2 | 0 | 0 | 2 | 0% |
-| `app.transforms.gold_enrichment` | 2 | 0 | 1 | 1 | 0% |
-| `app.transforms.silver_apt` | 12 | 0 | 0 | 12 | 0% |
-| `app.transforms.silver_macro` | 9 | 0 | 0 | 9 | 0% |
+| `app.simulation.domain` | 1 | 1 | 0 | 0 | 100% |
+| `app.simulation.domain.gu_resolver` | 2 | 2 | 0 | 0 | 100% |
+| `app.simulation.domain.shock_catalog` | 3 | 3 | 0 | 0 | 100% |
+| `app.simulation.event_store` | 13 | 13 | 0 | 0 | 100% |
+| `app.simulation.events` | 8 | 3 | 5 | 0 | 38% |
+| `app.simulation.evidence` | 1 | 1 | 0 | 0 | 100% |
+| `app.simulation.evidence.store` | 16 | 12 | 4 | 0 | 75% |
+| `app.simulation.graph` | 2 | 2 | 0 | 0 | 100% |
+| `app.simulation.graph_state` | 5 | 5 | 0 | 0 | 100% |
+| `app.simulation.llm` | 1 | 1 | 0 | 0 | 100% |
+| `app.simulation.llm.litellm_adapter` | 5 | 5 | 0 | 0 | 100% |
+| `app.simulation.llm.ports` | 4 | 4 | 0 | 0 | 100% |
+| `app.simulation.nodes` | 1 | 1 | 0 | 0 | 100% |
+| `app.simulation.nodes.citation_gate_node` | 2 | 2 | 0 | 0 | 100% |
+| `app.simulation.nodes.continue_gate` | 2 | 2 | 0 | 0 | 100% |
+| `app.simulation.nodes.evidence_builder` | 2 | 2 | 0 | 0 | 100% |
+| `app.simulation.nodes.intake_planner` | 2 | 2 | 0 | 0 | 100% |
+| `app.simulation.nodes.participant_decider` | 2 | 2 | 0 | 0 | 100% |
+| `app.simulation.nodes.report_renderer` | 2 | 2 | 0 | 0 | 100% |
+| `app.simulation.nodes.report_writer` | 2 | 2 | 0 | 0 | 100% |
+| `app.simulation.nodes.round_resolver` | 2 | 2 | 0 | 0 | 100% |
+| `app.simulation.nodes.round_summarizer` | 2 | 2 | 0 | 0 | 100% |
+| `app.simulation.nodes.scenario_builder` | 4 | 4 | 0 | 0 | 100% |
+| `app.simulation.nodes.world_initializer` | 2 | 2 | 0 | 0 | 100% |
+| `app.simulation.policies` | 1 | 1 | 0 | 0 | 100% |
+| `app.simulation.policies.heuristic` | 11 | 11 | 0 | 0 | 100% |
+| `app.simulation.policies.protocol` | 3 | 3 | 0 | 0 | 100% |
+| `app.simulation.policies.registry` | 2 | 2 | 0 | 0 | 100% |
+| `app.simulation.ports` | 1 | 1 | 0 | 0 | 100% |
+| `app.simulation.ports.snapshot_reader` | 6 | 6 | 0 | 0 | 100% |
+| `app.simulation.replay` | 1 | 1 | 0 | 0 | 100% |
+| `app.simulation.replay.engine` | 6 | 6 | 0 | 0 | 100% |
+| `app.simulation.schemas` | 1 | 1 | 0 | 0 | 100% |
+| `app.simulation.schemas.intake` | 2 | 2 | 0 | 0 | 100% |
+| `app.simulation.schemas.participant_roster` | 3 | 3 | 0 | 0 | 100% |
+| `app.simulation.schemas.report` | 4 | 4 | 0 | 0 | 100% |
+| `app.simulation.schemas.round` | 7 | 7 | 0 | 0 | 100% |
+| `app.simulation.tracing` | 4 | 4 | 0 | 0 | 100% |
+| `app.snapshot` | 3 | 3 | 0 | 0 | 100% |
+| `app.transforms` | 1 | 1 | 0 | 0 | 100% |
+| `app.transforms.gold_district` | 2 | 2 | 0 | 0 | 100% |
+| `app.transforms.gold_enrichment` | 2 | 2 | 0 | 0 | 100% |
+| `app.transforms.silver_apt` | 12 | 12 | 0 | 0 | 100% |
+| `app.transforms.silver_macro` | 9 | 9 | 0 | 0 | 100% |
 
 ## Gap List (Missing & Partial Docstrings)
 
@@ -111,251 +111,25 @@
 
 | File | Symbol | Kind | Line |
 |------|--------|------|------|
-| `src/younggeul_core/evidence/__init__.py` | `(module)` | module | L1 |
-| `src/younggeul_core/evidence/schemas.py` | `(module)` | module | L1 |
-| `src/younggeul_core/evidence/schemas.py` | `EvidenceRecord` | class | L11 |
-| `src/younggeul_core/evidence/schemas.py` | `EvidenceRecord.validate_evidence_id_uuid` | method | L27 |
-| `src/younggeul_core/evidence/schemas.py` | `EvidenceRecord.validate_sha256_hex` | method | L33 |
-| `src/younggeul_core/evidence/schemas.py` | `ClaimRecord` | class | L39 |
-| `src/younggeul_core/evidence/schemas.py` | `ClaimRecord.validate_uuid` | method | L54 |
-| `src/younggeul_core/evidence/schemas.py` | `ClaimRecord.validate_repair_count` | method | L60 |
-| `src/younggeul_core/evidence/schemas.py` | `GateResult` | class | L66 |
-| `src/younggeul_core/evidence/schemas.py` | `GateResult.validate_claim_id_uuid` | method | L77 |
-| `src/younggeul_core/evidence/sql.py` | `(module)` | module | L1 |
-| `src/younggeul_core/state/__init__.py` | `(module)` | module | L1 |
-| `src/younggeul_core/state/bronze.py` | `(module)` | module | L1 |
-| `src/younggeul_core/state/bronze.py` | `BronzeIngestMeta` | class | L7 |
-| `src/younggeul_core/state/bronze.py` | `BronzeAptTransaction` | class | L15 |
-| `src/younggeul_core/state/bronze.py` | `BronzeInterestRate` | class | L52 |
-| `src/younggeul_core/state/bronze.py` | `BronzeMigration` | class | L61 |
-| `src/younggeul_core/state/bronze.py` | `BronzeLegalDistrictCode` | class | L73 |
-| `src/younggeul_core/state/bronze.py` | `BronzeIngestManifest` | class | L81 |
-| `src/younggeul_core/state/gold.py` | `(module)` | module | L1 |
-| `src/younggeul_core/state/gold.py` | `GoldDistrictMonthlyMetrics` | class | L7 |
-| `src/younggeul_core/state/gold.py` | `GoldComplexMonthlyMetrics` | class | L29 |
-| `src/younggeul_core/state/gold.py` | `BaselineForecast` | class | L43 |
-| `src/younggeul_core/state/gold.py` | `BaselineForecast.validate_direction_confidence` | method | L58 |
-| `src/younggeul_core/state/silver.py` | `(module)` | module | L1 |
-| `src/younggeul_core/state/silver.py` | `SilverDataQualityScore` | class | L8 |
-| `src/younggeul_core/state/silver.py` | `SilverDataQualityScore.validate_score_range` | method | L17 |
-| `src/younggeul_core/state/silver.py` | `SilverAptTransaction` | class | L23 |
-| `src/younggeul_core/state/silver.py` | `SilverInterestRate` | class | L47 |
-| `src/younggeul_core/state/silver.py` | `SilverMigration` | class | L57 |
-| `src/younggeul_core/state/silver.py` | `SilverComplexBridge` | class | L70 |
-| `src/younggeul_core/state/simulation.py` | `(module)` | module | L1 |
-| `src/younggeul_core/state/simulation.py` | `RunMeta` | class | L7 |
-| `src/younggeul_core/state/simulation.py` | `SnapshotRef` | class | L17 |
-| `src/younggeul_core/state/simulation.py` | `SnapshotRef.validate_dataset_snapshot_id` | method | L26 |
-| `src/younggeul_core/state/simulation.py` | `Shock` | class | L34 |
-| `src/younggeul_core/state/simulation.py` | `Shock.validate_magnitude` | method | L44 |
-| `src/younggeul_core/state/simulation.py` | `ScenarioSpec` | class | L50 |
-| `src/younggeul_core/state/simulation.py` | `ScenarioSpec.validate_target_period` | method | L60 |
-| `src/younggeul_core/state/simulation.py` | `SegmentState` | class | L66 |
-| `src/younggeul_core/state/simulation.py` | `SegmentState.validate_sentiment_index` | method | L79 |
-| `src/younggeul_core/state/simulation.py` | `SegmentState.validate_supply_pressure` | method | L86 |
-| `src/younggeul_core/state/simulation.py` | `ParticipantState` | class | L92 |
-| `src/younggeul_core/state/simulation.py` | `ParticipantState.validate_risk_tolerance` | method | L104 |
-| `src/younggeul_core/state/simulation.py` | `ActionProposal` | class | L110 |
-| `src/younggeul_core/state/simulation.py` | `ActionProposal.validate_confidence` | method | L123 |
-| `src/younggeul_core/state/simulation.py` | `RoundOutcome` | class | L129 |
-| `src/younggeul_core/state/simulation.py` | `ReportClaim` | class | L139 |
-| `src/younggeul_core/state/simulation.py` | `ReportClaim.validate_repair_count` | method | L150 |
-| `src/younggeul_core/state/simulation.py` | `SimulationState` | class | L156 |
-| `src/younggeul_core/storage/snapshot.py` | `(module)` | module | L1 |
-| `src/younggeul_core/storage/snapshot.py` | `SnapshotTableEntry` | class | L11 |
-| `src/younggeul_core/storage/snapshot.py` | `SnapshotTableEntry.validate_table_hash` | method | L23 |
-| `src/younggeul_core/storage/snapshot.py` | `SnapshotManifest` | class | L29 |
-| `src/younggeul_core/storage/snapshot.py` | `SnapshotManifest.validate_dataset_snapshot_id` | method | L42 |
-| `src/younggeul_core/storage/snapshot.py` | `SnapshotManifest.table_hashes` | method | L49 |
-| `src/younggeul_core/storage/snapshot.py` | `SnapshotManifest.record_counts` | method | L54 |
-| `src/younggeul_core/storage/snapshot.py` | `SnapshotManifest.total_records` | method | L59 |
-| `src/younggeul_core/storage/snapshot.py` | `SnapshotManifest.validate_integrity` | method | L62 |
-| `src/younggeul_core/storage/snapshot.py` | `SnapshotManifest.get_table` | method | L66 |
-| `src/younggeul_core/storage/snapshot.py` | `SnapshotManifest.compute_snapshot_id` | method | L73 |
-| `src/younggeul_app_kr_seoul_apartment/cli.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/cli.py` | `main` | function | L194 |
-| `src/younggeul_app_kr_seoul_apartment/cli.py` | `ingest_command` | function | L207 |
-| `src/younggeul_app_kr_seoul_apartment/cli.py` | `snapshot_group` | function | L247 |
-| `src/younggeul_app_kr_seoul_apartment/cli.py` | `snapshot_publish_command` | function | L264 |
-| `src/younggeul_app_kr_seoul_apartment/cli.py` | `snapshot_list_command` | function | L297 |
-| `src/younggeul_app_kr_seoul_apartment/cli.py` | `baseline_command` | function | L364 |
-| `src/younggeul_app_kr_seoul_apartment/cli.py` | `simulate_command` | function | L404 |
-| `src/younggeul_app_kr_seoul_apartment/cli.py` | `report_command` | function | L440 |
-| `src/younggeul_app_kr_seoul_apartment/cli.py` | `eval_command` | function | L456 |
-| `src/younggeul_app_kr_seoul_apartment/forecaster.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/forecaster.py` | `forecast_baseline` | function | L23 |
-| `src/younggeul_app_kr_seoul_apartment/forecaster.py` | `generate_baseline_report` | function | L100 |
-| `src/younggeul_app_kr_seoul_apartment/pipeline.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/domain/__init__.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/domain/gu_resolver.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/domain/gu_resolver.py` | `resolve_gu_codes` | function | L33 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/domain/shock_catalog.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/domain/shock_catalog.py` | `normalize_shock_key` | function | L74 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/domain/shock_catalog.py` | `expand_shock` | function | L83 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/event_store.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/event_store.py` | `InMemoryEventStore` | class | L11 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/event_store.py` | `InMemoryEventStore.append` | method | L16 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/event_store.py` | `InMemoryEventStore.get_events` | method | L20 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/event_store.py` | `InMemoryEventStore.get_events_by_type` | method | L25 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/event_store.py` | `InMemoryEventStore.count` | method | L28 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/event_store.py` | `InMemoryEventStore.clear` | method | L32 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/event_store.py` | `FileEventStore` | class | L37 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/event_store.py` | `FileEventStore.append` | method | L46 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/event_store.py` | `FileEventStore.get_events` | method | L52 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/event_store.py` | `FileEventStore.get_events_by_type` | method | L68 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/event_store.py` | `FileEventStore.count` | method | L71 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/event_store.py` | `FileEventStore.clear` | method | L79 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/events.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/__init__.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `EvidenceRecord` | class | L9 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `EvidenceStore` | class | L20 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `InMemoryEvidenceStore` | class | L34 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `InMemoryEvidenceStore.add` | method | L38 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `InMemoryEvidenceStore.get` | method | L43 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `InMemoryEvidenceStore.get_all` | method | L46 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `InMemoryEvidenceStore.get_by_kind` | method | L49 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `InMemoryEvidenceStore.get_by_subject` | method | L52 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `InMemoryEvidenceStore.count` | method | L59 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/graph.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/graph.py` | `build_simulation_graph` | function | L54 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/graph_state.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/graph_state.py` | `SimulationGraphState` | class | L23 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/graph_state.py` | `seed_graph_state` | function | L75 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/graph_state.py` | `to_simulation_state` | function | L91 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/graph_state.py` | `validate_initialized_state` | function | L103 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/llm/__init__.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py` | `StructuredLLMTransportError` | class | L14 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py` | `StructuredLLMResponseError` | class | L18 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py` | `LiteLLMStructuredLLM` | class | L22 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py` | `LiteLLMStructuredLLM.generate_structured` | method | L27 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/llm/ports.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/llm/ports.py` | `LLMMessage` | class | L11 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/llm/ports.py` | `StructuredLLM` | class | L16 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/__init__.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/citation_gate_node.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/citation_gate_node.py` | `make_citation_gate_node` | function | L35 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/continue_gate.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/continue_gate.py` | `should_continue` | function | L8 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/evidence_builder.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/evidence_builder.py` | `make_evidence_builder_node` | function | L11 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/intake_planner.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/intake_planner.py` | `make_intake_planner_node` | function | L28 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/participant_decider.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/participant_decider.py` | `make_participant_decider_node` | function | L71 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/report_renderer.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/report_renderer.py` | `make_report_renderer_node` | function | L26 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/report_writer.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/report_writer.py` | `make_report_writer_node` | function | L52 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/round_resolver.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/round_resolver.py` | `make_round_resolver_node` | function | L50 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/round_summarizer.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/round_summarizer.py` | `make_round_summarizer_node` | function | L11 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/scenario_builder.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/scenario_builder.py` | `ScenarioSelection` | class | L25 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/scenario_builder.py` | `compute_max_rounds` | function | L33 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/scenario_builder.py` | `make_scenario_builder_node` | function | L181 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/world_initializer.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/nodes/world_initializer.py` | `make_world_initializer_node` | function | L158 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/__init__.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/heuristic.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/heuristic.py` | `BuyerPolicy` | class | L39 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/heuristic.py` | `BuyerPolicy.decide` | method | L40 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/heuristic.py` | `InvestorPolicy` | class | L64 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/heuristic.py` | `InvestorPolicy.decide` | method | L65 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/heuristic.py` | `TenantPolicy` | class | L98 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/heuristic.py` | `TenantPolicy.decide` | method | L99 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/heuristic.py` | `LandlordPolicy` | class | L109 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/heuristic.py` | `LandlordPolicy.decide` | method | L110 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/heuristic.py` | `BrokerPolicy` | class | L132 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/heuristic.py` | `BrokerPolicy.decide` | method | L133 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/protocol.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/protocol.py` | `ParticipantPolicy` | class | L13 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/registry.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/registry.py` | `get_default_policy` | function | L15 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/ports/__init__.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/ports/snapshot_reader.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/ports/snapshot_reader.py` | `SnapshotCoverage` | class | L11 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/ports/snapshot_reader.py` | `SnapshotReader` | class | L22 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/replay/__init__.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/replay/engine.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/replay/engine.py` | `ReplayResult` | class | L15 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/replay/engine.py` | `ReplayContext` | class | L26 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/replay/engine.py` | `ReplayError` | class | L30 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/replay/engine.py` | `ReplayEngine` | class | L197 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/replay/engine.py` | `ReplayEngine.replay` | method | L201 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/__init__.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/intake.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/intake.py` | `IntakePlan` | class | L8 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/participant_roster.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/participant_roster.py` | `RoleBucketSpec` | class | L8 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/participant_roster.py` | `ParticipantRosterSpec` | class | L22 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/report.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/report.py` | `RenderedClaimEntry` | class | L8 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/report.py` | `RenderedSection` | class | L17 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/report.py` | `RenderedReport` | class | L24 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/round.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/round.py` | `DecisionContext` | class | L12 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/round.py` | `SegmentDelta` | class | L21 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/round.py` | `SegmentDelta.validate_price_change_pct` | method | L30 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/round.py` | `ParticipantDelta` | class | L36 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/round.py` | `RoundResolvedPayload` | class | L44 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/schemas/round.py` | `validate_v01_action` | function | L52 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/tracing.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/tracing.py` | `init_tracing` | function | L18 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/tracing.py` | `get_tracer` | function | L44 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/tracing.py` | `trace_node` | function | L49 |
-| `src/younggeul_app_kr_seoul_apartment/snapshot.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/snapshot.py` | `publish_snapshot` | function | L49 |
-| `src/younggeul_app_kr_seoul_apartment/snapshot.py` | `resolve_snapshot` | function | L86 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/__init__.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/gold_district.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/gold_district.py` | `aggregate_district_monthly` | function | L54 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/gold_enrichment.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py` | `parse_deal_amount` | function | L39 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py` | `parse_deal_date` | function | L52 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py` | `parse_int` | function | L64 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py` | `parse_decimal` | function | L76 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py` | `derive_gu_code` | function | L88 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py` | `derive_gu_name` | function | L94 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py` | `is_cancelled` | function | L100 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py` | `generate_transaction_id` | function | L106 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py` | `compute_quality_score` | function | L122 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py` | `normalize_apt_transaction` | function | L186 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py` | `normalize_batch` | function | L243 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_macro.py` | `(module)` | module | L1 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_macro.py` | `parse_date` | function | L13 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_macro.py` | `parse_decimal_2dp` | function | L25 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_macro.py` | `parse_count` | function | L37 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_macro.py` | `build_period` | function | L49 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_macro.py` | `normalize_interest_rate` | function | L62 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_macro.py` | `normalize_migration` | function | L84 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_macro.py` | `normalize_interest_rate_batch` | function | L115 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/silver_macro.py` | `normalize_migration_batch` | function | L124 |
 
 ### Lower Priority: Partial Docstrings (missing Args/Returns sections)
 
 | File | Symbol | Kind | Line |
 |------|--------|------|------|
-| `src/younggeul_core/connectors/rate_limit.py` | `RateLimiter.min_interval` | method | L26 |
-| `src/younggeul_app_kr_seoul_apartment/connectors/bok.py` | `BokInterestRateConnector.fetch` | method | L173 |
-| `src/younggeul_app_kr_seoul_apartment/connectors/kostat.py` | `KostatMigrationConnector.fetch` | method | L194 |
-| `src/younggeul_app_kr_seoul_apartment/connectors/molit.py` | `MolitAptConnector.fetch` | method | L173 |
-| `src/younggeul_app_kr_seoul_apartment/pipeline.py` | `run_pipeline` | function | L44 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/events.py` | `EventStore.append` | method | L26 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/events.py` | `EventStore.get_events` | method | L31 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/events.py` | `EventStore.get_events_by_type` | method | L36 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/events.py` | `EventStore.count` | method | L41 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/events.py` | `EventStore.clear` | method | L46 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `EvidenceStore.add` | method | L21 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `EvidenceStore.get` | method | L23 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `EvidenceStore.get_by_kind` | method | L27 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `EvidenceStore.get_by_subject` | method | L29 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/llm/ports.py` | `StructuredLLM.generate_structured` | method | L17 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/policies/protocol.py` | `ParticipantPolicy.decide` | method | L14 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/ports/snapshot_reader.py` | `SnapshotReader.get_coverage` | method | L23 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/ports/snapshot_reader.py` | `SnapshotReader.get_latest_metrics` | method | L25 |
-| `src/younggeul_app_kr_seoul_apartment/simulation/ports/snapshot_reader.py` | `SnapshotReader.get_baseline_forecasts` | method | L31 |
-| `src/younggeul_app_kr_seoul_apartment/transforms/gold_enrichment.py` | `enrich_district_monthly_trends` | function | L28 |
+| `src/younggeul_app_kr_seoul_apartment/cli.py` | `main` | function | L196 |
+| `src/younggeul_app_kr_seoul_apartment/cli.py` | `ingest_command` | function | L210 |
+| `src/younggeul_app_kr_seoul_apartment/cli.py` | `snapshot_publish_command` | function | L269 |
+| `src/younggeul_app_kr_seoul_apartment/cli.py` | `snapshot_list_command` | function | L303 |
+| `src/younggeul_app_kr_seoul_apartment/cli.py` | `baseline_command` | function | L371 |
+| `src/younggeul_app_kr_seoul_apartment/cli.py` | `simulate_command` | function | L412 |
+| `src/younggeul_app_kr_seoul_apartment/cli.py` | `report_command` | function | L449 |
+| `src/younggeul_app_kr_seoul_apartment/cli.py` | `eval_command` | function | L466 |
+| `src/younggeul_app_kr_seoul_apartment/simulation/events.py` | `EventStore.append` | method | L28 |
+| `src/younggeul_app_kr_seoul_apartment/simulation/events.py` | `EventStore.get_events` | method | L33 |
+| `src/younggeul_app_kr_seoul_apartment/simulation/events.py` | `EventStore.get_events_by_type` | method | L38 |
+| `src/younggeul_app_kr_seoul_apartment/simulation/events.py` | `EventStore.count` | method | L43 |
+| `src/younggeul_app_kr_seoul_apartment/simulation/events.py` | `EventStore.clear` | method | L48 |
+| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `EvidenceStore.add` | method | L38 |
+| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `EvidenceStore.get` | method | L40 |
+| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `EvidenceStore.get_by_kind` | method | L44 |
+| `src/younggeul_app_kr_seoul_apartment/simulation/evidence/store.py` | `EvidenceStore.get_by_subject` | method | L46 |


### PR DESCRIPTION
## Summary
- Backfill Google-style docstrings across **all 289 public symbols** in core/ and apps/
- Coverage improved: **15.9% → 94.1%** full, **22.8% → 100%** full+partial
- 61 files changed, 1,851 insertions

## What changed
### Core (`younggeul_core`)
- `evidence/schemas.py` — EvidenceRecord, ClaimRecord, GateResult + all validators
- `state/bronze.py` — All 6 Bronze model classes
- `state/silver.py` — All 6 Silver model classes + validators
- `state/gold.py` — GoldDistrictMonthlyMetrics, GoldComplexMonthlyMetrics, BaselineForecast
- `state/simulation.py` — All 12 simulation state models + validators
- `storage/snapshot.py` — SnapshotTableEntry, SnapshotManifest + all methods
- `connectors/rate_limit.py` — Fixed partial docstring on RateLimiter.min_interval

### App (`younggeul_app_kr_seoul_apartment`)
- `cli.py` — All 9 Click CLI commands
- `pipeline.py`, `snapshot.py`, `forecaster.py` — Core pipeline functions
- `transforms/` — All 19 Silver transform functions + 2 Gold transform functions
- `connectors/` — Fixed partial docstrings on all 3 connector fetch() methods
- `simulation/nodes/` — All 12 node factory functions
- `simulation/policies/` — All 5 policy classes + decide() methods
- `simulation/schemas/` — All round, intake, report, roster schemas
- `simulation/evidence/`, `simulation/event_store.py` — Store classes + methods
- `simulation/replay/`, `simulation/tracing.py`, `simulation/graph*.py`

## Verification
- `ruff format --check .` ✅
- `ruff check .` ✅
- `pytest` — 1,111 passed, 0 failed ✅
- Updated `docs/api-audit.md` with new coverage numbers

Closes #141