### PR TITLE
docs: add developer tutorials for connectors and simulation nodes

### DIFF
--- a/docs/tutorials/add-connector.md
+++ b/docs/tutorials/add-connector.md
@@ -1,0 +1,316 @@
+# How to Add a Data Connector
+
+## Overview
+
+In Younggeul, a connector fetches one partition of external data, normalizes it, maps it to Bronze records, and returns a `ConnectorResult` with a manifest. The pipeline only sees typed Bronze models, so connectors are where source-specific API shape and cleanup logic live. Use the existing MOLIT/BOK/KOSTAT connectors as your implementation template.
+
+## Prerequisites
+
+- You know which upstream API and partition key(s) you need (for example: one `sigungu_code` + one `year_month`).
+- You have a Bronze record schema in `younggeul_core.state.bronze` (or will add one) that follows the Bronze convention.
+- You can run `pytest` for unit tests in `apps/kr-seoul-apartment/tests/unit`.
+
+## Step 1: Define the Request Model
+
+Use a frozen dataclass for partition-scoped request params.
+
+`MolitAptRequest` in `connectors/molit.py` is the canonical pattern:
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class MolitAptRequest:
+    """Partition-scoped request for one sigungu + one month."""
+
+    sigungu_code: str
+    year_month: str
+```
+
+For a new connector, keep the same shape (frozen + explicit partition fields):
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class NewLegalDistrictRequest:
+    """Partition-scoped request for one region + one month."""
+
+    region_scope: str
+    year_month: str
+```
+
+## Step 2: Define the Bronze Record Model
+
+Bronze models are Pydantic models in `younggeul_core.state.bronze` and include ingestion metadata via `BronzeIngestMeta`. Convention: source payload fields are `str | None` (raw, minimally interpreted).
+
+Pattern from existing models (`BronzeAptTransaction`, `BronzeInterestRate`, `BronzeMigration`, `BronzeLegalDistrictCode`):
+
+```python
+from pydantic import ConfigDict
+
+from younggeul_core.state.bronze import BronzeIngestMeta
+
+
+class BronzeLegalDistrictCode(BronzeIngestMeta):
+    model_config = ConfigDict(str_strip_whitespace=True, frozen=True)
+
+    code: str | None = None
+    name: str | None = None
+    is_active: str | None = None
+```
+
+## Step 3: Implement the Connector Class
+
+Follow the same import and fetch flow used by `MolitAptConnector`, `BokInterestRateConnector`, and `KostatMigrationConnector`.
+
+```python
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import Any, ClassVar
+
+import pandas as pd
+
+from younggeul_core.connectors.hashing import sha256_payload
+from younggeul_core.connectors.manifest import build_manifest
+from younggeul_core.connectors.protocol import ConnectorResult
+from younggeul_core.connectors.rate_limit import RateLimiter
+from younggeul_core.connectors.retry import ConnectorError, NonRetryableError, retry
+from younggeul_core.state.bronze import BronzeLegalDistrictCode
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _normalize_dataframe(df: pd.DataFrame) -> list[dict[str, Any]]:
+    # Keep deterministic row-order, convert NaN->None, stringify values.
+    rows: list[dict[str, Any]] = []
+    for _, series in df.iterrows():
+        rows.append(
+            {
+                "REGION_CODE": None if pd.isna(series["REGION_CODE"]) else str(series["REGION_CODE"]),
+                "REGION_NAME": None if pd.isna(series["REGION_NAME"]) else str(series["REGION_NAME"]),
+                "IS_ACTIVE": None if pd.isna(series["IS_ACTIVE"]) else str(series["IS_ACTIVE"]),
+            }
+        )
+    return rows
+
+
+def _map_to_bronze(
+    raw_rows: list[dict[str, Any]],
+    *,
+    source_id: str,
+    ingest_timestamp: datetime,
+    raw_response_hash: str,
+) -> list[BronzeLegalDistrictCode]:
+    return [
+        BronzeLegalDistrictCode(
+            ingest_timestamp=ingest_timestamp,
+            source_id=source_id,
+            raw_response_hash=raw_response_hash,
+            code=row.get("REGION_CODE"),
+            name=row.get("REGION_NAME"),
+            is_active=row.get("IS_ACTIVE"),
+        )
+        for row in raw_rows
+    ]
+
+
+class NewLegalDistrictConnector:
+    source_id: ClassVar[str] = "kostat_legal_district_code"
+
+    def __init__(
+        self,
+        client: Any,
+        rate_limiter: RateLimiter,
+        now_fn: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        self._client = client
+        self._rate_limiter = rate_limiter
+        self._now_fn = now_fn
+
+    def fetch(self, request: NewLegalDistrictRequest) -> ConnectorResult[BronzeLegalDistrictCode]:
+        now = self._now_fn()
+        request_params = {"region_scope": request.region_scope, "year_month": request.year_month}
+
+        def _call_api() -> pd.DataFrame:
+            self._rate_limiter.wait()  # keep this inside retry() callable
+            return self._client.get_data(region_scope=request.region_scope, year_month=request.year_month)
+
+        try:
+            raw_df = retry(_call_api)
+        except Exception as exc:
+            if isinstance(exc, ConnectorError) and not exc.retryable:
+                raise
+            manifest = build_manifest(
+                source_id=self.source_id,
+                api_endpoint="statisticsParameterData",
+                request_params=request_params,
+                response_count=0,
+                ingested_at=now,
+                status="failed",
+                error_message=str(exc),
+            )
+            return ConnectorResult(records=[], manifest=manifest)
+
+        if raw_df is None or raw_df.empty:
+            return ConnectorResult(
+                records=[],
+                manifest=build_manifest(
+                    source_id=self.source_id,
+                    api_endpoint="statisticsParameterData",
+                    request_params=request_params,
+                    response_count=0,
+                    ingested_at=now,
+                    status="success",
+                ),
+            )
+
+        required = {"REGION_CODE", "REGION_NAME", "IS_ACTIVE"}
+        missing = required - set(raw_df.columns)
+        if missing:
+            raise NonRetryableError(f"Missing expected columns: {sorted(missing)}")
+
+        raw_rows = _normalize_dataframe(raw_df)
+        response_hash = sha256_payload(raw_rows)
+        records = _map_to_bronze(
+            raw_rows,
+            source_id=self.source_id,
+            ingest_timestamp=now,
+            raw_response_hash=response_hash,
+        )
+
+        manifest = build_manifest(
+            source_id=self.source_id,
+            api_endpoint="statisticsParameterData",
+            request_params=request_params,
+            response_count=len(records),
+            ingested_at=now,
+            status="success",
+        )
+        return ConnectorResult(records=records, manifest=manifest)
+```
+
+## Step 4: Write Unit Tests
+
+Mirror `tests/unit/test_molit.py`: mock client, use `RateLimiter(min_interval=0.0)`, inject fixed `now_fn`, and test mapping/manifest/errors/hash.
+
+```python
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from younggeul_core.connectors.rate_limit import RateLimiter
+from younggeul_core.connectors.retry import ConnectorError, NonRetryableError
+
+_FIXED_NOW = datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _fixed_now() -> datetime:
+    return _FIXED_NOW
+
+
+def _make_connector(client: MagicMock | None = None) -> tuple[NewLegalDistrictConnector, MagicMock]:
+    mock_client = client or MagicMock()
+    connector = NewLegalDistrictConnector(
+        client=mock_client,
+        rate_limiter=RateLimiter(min_interval=0.0),
+        now_fn=_fixed_now,
+    )
+    return connector, mock_client
+
+
+def test_success_mapping() -> None:
+    connector, client = _make_connector()
+    client.get_data.return_value = pd.DataFrame(
+        {
+            "REGION_CODE": ["11680"],
+            "REGION_NAME": ["강남구"],
+            "IS_ACTIVE": ["Y"],
+        }
+    )
+
+    result = connector.fetch(NewLegalDistrictRequest(region_scope="seoul", year_month="202507"))
+
+    assert len(result.records) == 1
+    assert result.records[0].code == "11680"
+    assert result.records[0].ingest_timestamp == _FIXED_NOW
+    assert result.manifest.status == "success"
+
+
+def test_failed_manifest_on_error() -> None:
+    connector, client = _make_connector()
+    client.get_data.side_effect = ConnectorError("API timeout")
+
+    result = connector.fetch(NewLegalDistrictRequest(region_scope="seoul", year_month="202507"))
+
+    assert result.records == []
+    assert result.manifest.status == "failed"
+    assert "API timeout" in (result.manifest.error_message or "")
+
+
+def test_missing_columns_raises_non_retryable() -> None:
+    connector, client = _make_connector()
+    client.get_data.return_value = pd.DataFrame({"REGION_CODE": ["11680"]})
+
+    with pytest.raises(NonRetryableError, match="Missing expected columns"):
+        connector.fetch(NewLegalDistrictRequest(region_scope="seoul", year_month="202507"))
+
+
+def test_hash_deterministic() -> None:
+    connector, client = _make_connector()
+    df = pd.DataFrame(
+        {
+            "REGION_CODE": ["11680"],
+            "REGION_NAME": ["강남구"],
+            "IS_ACTIVE": ["Y"],
+        }
+    )
+
+    client.get_data.return_value = df
+    r1 = connector.fetch(NewLegalDistrictRequest(region_scope="seoul", year_month="202507"))
+    client.get_data.return_value = df
+    r2 = connector.fetch(NewLegalDistrictRequest(region_scope="seoul", year_month="202507"))
+
+    assert r1.records[0].raw_response_hash == r2.records[0].raw_response_hash
+```
+
+## Step 5: Integrate with Ingestion
+
+Connector outputs are just typed Bronze lists + manifests. Convert them into `BronzeInput` and pass to `run_pipeline`.
+
+```python
+from younggeul_app_kr_seoul_apartment.pipeline import BronzeInput, run_pipeline
+
+# Example partition loop
+molit_records = []
+for req in [MolitAptRequest(sigungu_code="11680", year_month="202507")]:
+    result = molit_connector.fetch(req)
+    molit_records.extend(result.records)
+    # persist result.manifest if needed
+
+bronze = BronzeInput(
+    apt_transactions=molit_records,
+    interest_rates=interest_rate_records,
+    migrations=migration_records,
+)
+
+pipeline_result = run_pipeline(bronze)
+```
+
+## Summary
+
+Checklist:
+
+- [ ] Added a frozen partition request dataclass.
+- [ ] Added/confirmed a Bronze Pydantic model with source fields as `str | None`.
+- [ ] Implemented connector `fetch()` with: `retry()` + `RateLimiter.wait()` + normalization + `sha256_payload()` + Bronze mapping + `build_manifest()`.
+- [ ] Added unit tests for success mapping, failed manifest, missing-column `NonRetryableError`, and deterministic hash.
+- [ ] Wired connector records into `BronzeInput` and executed `run_pipeline()`.

--- a/docs/tutorials/add-node.md
+++ b/docs/tutorials/add-node.md
@@ -1,0 +1,264 @@
+# How to Add a Simulation Node
+
+## Overview
+
+Simulation nodes are LangGraph node callables that read `SimulationGraphState`, compute one step, emit provenance events, and return partial state updates. In Younggeul, nodes are built via dependency-injected factories (`make_<node>_node(...)`) and then wired into `build_simulation_graph`. The intake planner is the canonical reference implementation.
+
+## Prerequisites
+
+- You understand LangGraph `StateGraph` basics (`add_node`, `add_edge`, `add_conditional_edges`).
+- You know the required input keys your node needs from `SimulationGraphState`.
+- You can run unit tests in `apps/kr-seoul-apartment/tests/unit`.
+
+## Step 1: Understand the Graph State
+
+`SimulationGraphState` (TypedDict) is the contract between nodes.
+
+```python
+from typing import Annotated, Any, TypedDict
+import operator
+
+from younggeul_core.state.simulation import (
+    ActionProposal,
+    ParticipantState,
+    ReportClaim,
+    RoundOutcome,
+    RunMeta,
+    ScenarioSpec,
+    SegmentState,
+    SnapshotRef,
+)
+
+
+class SimulationGraphState(TypedDict, total=False):
+    user_query: str
+    intake_plan: dict[str, Any]
+
+    run_meta: RunMeta
+    snapshot: SnapshotRef
+    scenario: ScenarioSpec
+    round_no: int
+    max_rounds: int
+    world: dict[str, SegmentState]
+    participants: dict[str, ParticipantState]
+    governance_actions: dict[str, ActionProposal]
+    market_actions: dict[str, ActionProposal]
+    last_outcome: RoundOutcome | None
+
+    event_refs: Annotated[list[str], operator.add]
+    evidence_refs: Annotated[list[str], operator.add]
+    report_claims: Annotated[list[ReportClaim], operator.add]
+    warnings: Annotated[list[str], operator.add]
+```
+
+Key idea: nodes return only changed keys; reducers (for `event_refs`, `warnings`, etc.) merge outputs over graph execution.
+
+## Step 2: Create the Node Factory
+
+Follow the `intake_planner.py` factory pattern: dependency injection + inner node callable.
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from ..events import EventStore, SimulationEvent
+from ..graph_state import SimulationGraphState
+from ..llm.ports import LLMMessage, StructuredLLM
+from ..schemas.intake import IntakePlan
+
+
+def make_intake_planner_node(
+    event_store: EventStore,
+    structured_llm: StructuredLLM,
+) -> Any:
+    def node(state: SimulationGraphState) -> dict[str, Any]:
+        from datetime import datetime, timezone
+        from uuid import uuid4
+
+        user_query = state.get("user_query", "")
+        messages: list[LLMMessage] = [
+            {"role": "system", "content": INTAKE_SYSTEM_PROMPT},
+            {"role": "user", "content": user_query},
+        ]
+
+        plan = structured_llm.generate_structured(
+            messages=messages,
+            response_model=IntakePlan,
+            temperature=0.0,
+        )
+
+        run_meta = state.get("run_meta")
+        if run_meta is None:
+            raise ValueError("run_meta is required before emitting simulation events")
+
+        event_id = str(uuid4())
+        event_store.append(
+            SimulationEvent(
+                event_id=event_id,
+                run_id=run_meta.run_id,
+                round_no=0,
+                event_type="INTAKE_PLANNED",
+                timestamp=datetime.now(timezone.utc),
+                payload=plan.model_dump(),
+            )
+        )
+
+        return {
+            "intake_plan": plan.model_dump(),
+            "event_refs": [event_id],
+        }
+
+    return node
+```
+
+When adding your own node, keep this structure:
+
+- `make_<node>_node(...dependencies)` returns `node`.
+- `node(state: SimulationGraphState) -> dict[str, Any]`.
+- Read with `state.get(...)`.
+- Validate required inputs and `raise ValueError` for missing invariants.
+- Return only state updates.
+
+## Step 3: Emit Events for Provenance
+
+Every important node action should append a `SimulationEvent` and return its ID in `event_refs`.
+
+```python
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from ..events import SimulationEvent
+
+run_meta = state.get("run_meta")
+if run_meta is None:
+    raise ValueError("run_meta is required before emitting simulation events")
+
+event_id = str(uuid4())
+event_store.append(
+    SimulationEvent(
+        event_id=event_id,
+        run_id=run_meta.run_id,
+        round_no=state.get("round_no", 0),
+        event_type="MY_NODE_COMPLETED",
+        timestamp=datetime.now(timezone.utc),
+        payload={"input_summary": "...", "result_summary": "..."},
+    )
+)
+
+return {
+    "event_refs": [event_id],
+    # plus your node outputs
+}
+```
+
+## Step 4: Register the Node in the Graph
+
+Wire your node in `simulation/graph.py` with tracing and explicit edges.
+
+```python
+graph = StateGraph(SimulationGraphState)
+
+intake_planner_node = make_intake_planner_node(event_store, structured_llm)
+world_initializer_node = make_world_initializer_node(event_store, snapshot_reader)
+
+graph.add_node("intake_planner", _traced_node("intake_planner", intake_planner_node))
+graph.add_node("world_initializer", _traced_node("world_initializer", world_initializer_node))
+
+graph.add_edge(START, "intake_planner")
+graph.add_edge("intake_planner", "scenario_builder")
+graph.add_conditional_edges(
+    "world_initializer",
+    _should_start_rounds,
+    {
+        "participant_decider": "participant_decider",
+        "round_summarizer": "round_summarizer",
+    },
+)
+```
+
+The existing graph already uses this pattern for every node (`intake_planner`, `scenario_builder`, `world_initializer`, ...).
+
+## Step 5: Write Unit Tests
+
+Match `test_intake_planner.py`: seed state with `seed_graph_state`, inject fake ports, call node directly, assert state + events.
+
+```python
+from typing import Any
+
+import pytest
+
+from younggeul_app_kr_seoul_apartment.simulation.event_store import InMemoryEventStore
+from younggeul_app_kr_seoul_apartment.simulation.graph_state import (
+    SimulationGraphState,
+    seed_graph_state,
+)
+from younggeul_app_kr_seoul_apartment.simulation.nodes.intake_planner import make_intake_planner_node
+from younggeul_app_kr_seoul_apartment.simulation.schemas.intake import IntakePlan
+
+
+class FakeStructuredLLM:
+    def __init__(self, response: IntakePlan) -> None:
+        self.response = response
+
+    def generate_structured(self, **_: Any) -> IntakePlan:
+        return self.response
+
+
+def test_node_returns_updates_and_event_refs() -> None:
+    store = InMemoryEventStore()
+    plan = IntakePlan(
+        user_query="강남구 아파트를 스트레스 테스트해줘",
+        objective="금리 인상 시 가격 민감도를 확인한다.",
+        analysis_mode="stress",
+        geography_hint="강남구",
+        segment_hint="아파트",
+        horizon_months=12,
+        requested_shocks=["금리인상"],
+        participant_focus=["실수요자", "투자자"],
+        constraints=["월 1회 업데이트"],
+        assumptions=["정책 변화 없음"],
+        ambiguities=["시작 시점이 불명확함"],
+    )
+    node = make_intake_planner_node(store, FakeStructuredLLM(plan))
+    state = seed_graph_state(plan.user_query, "run-node-001", "run-node", "gpt-test")
+
+    result = node(state)
+
+    assert result["intake_plan"] == plan.model_dump()
+    assert len(result["event_refs"]) == 1
+    assert store.count("run-node-001") == 1
+
+
+def test_node_raises_when_required_input_missing() -> None:
+    store = InMemoryEventStore()
+    minimal_plan = IntakePlan(
+        user_query="강남구 분석",
+        objective="시장 방향을 요약한다.",
+        analysis_mode="baseline",
+        geography_hint=None,
+        segment_hint=None,
+        horizon_months=12,
+        requested_shocks=[],
+        participant_focus=[],
+        constraints=[],
+        assumptions=[],
+        ambiguities=[],
+    )
+    node = make_intake_planner_node(store, FakeStructuredLLM(minimal_plan))
+    state: SimulationGraphState = {"user_query": "강남구 분석"}
+
+    with pytest.raises(ValueError, match="run_meta is required"):
+        node(state)
+```
+
+## Summary
+
+Checklist:
+
+- [ ] Identified required input/output keys in `SimulationGraphState`.
+- [ ] Added `make_<node>_node(...dependencies)` with `node(state) -> dict[str, Any]`.
+- [ ] Added invariant checks (`ValueError`) for required state inputs.
+- [ ] Emitted `SimulationEvent` via `EventStore.append(...)` and returned `event_refs`.
+- [ ] Registered node with `_traced_node` and connected edges (`add_edge` / `add_conditional_edges`).
+- [ ] Added unit tests with `seed_graph_state`, fake ports, and direct node invocation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,9 @@ nav:
     - Data Plane: architecture/data-plane.md
     - Simulation Plane: architecture/simulation-plane.md
     - Evidence-Gated Reporting: architecture/reporting.md
+  - Tutorials:
+    - How to Add a Connector: tutorials/add-connector.md
+    - How to Add a Simulation Node: tutorials/add-node.md
   - ADRs:
     - ADR-001 Clean-Room Development: adr/001-clean-room-development.md
     - ADR-002 Monorepo Boundaries: adr/002-monorepo-boundaries.md


### PR DESCRIPTION
## Summary

Adds two code-forward developer tutorials showing how to extend the Younggeul platform:

- **How to Add a Data Connector** (`docs/tutorials/add-connector.md`) — Walks through the `Connector` protocol, request dataclass, Bronze model, fetch pattern (retry + rate limiter), hash/manifest, and unit testing.
- **How to Add a Simulation Node** (`docs/tutorials/add-node.md`) — Walks through `SimulationGraphState`, node factory pattern, event emission, graph registration, and unit testing.

Both tutorials use real imports, class names, and patterns from the existing codebase (MolitAptConnector, intake_planner, etc.).

## Changes

- `docs/tutorials/add-connector.md` — New tutorial (316 lines)
- `docs/tutorials/add-node.md` — New tutorial (264 lines)
- `mkdocs.yml` — Added "Tutorials" nav section between Architecture and ADRs

## Verification

- `mkdocs build --strict` passes with zero warnings

Closes #144