### PR TITLE
fix: add explicit type casts to resolve no-any-return mypy errors

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/report_renderer.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/report_renderer.py
@@ -196,4 +196,4 @@ def _is_legacy_stub_claims(report_claims: list[ReportClaim]) -> bool:
     if len(report_claims) != 1:
         return False
     claim_json = report_claims[0].claim_json
-    return claim_json == {"summary": "stub report"}
+    return bool(claim_json == {"summary": "stub report"})

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/gold_district.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/gold_district.py
@@ -33,7 +33,7 @@ def _find_interest_rate(rates: list[SilverInterestRate] | None, period: str) -> 
         return None
 
     latest = max(candidates, key=lambda rate: rate.rate_date)
-    return latest.rate_value
+    return Decimal(latest.rate_value)
 
 
 def _find_net_migration(
@@ -49,7 +49,7 @@ def _find_net_migration(
         if migration.period != period:
             continue
         if migration.region_code == city_code:
-            return migration.net_count
+            return int(migration.net_count)
     return None
 
 

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py
@@ -184,7 +184,7 @@ def generate_transaction_id(bronze: BronzeAptTransaction) -> str:
             "serial_number": bronze.serial_number,
         }
     ]
-    return sha256_payload(payload)
+    return str(sha256_payload(payload))
 
 
 def compute_quality_score(bronze: BronzeAptTransaction, silver_fields: dict[str, object]) -> SilverDataQualityScore:


### PR DESCRIPTION
## Summary

Closes #153

- Add `str()` cast in `silver_apt.py:187` for `sha256_payload()` return
- Add `Decimal()` cast in `gold_district.py:36` for `latest.rate_value` return
- Add `int()` cast in `gold_district.py:52` for `migration.net_count` return
- Add `bool()` cast in `report_renderer.py:199` for dict comparison return

These are no-op casts at runtime but satisfy mypy's `no-any-return` check when cross-package imports resolve as `Any` locally.

## Testing

- All 1,111 tests pass
- `ruff format --check` clean
- `ruff check` clean
- `mypy` shows 0 `no-any-return` errors (only pre-existing `import-not-found` from local env)