### PR TITLE
feat: add OTEL child spans around LiteLLM completion calls

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py
@@ -3,14 +3,24 @@
 from __future__ import annotations
 
 import json
+import time
+from collections.abc import Sequence
 from importlib import import_module
-from typing import Any, Sequence, TypeVar
+from typing import Any, TypeVar
 
+from opentelemetry.trace import Status, StatusCode
 from pydantic import BaseModel, ValidationError
 
+from ..tracing import get_tracer
 from .ports import LLMMessage
 
 T = TypeVar("T", bound=BaseModel)
+
+
+def _normalize_provider(model: str) -> str:
+    if "/" in model:
+        return model.split("/")[0]
+    return "openai"
 
 
 class StructuredLLMTransportError(RuntimeError):
@@ -61,16 +71,71 @@ class LiteLLMStructuredLLM:
             "json_schema": {"name": response_model.__name__, "schema": schema},
         }
 
-        try:
-            response = litellm.completion(
-                model=self.model,
-                messages=list(messages),
-                temperature=temperature,
-                response_format=response_format,
-                **self._default_kwargs,
-            )
-        except Exception as exc:
-            raise StructuredLLMTransportError(f"LLM call failed: {exc}") from exc
+        tracer = get_tracer()
+        span_attrs = {
+            "llm.request.model": self.model,
+            "llm.provider": _normalize_provider(self.model),
+        }
+        start = time.monotonic()
+
+        with tracer.start_as_current_span("llm.completion", attributes=span_attrs) as span:
+            try:
+                response = litellm.completion(
+                    model=self.model,
+                    messages=list(messages),
+                    temperature=temperature,
+                    response_format=response_format,
+                    **self._default_kwargs,
+                )
+            except Exception as exc:
+                elapsed_ms = (time.monotonic() - start) * 1000
+                span.set_attribute("llm.status", "error")
+                span.set_attribute("llm.error.type", type(exc).__name__)
+                span.set_attribute("llm.latency_ms", elapsed_ms)
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+                span.record_exception(exc)
+                raise StructuredLLMTransportError(f"LLM call failed: {exc}") from exc
+
+            elapsed_ms = (time.monotonic() - start) * 1000
+            actual_model = getattr(response, "model", None)
+            if isinstance(actual_model, str) and actual_model != self.model:
+                span.set_attribute("llm.response.model", actual_model)
+
+            usage = getattr(response, "usage", None)
+            if usage is not None:
+                prompt_tokens = (
+                    usage.get("prompt_tokens") if isinstance(usage, dict) else getattr(usage, "prompt_tokens", None)
+                )
+                completion_tokens = (
+                    usage.get("completion_tokens")
+                    if isinstance(usage, dict)
+                    else getattr(usage, "completion_tokens", None)
+                )
+                total_tokens = (
+                    usage.get("total_tokens") if isinstance(usage, dict) else getattr(usage, "total_tokens", None)
+                )
+
+                if prompt_tokens is not None:
+                    span.set_attribute("llm.prompt_tokens", prompt_tokens)
+                if completion_tokens is not None:
+                    span.set_attribute("llm.completion_tokens", completion_tokens)
+                if total_tokens is not None:
+                    span.set_attribute("llm.total_tokens", total_tokens)
+
+            hidden_params = getattr(response, "_hidden_params", None)
+            if isinstance(hidden_params, dict):
+                cost_usd = hidden_params.get("response_cost")
+                if cost_usd is not None:
+                    span.set_attribute("llm.cost_usd", cost_usd)
+
+            choices = getattr(response, "choices", None)
+            if choices:
+                finish_reason = getattr(choices[0], "finish_reason", None)
+                if finish_reason is not None:
+                    span.set_attribute("llm.finish_reason", finish_reason)
+
+            span.set_attribute("llm.status", "success")
+            span.set_attribute("llm.latency_ms", elapsed_ms)
 
         raw_content = response.choices[0].message.content
         if raw_content is None:

--- a/apps/kr-seoul-apartment/tests/unit/test_litellm_adapter.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_litellm_adapter.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
+from pydantic import BaseModel
+
+litellm_adapter_module = import_module("younggeul_app_kr_seoul_apartment.simulation.llm.litellm_adapter")
+
+LiteLLMStructuredLLM = litellm_adapter_module.LiteLLMStructuredLLM
+StructuredLLMTransportError = litellm_adapter_module.StructuredLLMTransportError
+_normalize_provider = litellm_adapter_module._normalize_provider
+
+
+class _StructuredResponse(BaseModel):
+    message: str
+
+
+def _choice(content: str, *, finish_reason: str = "stop") -> SimpleNamespace:
+    return SimpleNamespace(message=SimpleNamespace(content=content), finish_reason=finish_reason)
+
+
+def _make_test_tracer() -> tuple[object, InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider.get_tracer("unit-test"), exporter
+
+
+def _span_attributes(span: object) -> dict[str, object]:
+    attrs = getattr(span, "attributes")
+    assert attrs is not None
+    return dict(attrs)
+
+
+def test_generate_structured_creates_child_span() -> None:
+    adapter = LiteLLMStructuredLLM(model="vllm/meta-llama")
+    tracer, exporter = _make_test_tracer()
+    mock_litellm = MagicMock()
+    mock_litellm.completion.return_value = SimpleNamespace(
+        model="vllm/meta-llama-instruct",
+        usage=SimpleNamespace(prompt_tokens=11, completion_tokens=7, total_tokens=18),
+        _hidden_params={"response_cost": 0.0123},
+        choices=[_choice('{"message":"ok"}', finish_reason="stop")],
+    )
+
+    with patch.object(litellm_adapter_module, "get_tracer", return_value=tracer):
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            result = adapter.generate_structured(
+                messages=[{"role": "user", "content": "hello"}],
+                response_model=_StructuredResponse,
+            )
+
+    assert result == _StructuredResponse(message="ok")
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    attrs = _span_attributes(span)
+    assert span.name == "llm.completion"
+    assert attrs["llm.request.model"] == "vllm/meta-llama"
+    assert attrs["llm.provider"] == "vllm"
+    assert attrs["llm.response.model"] == "vllm/meta-llama-instruct"
+    assert attrs["llm.prompt_tokens"] == 11
+    assert attrs["llm.completion_tokens"] == 7
+    assert attrs["llm.total_tokens"] == 18
+    assert attrs["llm.cost_usd"] == pytest.approx(0.0123)
+    assert attrs["llm.finish_reason"] == "stop"
+    assert attrs["llm.status"] == "success"
+    assert isinstance(attrs["llm.latency_ms"], (int, float))
+    assert attrs["llm.latency_ms"] >= 0
+    assert span.status.status_code == StatusCode.UNSET
+
+
+def test_generate_structured_records_error_span() -> None:
+    adapter = LiteLLMStructuredLLM(model="anthropic/claude-3")
+    tracer, exporter = _make_test_tracer()
+    mock_litellm = MagicMock()
+    mock_litellm.completion.side_effect = RuntimeError("network down")
+
+    with patch.object(litellm_adapter_module, "get_tracer", return_value=tracer):
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            with pytest.raises(StructuredLLMTransportError, match="LLM call failed"):
+                adapter.generate_structured(
+                    messages=[{"role": "user", "content": "hello"}],
+                    response_model=_StructuredResponse,
+                )
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    attrs = _span_attributes(span)
+    assert span.name == "llm.completion"
+    assert attrs["llm.request.model"] == "anthropic/claude-3"
+    assert attrs["llm.provider"] == "anthropic"
+    assert attrs["llm.status"] == "error"
+    assert attrs["llm.error.type"] == "RuntimeError"
+    assert isinstance(attrs["llm.latency_ms"], (int, float))
+    assert attrs["llm.latency_ms"] >= 0
+    assert span.status.status_code == StatusCode.ERROR
+
+
+def test_normalize_provider_openai() -> None:
+    assert _normalize_provider("gpt-4") == "openai"
+
+
+def test_normalize_provider_vllm() -> None:
+    assert _normalize_provider("vllm/model") == "vllm"
+
+
+def test_normalize_provider_anthropic() -> None:
+    assert _normalize_provider("anthropic/claude-3") == "anthropic"
+
+
+def test_cost_usd_absent_gracefully_handled() -> None:
+    adapter = LiteLLMStructuredLLM(model="gpt-4")
+    tracer, exporter = _make_test_tracer()
+    mock_litellm = MagicMock()
+    mock_litellm.completion.return_value = SimpleNamespace(
+        model="gpt-4",
+        usage=SimpleNamespace(prompt_tokens=2, completion_tokens=3, total_tokens=5),
+        _hidden_params={},
+        choices=[_choice('{"message":"ok"}', finish_reason="stop")],
+    )
+
+    with patch.object(litellm_adapter_module, "get_tracer", return_value=tracer):
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            adapter.generate_structured(
+                messages=[{"role": "user", "content": "hello"}],
+                response_model=_StructuredResponse,
+            )
+
+    span = exporter.get_finished_spans()[0]
+    attrs = _span_attributes(span)
+    assert "llm.cost_usd" not in attrs
+    assert attrs["llm.status"] == "success"
+    assert attrs["llm.prompt_tokens"] == 2
+    assert attrs["llm.completion_tokens"] == 3
+    assert attrs["llm.total_tokens"] == 5


### PR DESCRIPTION
Closes #158

## Summary
- Add explicit child spans in litellm_adapter.py around litellm.completion()
- Record: provider, model, tokens, cost_usd, latency_ms, status, finish_reason
- Add _normalize_provider() helper for model string parsing
- Add unit tests for span creation, error paths, and provider normalization

## Testing
- All existing tests pass
- New tests verify span attributes on success and failure