### PR TITLE
docs: expand ADRs with alternatives, rationale, and examples

### DIFF
--- a/docs/adr/001-clean-room-development.md
+++ b/docs/adr/001-clean-room-development.md
@@ -11,6 +11,8 @@ The Younggeul project aims to provide a robust open-source platform for real est
 
 To maximize adoption, encourage commercial compatibility, and foster a broad ecosystem of contributors, Younggeul must be licensed under the Apache License 2.0. However, the existence of MiroFish creates a risk of "licensing contamination" if any code, architectural patterns, or specific LLM prompts are carried over from the AGPL-licensed codebase.
 
+This risk is not only legal but also operational: once contamination is suspected, downstream adopters may avoid the project regardless of technical quality. The project also needs a clean provenance story for enterprise due diligence, including package audits and procurement reviews. Finally, architecture and prompts must be independently designed so that future governance decisions can rely on clearly documented original authorship.
+
 ## Decision
 We will implement a strict **Clean-Room Development** process for Younggeul.
 
@@ -19,6 +21,93 @@ We will implement a strict **Clean-Room Development** process for Younggeul.
 3.  **Prompt Engineering**: All LLM prompts used for reasoning, extraction, and reporting must be written from scratch. Even if the functional goal is identical to a MiroFish prompt, the implementation must be original.
 4.  **Independent Implementation**: The core engine, data pipelines (Bronze/Silver/Gold), and agent orchestration must be designed based on the requirements of Younggeul without looking at the MiroFish implementation details.
 5.  **Clean Dependency Graph**: Younggeul will not depend on Zep Cloud or OASIS in its core runtime, ensuring a portable and unencumbered codebase.
+
+## Alternatives Considered
+### A) Fork MiroFish and attempt relicensing
+- **Pros**
+  - Fastest path to a feature-complete baseline.
+  - Existing battle-tested prompt and pipeline logic.
+- **Cons**
+  - AGPL inheritance would remain or require complex rights clearance.
+  - High legal uncertainty for external adopters.
+  - Strong risk of carrying over hidden coupling to Zep Cloud/OASIS.
+
+### B) Dual-license with AGPL compatibility layer
+- **Pros**
+  - Could preserve some prior components while adding permissive wrappers.
+  - Potentially less rewrite effort than full reimplementation.
+- **Cons**
+  - Core legal ambiguity remains for derivative components.
+  - Operational complexity in separating boundaries of AGPL vs Apache code.
+  - Difficult for contributors to reason about what is safe to modify or redistribute.
+
+### C) Clean-room implementation from scratch (Selected)
+- **Pros**
+  - Strongest legal clarity and provenance.
+  - Clean architecture reset without historical coupling constraints.
+  - Simplifies enterprise adoption under Apache-2.0 expectations.
+- **Cons**
+  - Highest short-term implementation effort.
+  - Requires systematic re-validation of old domain edge cases.
+
+## Rationale
+The selected clean-room strategy best aligns with the project’s adoption goals: broad open-source usage, commercial compatibility, and low-friction legal review. The primary design constraint is not only “can it work?” but “can every component be shown as independently authored and redistributable under Apache-2.0.”
+
+A fork or compatibility-layer approach could reduce initial engineering cost, but both introduce legal and governance debt that compounds over time. In contrast, a clean-room process localizes cost at project inception and keeps long-term maintenance simpler.
+
+The runtime architecture already reflects this decision:
+- `core/` defines generic reusable mechanics.
+- `apps/` provides market/domain implementations.
+- `benchmarks/` evaluates behavior without changing legal boundaries.
+
+This separation allows independent evolution while preserving licensing clarity and avoiding vendor lock-in dependencies.
+
+## Examples
+### 1) Required Apache-2.0 file header template
+The project policy requires each new source file to include an Apache-2.0 notice header.
+
+```python
+# Copyright 2026 Younggeul Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+```
+
+### 2) Dependency direction that avoids AGPL-coupled runtime components
+Current repository layout and packaging show explicit separation:
+
+```text
+/data/GitHub/younggeul/
+├── core/
+├── apps/
+│   └── kr-seoul-apartment/
+└── benchmarks/
+    └── kr-housing/
+```
+
+`pyproject.toml` wheel packages:
+
+```toml
+[tool.hatch.build.targets.wheel]
+packages = [
+  "core/src/younggeul_core",
+  "apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment",
+]
+```
+
+`apps` importing from `core` (allowed direction):
+
+```python
+# apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py
+from younggeul_core.state.bronze import BronzeAptTransaction, BronzeInterestRate, BronzeMigration
+from younggeul_core.state.gold import GoldDistrictMonthlyMetrics
+from younggeul_core.state.simulation import SnapshotRef
+```
+
+These examples demonstrate a clean core-first dependency graph (`core -> apps -> benchmarks` usage pattern) and no runtime dependency on Zep Cloud/OASIS.
 
 ## Consequences
 ### Positive

--- a/docs/adr/002-monorepo-boundaries.md
+++ b/docs/adr/002-monorepo-boundaries.md
@@ -14,6 +14,8 @@ The Younggeul project must simultaneously support:
 
 Without clear package boundaries, these components could become tightly coupled. For instance, if the core platform depends on Seoul-specific apartment data schemas, it becomes difficult to extend the system to other asset types or countries.
 
+The repository also needs a single source of truth for tooling, testing, linting, and dependency definitions. A fragmented structure would increase CI complexity and make cross-package refactors slow and error-prone. We therefore need explicit dependency direction and packaging conventions that are easy to enforce and audit.
+
 ## Decision
 We will adopt a **Monorepo Structure** with three distinct top-level directories, each with its own package definition and clear dependency directions.
 
@@ -27,6 +29,90 @@ We will adopt a **Monorepo Structure** with three distinct top-level directories
 2.  **Apps Build on Core**: Packages in `apps/` import from `core/`. They provide the concrete implementation of the abstract interfaces defined in core.
 3.  **Benchmarks Evaluate Both**: Packages in `benchmarks/` may import from both `core/` and any package in `apps/` to run full end-to-end evaluation cycles.
 4.  **No Cross-App Imports**: Packages within `apps/` should not depend on each other (e.g., `kr-seoul-apartment` should not import from `kr-daegu-commercial`). Common logic between apps should be promoted to `core/`.
+
+## Alternatives Considered
+### A) Polyrepo with separate git repositories
+- **Pros**
+  - Strong physical isolation between packages.
+  - Independent release cadence per repository.
+- **Cons**
+  - High overhead for synchronized changes across core/apps/benchmarks.
+  - Duplicated CI templates and tooling configs.
+  - Harder local development and integration testing.
+
+### B) Single package with submodules/namespaces only
+- **Pros**
+  - Minimal packaging complexity.
+  - One install target for all functionality.
+- **Cons**
+  - Weak architectural boundary enforcement.
+  - Higher risk of accidental reverse dependencies into `core`.
+  - Difficult to reason about ownership and extension points.
+
+### C) Monorepo with workspace-style layout (Selected)
+- **Pros**
+  - Shared tooling and unified quality gates.
+  - Fast cross-cutting refactors with atomic commits.
+  - Clear dependency rules by directory/package role.
+- **Cons**
+  - Requires discipline to prevent boundary erosion.
+  - CI may need path-aware optimization as repository grows.
+
+## Rationale
+The monorepo model best supports Younggeul’s current scale and roadmap. We need cohesive iteration across shared schemas (`younggeul_core`), application behavior (`younggeul_app_kr_seoul_apartment`), and evaluation paths (`benchmarks/kr-housing`). This is easiest when all components evolve in one repository with a consistent toolchain.
+
+The decisive constraint is controlled dependency direction. `core` must remain geography-agnostic; `apps` can specialize by geography/asset; `benchmarks` can compose both for end-to-end verification. This minimizes accidental coupling while retaining development velocity.
+
+`pyproject.toml` already reflects this organization by declaring package roots and test paths spanning `core`, `apps`, and `benchmarks`.
+
+## Examples
+### 1) Actual repository directory structure
+
+```text
+/data/GitHub/younggeul/
+├── core/
+│   ├── src/
+│   └── tests/
+├── apps/
+│   └── kr-seoul-apartment/
+└── benchmarks/
+    └── kr-housing/
+```
+
+### 2) Workspace/package configuration in `pyproject.toml`
+
+```toml
+[tool.hatch.build.targets.wheel]
+packages = [
+  "core/src/younggeul_core",
+  "apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment",
+]
+
+[tool.pytest.ini_options]
+testpaths = [
+  "core/tests",
+  "apps/kr-seoul-apartment/tests",
+]
+pythonpath = [
+  "core/src",
+  "apps/kr-seoul-apartment/src",
+  "benchmarks/kr-housing/src",
+]
+```
+
+### 3) Allowed import direction: `apps` importing from `core`
+
+```python
+# apps/kr-seoul-apartment/.../simulation/graph_state.py
+from younggeul_core.state.simulation import (
+    ActionProposal,
+    ParticipantState,
+    ReportClaim,
+    RoundOutcome,
+)
+```
+
+This import direction is intentional: application packages consume generic core contracts and provide concrete domain behavior.
 
 ## Consequences
 ### Positive

--- a/docs/adr/003-immutable-dataset-snapshots.md
+++ b/docs/adr/003-immutable-dataset-snapshots.md
@@ -11,6 +11,8 @@ Younggeul simulations (e.g., forecasting ROI for Seoul apartments) must be repro
 
 Furthermore, auditing a simulation run requires knowing exactly what data the agent saw at that moment. A dynamic, ever-changing database makes such auditing impossible.
 
+The system also needs deterministic identifiers for caching, report traceability, and reproducible benchmark baselines. When teams share runs, they must be able to verify that all tables and hashes match without manual reconciliation. This requires a manifest format with explicit table metadata, integrity checks, and a stable `dataset_snapshot_id` derivation rule.
+
 ## Decision
 We will implement an **Immutable Dataset Snapshot** system for all simulation and evaluation runs.
 
@@ -19,6 +21,101 @@ We will implement an **Immutable Dataset Snapshot** system for all simulation an
 3.  **Storage Format**: Snapshots are stored as sets of versioned Parquet files accompanied by a JSON manifest. The manifest includes metadata about data sources, ingestion timestamps, and the specific table schema versions.
 4.  **Deterministic Production**: Identical input data (raw files and processing scripts) must always produce an identical `dataset_snapshot_id`. This ensures that snapshots can be safely cached and distributed between team members.
 5.  **Audit Trail**: The `dataset_snapshot_id` will be logged as part of every simulation's trace data, allowing us to recreate the exact environment of any historical run.
+
+## Alternatives Considered
+### A) Git-tracked data files
+- **Pros**
+  - Simple mental model: data versioned directly in git history.
+  - Easy to inspect diffs for tiny datasets.
+- **Cons**
+  - Repository bloat for realistic real-estate data volumes.
+  - Poor scalability for frequent updates.
+  - Difficult to enforce strict run-time snapshot pinning semantics.
+
+### B) Database with versioned tables
+- **Pros**
+  - Centralized data governance and query flexibility.
+  - Potentially strong audit controls at DB layer.
+- **Cons**
+  - Higher operational cost and infrastructure dependency.
+  - Harder local reproducibility for contributors.
+  - Additional migration/versioning complexity across environments.
+
+### C) Immutable snapshot manifests + content hashes (Selected)
+- **Pros**
+  - Deterministic identity and integrity checks.
+  - Portable artifacts that can be moved across environments.
+  - Clean linkage into simulation/report traces.
+- **Cons**
+  - Requires explicit publish/resolve workflow.
+  - Storage lifecycle policy needed for older snapshots.
+
+## Rationale
+The selected approach balances determinism, portability, and operational simplicity. The core requirement is reproducibility across local runs, CI, and shared environments without relying on centralized mutable state. Hash-addressed snapshots directly satisfy this requirement.
+
+The implementation in `core/src/younggeul_core/storage/snapshot.py` codifies strict schema validation (`dataset_snapshot_id` and `table_hash` must be lowercase 64-char SHA-256 hex) and integrity verification (`validate_integrity`). In app-level publishing (`apps/kr-seoul-apartment/.../snapshot.py`), table content is hashed, snapshot ID is computed deterministically, and a manifest is written with table metadata.
+
+This gives an auditable chain from raw table bytes → table hash → ordered hash set → snapshot ID used by simulations and reports.
+
+## Examples
+### 1) Manifest schema and required fields (real implementation)
+
+```python
+# core/src/younggeul_core/storage/snapshot.py
+class SnapshotManifest(BaseModel):
+    dataset_snapshot_id: str
+    created_at: datetime
+    description: str | None = None
+    table_entries: list[SnapshotTableEntry]
+    source_ids: list[str] = Field(default_factory=list)
+    ingestion_started_at: datetime | None = None
+    ingestion_completed_at: datetime | None = None
+```
+
+`SnapshotTableEntry` includes:
+- `table_name`
+- `table_hash`
+- `record_count`
+- `schema_version`
+- `source_uri` (optional)
+- `file_format` (`"parquet" | "csv" | "jsonl"`)
+
+### 2) Deterministic `dataset_snapshot_id` computation
+
+```python
+# core/src/younggeul_core/storage/snapshot.py
+@classmethod
+def compute_snapshot_id(cls, table_hashes: dict[str, str]) -> str:
+    items = sorted(table_hashes.items(), key=lambda item: item[0])
+    joined = "".join(f"{table_name}:{table_hash}" for table_name, table_hash in items)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+```
+
+This guarantees ordering independence at input map level and stable output for the same table hash set.
+
+### 3) Concrete publish flow and manifest output
+
+```python
+# apps/kr-seoul-apartment/src/.../snapshot.py
+table_hash = hashlib.sha256(jsonl_content).hexdigest()
+dataset_snapshot_id = SnapshotManifest.compute_snapshot_id({_TABLE_NAME: table_hash})
+
+manifest = SnapshotManifest(
+    dataset_snapshot_id=dataset_snapshot_id,
+    created_at=created_at,
+    table_entries=[
+        SnapshotTableEntry(
+            table_name=_TABLE_NAME,
+            table_hash=table_hash,
+            record_count=len(sorted_rows),
+            schema_version="1.0.0",
+            file_format="jsonl",
+        )
+    ],
+)
+```
+
+The manifest is serialized to `manifest.json` in the snapshot directory and verified during `resolve_snapshot` before use.
 
 ## Consequences
 ### Positive

--- a/docs/adr/004-langgraph-boundaries.md
+++ b/docs/adr/004-langgraph-boundaries.md
@@ -9,6 +9,8 @@ Accepted
 ## Context
 LangGraph provides a powerful framework for multi-agent orchestration, allowing for cycles, branching, and complex state management. However, unconstrained use of LangGraph—especially with free-form message lists—tends to produce "black box" agents that are difficult to debug, hard to test, and prone to state bloat. We need to define clear boundaries and patterns for LangGraph usage in Younggeul to ensure reproducibility and maintainability.
 
+Younggeul’s simulation pipeline must combine deterministic transforms, typed evidence artifacts, and constrained LLM usage. If graph state becomes untyped or overly conversational, deterministic replay and schema validation degrade quickly. We therefore need a strict state-machine style discipline for graph construction, node signatures, and accumulated state fields.
+
 ## Decision
 We will enforce several strict constraints on how LangGraph is used within the project:
 
@@ -17,6 +19,91 @@ We will enforce several strict constraints on how LangGraph is used within the p
 3.  **Structured Action Proposals**: Every agent node must read the typed state and produce a structured `ActionProposal` object. No free-form string passing between nodes is permitted. This makes it possible to unit-test individual nodes by mocking their input and verifying their output structure.
 4.  **External Trace Store**: Large trace data, full LLM prompt/response pairs, and intermediate reasoning steps must be written to an external JSONL store. They should NOT be kept in the LangGraph state. This prevents the state from growing too large, which can lead to memory issues and slow checkpointing.
 5.  **Bounded Recursion**: Every simulation or multi-step reasoning graph must have a hard cap on the number of rounds (configurable, but defaulting to 8). This prevents infinite loops and ensures predictable execution times.
+
+## Alternatives Considered
+### A) Free-form message list (standard LangGraph chat pattern)
+- **Pros**
+  - Very flexible for rapid prototyping.
+  - Minimal upfront schema work.
+- **Cons**
+  - Poor traceability of business-critical fields.
+  - State growth and replay instability in long runs.
+  - Harder deterministic tests and static analysis.
+
+### B) Hybrid typed state + free-form message channel
+- **Pros**
+  - Keeps key fields typed while preserving chat flexibility.
+  - Easier migration path from prototype agents.
+- **Cons**
+  - Dual-state complexity; message channel can bypass contracts.
+  - In practice, “temporary” free-form paths become permanent.
+  - Validation surface remains ambiguous.
+
+### C) Strict `TypedDict` state with no message list (Selected)
+- **Pros**
+  - Explicit contracts for every node transition.
+  - Easier debugging and deterministic replay.
+  - Better compatibility with schema validation and unit tests.
+- **Cons**
+  - More up-front schema maintenance.
+  - Reduced flexibility for ad hoc agent communication.
+
+## Rationale
+Younggeul optimizes for reproducibility and auditability, not chat-like free-form interaction inside the orchestration runtime. Typed state ensures each node reads/writes explicit fields and keeps data-plane and reasoning-plane boundaries visible.
+
+The existing graph implementation (`apps/kr-seoul-apartment/.../simulation/graph.py`) already reflects this design: nodes are named business transitions (`intake_planner`, `scenario_builder`, `world_initializer`, `citation_gate`, `report_renderer`), and edges model process flow rather than conversational turns.
+
+By pairing strict `SimulationGraphState` fields with bounded rounds (`max_rounds`), we avoid hidden state channels and ensure that deterministic components remain testable independent of LLM variability.
+
+## Examples
+### 1) Real strict state schema (`TypedDict`)
+
+```python
+# apps/kr-seoul-apartment/src/.../simulation/graph_state.py
+class SimulationGraphState(TypedDict, total=False):
+    user_query: str
+    intake_plan: dict[str, Any]
+    participant_roster: dict[str, Any]
+    run_meta: RunMeta
+    snapshot: SnapshotRef
+    scenario: ScenarioSpec
+    round_no: int
+    max_rounds: int
+    world: dict[str, SegmentState]
+    participants: dict[str, ParticipantState]
+    governance_actions: dict[str, ActionProposal]
+    market_actions: dict[str, ActionProposal]
+    last_outcome: RoundOutcome | None
+    event_refs: Annotated[list[str], operator.add]
+    evidence_refs: Annotated[list[str], operator.add]
+    report_claims: Annotated[list[ReportClaim], operator.add]
+    warnings: Annotated[list[str], operator.add]
+```
+
+No `messages: list[BaseMessage]` field exists.
+
+### 2) Node function signature used in practice
+
+```python
+# apps/kr-seoul-apartment/src/.../simulation/nodes/citation_gate_node.py
+def make_citation_gate_node(evidence_store: EvidenceStore, event_store: EventStore) -> Any:
+    def node(state: SimulationGraphState) -> dict[str, Any]:
+        ...
+        return {"warnings": warnings, "event_refs": [event_id]}
+    return node
+```
+
+This enforces typed input (`SimulationGraphState`) and structured output (`dict[str, Any]` with known keys).
+
+### 3) Rejected pattern (for contrast)
+
+```python
+# Rejected for Younggeul
+class ChatState(TypedDict):
+    messages: list[BaseMessage]
+```
+
+This pattern is intentionally avoided because it obscures domain state transitions and weakens deterministic validation.
 
 ## Consequences
 ### Positive

--- a/docs/adr/005-evidence-gated-reporting.md
+++ b/docs/adr/005-evidence-gated-reporting.md
@@ -9,6 +9,8 @@ Accepted
 ## Context
 Generative AI models excel at producing natural-sounding prose but are prone to "hallucinations"—claims that are factually incorrect or unsupported by the source data. In real estate analysis, where financial decisions are based on the reported metrics (e.g., 매매가 추세, 수익률), a single hallucination can undermine the entire system's credibility. We need a structural guarantee that every claim in a generated report is backed by verifiable evidence.
 
+The risk is amplified when reports summarize multi-round simulations and multiple market segments: tiny numerical drift or subject mismatch can silently produce plausible but wrong narratives. Human review alone is insufficient at scale, especially for regression testing and automated evaluation. The architecture therefore needs a deterministic gate between claim generation and narrative rendering.
+
 ## Decision
 We will implement a **Three-Phase Evidence-Gated Reporting Pipeline**. This pipeline decouples the factual reasoning from the natural language generation.
 
@@ -18,6 +20,91 @@ We will implement a **Three-Phase Evidence-Gated Reporting Pipeline**. This pipe
     -   That the values in the `claim_json` (e.g., "The average price is 1.5 billion KRW") match the values in the evidence store within a specified tolerance.
     -   Claims that pass this gate are marked as "Validated". Claims that fail are sent to a "Critic" LLM for repair or removal.
 3.  **Phase 3: Prose Rendering**: Only claims that have successfully passed the citation gate are sent to a final "Renderer" LLM. The Renderer's job is purely linguistic: it converts the validated JSON claims into natural language prose. The Renderer is explicitly instructed NOT to add any factual information not present in the validated claims.
+
+## Alternatives Considered
+### A) Single-shot report generation
+- **Pros**
+  - Lowest latency and simplest orchestration.
+  - Minimal implementation complexity.
+- **Cons**
+  - No structural guarantee of factual grounding.
+  - Hard to audit claims and regress quality reliably.
+  - High risk for financial decision-support use cases.
+
+### B) Post-hoc fact-checking after prose generation
+- **Pros**
+  - Preserves natural generation flow.
+  - Can catch some obvious inconsistencies.
+- **Cons**
+  - Repairs after narrative generation are brittle.
+  - Difficult to map prose fragments back to exact evidence IDs.
+  - Increased rework loops and inconsistent style after corrections.
+
+### C) Three-phase evidence-gated pipeline (Selected)
+- **Pros**
+  - Claim-evidence linkage is explicit before prose exists.
+  - Deterministic gate enforces minimum trust guarantees.
+  - Clear operational metrics (passed/failed claims).
+- **Cons**
+  - More pipeline complexity and latency.
+  - Requires robust claim schema and retry policies.
+
+## Rationale
+The selected design separates factual correctness from linguistic quality. This is essential because LLMs are strongest at language generation, while deterministic code is strongest at validation and constraint enforcement.
+
+Younggeul already encodes this split in the graph topology and schemas. Claims are represented as `ReportClaim` objects in core state contracts, validated in `citation_gate`, and only then transformed into markdown by `report_renderer`.
+
+The design constraint is “no unchecked fact reaches prose.” This is stricter than common RAG pipelines and better aligned with audit requirements for simulation-backed market analysis.
+
+## Examples
+### 1) Real `ReportClaim` schema
+
+```python
+# core/src/younggeul_core/state/simulation.py
+class ReportClaim(BaseModel):
+    claim_id: str
+    claim_json: dict[str, object]
+    evidence_ids: list[str]
+    gate_status: Literal["pending", "passed", "failed", "repaired"] = "pending"
+    repair_count: int = 0
+```
+
+This is the typed envelope passed between writer, gate, critic, and renderer stages.
+
+### 2) Deterministic citation-gate validation flow
+
+```python
+# apps/kr-seoul-apartment/src/.../simulation/nodes/citation_gate_node.py
+for claim in report_claims:
+    evidence_ids = list(claim.evidence_ids)
+    if not evidence_ids:
+        failure_reason = "missing evidence_ids"
+    ...
+    record = evidence_store.get(evidence_id)
+    if record is None:
+        failure_reason = f"missing evidence record: {evidence_id}"
+    ...
+    if not any(record.round_no == round_no for record in resolved_records):
+        failure_reason = f"no evidence for round_no={round_no}"
+```
+
+Claims are rewritten with `gate_status` (`passed`/`failed`) and summary outcomes are emitted as `CITATION_GATE` events.
+
+### 3) Actual graph node sequence implementing the pipeline
+
+```python
+# apps/kr-seoul-apartment/src/.../simulation/graph.py
+graph.add_node("report_writer", _traced_node("report_writer", report_writer_node))
+graph.add_node("critic", _traced_node("critic", _make_passthrough_stub(event_store, "critic")))
+graph.add_node("citation_gate", _traced_node("citation_gate", citation_gate_node))
+graph.add_node("report_renderer", _traced_node("report_renderer", report_renderer_node))
+
+graph.add_edge("report_writer", "critic")
+graph.add_edge("critic", "citation_gate")
+graph.add_edge("citation_gate", "report_renderer")
+```
+
+These concrete node names and edges encode the evidence-gated transition before final rendering.
 
 ## Consequences
 ### Positive

--- a/docs/adr/006-public-data-policy.md
+++ b/docs/adr/006-public-data-policy.md
@@ -12,6 +12,10 @@ Younggeul relies heavily on public data provided by the South Korean government 
 2.  **Repo Bloat**: Real estate datasets can be several gigabytes in size, which is unsuitable for git storage.
 3.  **Data Staleness**: Committing raw data makes it difficult to keep it up-to-date across all development environments.
 
+In addition, data publication policy must align with snapshot reproducibility (ADR-003) and benchmark transparency without leaking provider-restricted artifacts. Contributors need a predictable workflow where code and manifests are versioned in git, but high-volume or policy-sensitive payloads remain external. This keeps onboarding clear while preserving legal and operational boundaries.
+
+Another practical constraint is contributor ergonomics: accidental large-file commits should be rare and quickly detectable. The policy must therefore be enforceable using default repository behavior (`.gitignore`) plus explicit CLI workflows, not tribal knowledge. This reduces maintenance load as the contributor base grows.
+
 ## Decision
 We will enforce a strict **Public Data Publication Policy** for the Younggeul project.
 
@@ -21,6 +25,91 @@ We will enforce a strict **Public Data Publication Policy** for the Younggeul pr
 4.  **Synthetic Test Fixtures**: All unit and integration tests must use small, hand-crafted synthetic datasets (test fixtures) rather than subsets of real API data. These fixtures must be small enough to be committed to git and must contain no PII (Personally Identifiable Information).
 5.  **User-Driven Ingestion**: The data collection pipeline must be designed so that users provide their own API keys (from 공공데이터포털) and run the ingestion process themselves on their local machines or in their own infrastructure.
 6.  **CI/CD Isolation**: CI/CD pipelines will primarily use synthetic fixtures for testing. A separate, scheduled workflow (using GitHub Secrets for API keys) may run a full data ingestion and snapshot generation process to verify the end-to-end pipeline.
+
+## Alternatives Considered
+### A) Commit data directly to git (possibly with LFS)
+- **Pros**
+  - Easy cloning of code + data in one step.
+  - Reproducibility appears straightforward for small datasets.
+- **Cons**
+  - Large storage and bandwidth overhead.
+  - Potential ToS/policy violations through redistribution.
+  - Git history becomes heavy and hard to maintain.
+
+### B) Host all data on an external CDN maintained by project
+- **Pros**
+  - Keeps repository size small.
+  - Centralized distribution endpoint.
+- **Cons**
+  - Shifts legal/compliance burden to maintainers.
+  - Requires ongoing ops budget and governance.
+  - Risk of accidental redistribution beyond provider terms.
+
+### C) User-driven ingestion + manifest-only git strategy (Selected)
+- **Pros**
+  - Better ToS alignment and legal safety.
+  - Small, fast repository for contributors and CI.
+  - Compatible with immutable snapshot verification.
+- **Cons**
+  - Higher onboarding effort for first-time users.
+  - Requires clear CLI documentation and integrity checks.
+
+## Rationale
+The selected policy minimizes legal exposure while preserving reproducibility guarantees through manifests and snapshot IDs rather than raw payload storage. It aligns with the project’s architecture: deterministic pipelines, manifest-based snapshot integrity, and synthetic fixtures for CI.
+
+A central hosted-dataset approach would simplify setup but creates continuous operational and legal liability for maintainers. Committing raw datasets into git (even via LFS) introduces long-term repository drag and weakens compliance controls.
+
+By separating “code + metadata” from “user-acquired data,” Younggeul remains lightweight and portable while still enabling verifiable data provenance.
+
+This also keeps test and documentation pipelines predictable: CI can run on synthetic fixtures while production-like ingestion remains opt-in for users with their own credentials and infrastructure. The result is a cleaner boundary between open-source code distribution and data access responsibilities.
+
+## Examples
+### 1) Actual `.gitignore` data exclusion rules
+
+```gitignore
+# Data artifacts
+data/bronze/**
+data/silver/**
+data/gold/**
+data/snapshots/**
+!data/.gitkeep
+eval_results/
+demo_output/
+```
+
+These patterns enforce that raw and derived data artifacts are not committed by default.
+
+### 2) CLI ingestion and snapshot publication commands
+
+```bash
+younggeul ingest --output-dir ./output/pipeline
+younggeul snapshot publish --data-dir ./output/pipeline --snapshot-dir ./output/snapshots
+younggeul snapshot list --snapshot-dir ./output/snapshots
+```
+
+The command wiring is implemented in `apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py` via `ingest`, `snapshot publish`, and `snapshot list` subcommands.
+
+Command declarations in the codebase:
+
+```python
+@main.command("ingest")
+def ingest_command(...):
+    ...
+
+@snapshot_group.command("publish")
+def snapshot_publish_command(...):
+    ...
+```
+
+### 3) Manifest-only commit pattern
+
+```text
+git add docs/adr/006-public-data-policy.md
+git add output/snapshots/<dataset_snapshot_id>/manifest.json
+# Do NOT add snapshot table payload files or data/bronze|silver|gold directories
+```
+
+This preserves provenance (`dataset_snapshot_id`, table hashes, record counts) without storing provider-distributed raw datasets in git.
 
 ## Consequences
 ### Positive


### PR DESCRIPTION
## Summary

Expands all 6 Architecture Decision Records from ~40 lines each to ~125 lines each with consistent new sections across all ADRs.

## Changes

Each ADR now includes three new sections inserted between Decision and Consequences:

- **Alternatives Considered** — 2-3 alternatives per ADR with pros/cons
- **Rationale** — Why the chosen alternative was selected, design constraints
- **Examples** — Real code snippets from the codebase demonstrating the decision in practice

### Per-ADR details

| ADR | Lines (before → after) | Example highlights |
|-----|----------------------|-------------------|
| 001 Clean-Room Development | 38 → 127 | Apache-2.0 header, dependency graph |
| 002 Monorepo Boundaries | 46 → 132 | Directory structure, cross-package imports |
| 003 Immutable Snapshots | 38 → 135 | Snapshot manifest JSON, SHA-256 computation |
| 004 LangGraph Boundaries | 36 → 123 | SimulationGraphState TypedDict, node signature |
| 005 Evidence-Gated Reporting | 37 → 124 | ReportClaim schema, citation gate validation |
| 006 Public Data Policy | 39 → 128 | .gitignore patterns, CLI ingestion commands |

Also unescaped Unicode sequences to readable Korean text across all ADRs.

## Verification

- `mkdocs build --strict` passes with zero warnings

Closes #146