### PR TITLE
docs: publish API reference via mkdocstrings

### DIFF
--- a/core/src/younggeul_core/connectors/protocol.py
+++ b/core/src/younggeul_core/connectors/protocol.py
@@ -28,9 +28,8 @@ class ConnectorResult(Generic[TRec]):
 class Connector(Protocol[TReq, TRec]):
     """Protocol that all data connectors must satisfy.
 
-    Type Parameters:
-        TReq: The request model type (defines what to fetch).
-        TRec: The Bronze record model type (defines what is returned).
+    Generic over ``TReq`` (request model — defines what to fetch) and
+    ``TRec`` (Bronze record model — defines what is returned).
     """
 
     source_id: ClassVar[str]

--- a/core/src/younggeul_core/connectors/rate_limit.py
+++ b/core/src/younggeul_core/connectors/rate_limit.py
@@ -26,9 +26,6 @@ class RateLimiter:
     def min_interval(self) -> float:
         """Return the configured minimum interval in seconds.
 
-        Args:
-            None: This property does not accept parameters.
-
         Returns:
             The minimum interval value in seconds.
         """

--- a/core/src/younggeul_core/connectors/retry.py
+++ b/core/src/younggeul_core/connectors/retry.py
@@ -55,8 +55,8 @@ def retry(
         The return value of fn on success.
 
     Raises:
-        The last exception encountered after exhausting all attempts,
-        or NonRetryableError immediately.
+        ConnectorError: After exhausting all retry attempts.
+        NonRetryableError: Immediately on non-retryable errors.
     """
     last_exception: Exception | None = None
 

--- a/core/src/younggeul_core/state/simulation.py
+++ b/core/src/younggeul_core/state/simulation.py
@@ -123,9 +123,6 @@ class ScenarioSpec(BaseModel):
     def validate_target_period(self) -> "ScenarioSpec":
         """Validate that the scenario end date is not earlier than the start date.
 
-        Args:
-            self: The instance to validate.
-
         Returns:
             The validated instance.
 

--- a/docs/api/app-cli.md
+++ b/docs/api/app-cli.md
@@ -1,0 +1,7 @@
+# CLI Reference (API)
+
+Click-based command-line interface for the younggeul simulator.
+
+For usage examples, see the [CLI User Guide](../guide/cli.md).
+
+::: younggeul_app_kr_seoul_apartment.cli

--- a/docs/api/app-connectors.md
+++ b/docs/api/app-connectors.md
@@ -1,0 +1,21 @@
+# Data Connectors
+
+Government API connectors for Korean real estate data.
+
+## MOLIT (실거래가)
+
+Apartment transaction data from the Ministry of Land, Infrastructure and Transport.
+
+::: younggeul_app_kr_seoul_apartment.connectors.molit
+
+## BOK (금리)
+
+Interest rate data from the Bank of Korea.
+
+::: younggeul_app_kr_seoul_apartment.connectors.bok
+
+## KOSTAT (인구이동)
+
+Migration statistics from Statistics Korea.
+
+::: younggeul_app_kr_seoul_apartment.connectors.kostat

--- a/docs/api/app-pipeline.md
+++ b/docs/api/app-pipeline.md
@@ -1,0 +1,15 @@
+# Pipeline & Snapshot
+
+Data pipeline orchestration and immutable snapshot management.
+
+## Pipeline
+
+::: younggeul_app_kr_seoul_apartment.pipeline
+
+## Snapshot Management
+
+::: younggeul_app_kr_seoul_apartment.snapshot
+
+## Baseline Forecaster
+
+::: younggeul_app_kr_seoul_apartment.forecaster

--- a/docs/api/app-simulation.md
+++ b/docs/api/app-simulation.md
@@ -1,0 +1,111 @@
+# Simulation
+
+LangGraph-based multi-agent simulation engine.
+
+## Graph Builder
+
+::: younggeul_app_kr_seoul_apartment.simulation.graph
+
+## Graph State
+
+::: younggeul_app_kr_seoul_apartment.simulation.graph_state
+
+## Simulation Nodes
+
+### Intake Planner
+
+::: younggeul_app_kr_seoul_apartment.simulation.nodes.intake_planner
+
+### Scenario Builder
+
+::: younggeul_app_kr_seoul_apartment.simulation.nodes.scenario_builder
+
+### World Initializer
+
+::: younggeul_app_kr_seoul_apartment.simulation.nodes.world_initializer
+
+### Participant Decider
+
+::: younggeul_app_kr_seoul_apartment.simulation.nodes.participant_decider
+
+### Round Resolver
+
+::: younggeul_app_kr_seoul_apartment.simulation.nodes.round_resolver
+
+### Continue Gate
+
+::: younggeul_app_kr_seoul_apartment.simulation.nodes.continue_gate
+
+### Round Summarizer
+
+::: younggeul_app_kr_seoul_apartment.simulation.nodes.round_summarizer
+
+### Evidence Builder
+
+::: younggeul_app_kr_seoul_apartment.simulation.nodes.evidence_builder
+
+### Report Writer
+
+::: younggeul_app_kr_seoul_apartment.simulation.nodes.report_writer
+
+### Citation Gate
+
+::: younggeul_app_kr_seoul_apartment.simulation.nodes.citation_gate_node
+
+### Report Renderer
+
+::: younggeul_app_kr_seoul_apartment.simulation.nodes.report_renderer
+
+## Policies
+
+### Protocol
+
+::: younggeul_app_kr_seoul_apartment.simulation.policies.protocol
+
+### Heuristic Policies
+
+::: younggeul_app_kr_seoul_apartment.simulation.policies.heuristic
+
+### Policy Registry
+
+::: younggeul_app_kr_seoul_apartment.simulation.policies.registry
+
+## Schemas
+
+### Round
+
+::: younggeul_app_kr_seoul_apartment.simulation.schemas.round
+
+### Intake
+
+::: younggeul_app_kr_seoul_apartment.simulation.schemas.intake
+
+### Participant Roster
+
+::: younggeul_app_kr_seoul_apartment.simulation.schemas.participant_roster
+
+### Report
+
+::: younggeul_app_kr_seoul_apartment.simulation.schemas.report
+
+## Event System
+
+### Events
+
+::: younggeul_app_kr_seoul_apartment.simulation.events
+
+### Event Store
+
+::: younggeul_app_kr_seoul_apartment.simulation.event_store
+
+## Evidence Store
+
+::: younggeul_app_kr_seoul_apartment.simulation.evidence.store
+
+## Replay Engine
+
+::: younggeul_app_kr_seoul_apartment.simulation.replay.engine
+
+## Tracing
+
+::: younggeul_app_kr_seoul_apartment.simulation.tracing

--- a/docs/api/app-transforms.md
+++ b/docs/api/app-transforms.md
@@ -1,0 +1,19 @@
+# Data Transforms
+
+Bronze → Silver → Gold transformation functions.
+
+## Silver — Apartment Transactions
+
+::: younggeul_app_kr_seoul_apartment.transforms.silver_apt
+
+## Silver — Macro Indicators
+
+::: younggeul_app_kr_seoul_apartment.transforms.silver_macro
+
+## Gold — District Aggregation
+
+::: younggeul_app_kr_seoul_apartment.transforms.gold_district
+
+## Gold — Trend Enrichment
+
+::: younggeul_app_kr_seoul_apartment.transforms.gold_enrichment

--- a/docs/api/core-connectors.md
+++ b/docs/api/core-connectors.md
@@ -1,0 +1,23 @@
+# Connectors
+
+Protocol and utilities for data source connectors.
+
+## Connector Protocol
+
+::: younggeul_core.connectors.protocol
+
+## Retry Logic
+
+::: younggeul_core.connectors.retry
+
+## Rate Limiting
+
+::: younggeul_core.connectors.rate_limit
+
+## Content Hashing
+
+::: younggeul_core.connectors.hashing
+
+## Ingest Manifest
+
+::: younggeul_core.connectors.manifest

--- a/docs/api/core-evidence.md
+++ b/docs/api/core-evidence.md
@@ -1,0 +1,7 @@
+# Evidence Schemas
+
+Data models for the evidence-gated reporting pipeline.
+
+## Evidence Records
+
+::: younggeul_core.evidence.schemas

--- a/docs/api/core-state.md
+++ b/docs/api/core-state.md
@@ -1,0 +1,27 @@
+# State Schemas
+
+Data models for the Bronze → Silver → Gold data pipeline and simulation state.
+
+## Bronze Layer
+
+Raw ingested data — all fields are `str | None` for conservative parsing.
+
+::: younggeul_core.state.bronze
+
+## Silver Layer
+
+Typed and validated data with proper Python types.
+
+::: younggeul_core.state.silver
+
+## Gold Layer
+
+Aggregated features at district-monthly granularity.
+
+::: younggeul_core.state.gold
+
+## Simulation State
+
+Schemas for simulation runs, scenarios, participants, and outcomes.
+
+::: younggeul_core.state.simulation

--- a/docs/api/core-storage.md
+++ b/docs/api/core-storage.md
@@ -1,0 +1,7 @@
+# Storage
+
+Immutable snapshot system with content-addressed manifests.
+
+## Snapshot Schemas
+
+::: younggeul_core.storage.snapshot

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,30 @@
+# API Reference
+
+Auto-generated reference documentation for the **younggeul** public API,
+built from source code docstrings using
+[mkdocstrings](https://mkdocstrings.github.io/).
+
+## Packages
+
+### Core (`younggeul_core`)
+
+Platform-agnostic schemas, protocols, and utilities.
+
+| Module | Description |
+|--------|-------------|
+| [State Schemas](core-state.md) | Bronze, Silver, Gold, and Simulation data models |
+| [Evidence Schemas](core-evidence.md) | Evidence records, claim records, and gate results |
+| [Connectors](core-connectors.md) | Connector protocol, retry, rate limiting, hashing |
+| [Storage](core-storage.md) | Immutable snapshot manifest and table entries |
+
+### App (`younggeul_app_kr_seoul_apartment`)
+
+Korea-specific application implementing the Seoul apartment market simulator.
+
+| Module | Description |
+|--------|-------------|
+| [CLI](app-cli.md) | Click-based command-line interface |
+| [Pipeline](app-pipeline.md) | Data pipeline orchestration and snapshot management |
+| [Connectors](app-connectors.md) | MOLIT, BOK, KOSTAT government API connectors |
+| [Transforms](app-transforms.md) | Bronze → Silver → Gold data transformations |
+| [Simulation](app-simulation.md) | LangGraph simulation nodes, policies, and schemas |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,22 @@ theme:
 
 plugins:
   - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths:
+            - core/src
+            - apps/kr-seoul-apartment/src
+          options:
+            docstring_style: google
+            show_root_heading: true
+            show_source: false
+            members_order: source
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            merge_init_into_class: true
+            show_if_no_docstring: false
 
 markdown_extensions:
   - admonition
@@ -73,5 +89,18 @@ nav:
     - ADR-004 LangGraph Boundaries: adr/004-langgraph-boundaries.md
     - ADR-005 Evidence-Gated Reporting: adr/005-evidence-gated-reporting.md
     - ADR-006 Public Data Policy: adr/006-public-data-policy.md
+  - API Reference:
+    - Overview: api/index.md
+    - Core:
+      - State Schemas: api/core-state.md
+      - Evidence Schemas: api/core-evidence.md
+      - Connectors: api/core-connectors.md
+      - Storage: api/core-storage.md
+    - App:
+      - CLI: api/app-cli.md
+      - Pipeline: api/app-pipeline.md
+      - Connectors: api/app-connectors.md
+      - Transforms: api/app-transforms.md
+      - Simulation: api/app-simulation.md
   - Development History: development-history.md
   - Release Notes: release-notes.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ kr-seoul-apartment = [
 docs = [
   "mkdocs-material>=9.0",
   "mkdocs>=1.5",
+  "mkdocstrings[python]>=0.25",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Summary

Publishes auto-generated API reference documentation using mkdocstrings, rendering Google-style docstrings directly from source code into the MkDocs site.

## Changes

- **`pyproject.toml`**: Add `mkdocstrings[python]>=0.25` to `[project.optional-dependencies].docs`
- **`mkdocs.yml`**: Configure mkdocstrings plugin with Google-style parser, source paths for core and app packages, and API Reference nav section
- **`docs/api/`**: 11 new API reference pages:
  - `index.md` — overview with module map
  - Core: `core-state.md`, `core-evidence.md`, `core-connectors.md`, `core-storage.md`
  - App: `app-cli.md`, `app-pipeline.md`, `app-connectors.md`, `app-transforms.md`, `app-simulation.md`
- **Griffe warning fixes** (4 files):
  - `protocol.py`: Replace structured "Type Parameters:" section with inline prose (griffe limitation with Protocol generics)
  - `rate_limit.py`: Remove invalid `Args: None:` from property docstring
  - `retry.py`: Fix Raises section to use `ExceptionType: description` format
  - `simulation.py`: Remove invalid `Args: self:` from validator docstring

## Verification

- `mkdocs build --strict` passes with **zero warnings**
- All 11 API reference pages render correctly
- Existing docs pages unaffected

Closes #143