### PR TITLE
feat: OTEL metrics emission for simulation, LLM, and citation gate (#160)

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py
@@ -11,6 +11,13 @@ from typing import Any, Protocol, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
+from ..metrics import (
+    llm_cost_usd_total,
+    llm_request_duration_seconds,
+    llm_requests_total,
+    llm_tokens_total,
+    metric_attrs,
+)
 from .ports import LLMMessage
 
 T = TypeVar("T", bound=BaseModel)
@@ -145,6 +152,8 @@ class LiteLLMStructuredLLM:
             "llm.request.model": self.model,
             "llm.provider": _normalize_provider(self.model),
         }
+        provider = _normalize_provider(self.model)
+        request_metric_attrs = metric_attrs(provider=provider, model=self.model)
         start = time.monotonic()
 
         with _make_span_ctx("llm.completion", attributes=span_attrs) as span:
@@ -158,6 +167,11 @@ class LiteLLMStructuredLLM:
                 )
             except Exception as exc:
                 elapsed_ms = (time.monotonic() - start) * 1000
+                llm_requests_total().add(
+                    1,
+                    attributes=metric_attrs(provider=provider, model=self.model, status="error"),
+                )
+                llm_request_duration_seconds().record(elapsed_ms / 1000, attributes=request_metric_attrs)
                 span.set_attribute("llm.status", "error")
                 span.set_attribute("llm.error.type", type(exc).__name__)
                 span.set_attribute("llm.latency_ms", elapsed_ms)
@@ -170,6 +184,8 @@ class LiteLLMStructuredLLM:
                 span.set_attribute("llm.response.model", actual_model)
 
             usage = getattr(response, "usage", None)
+            prompt_tokens: int | float | None = None
+            completion_tokens: int | float | None = None
             if usage is not None:
                 prompt_tokens = (
                     usage.get("prompt_tokens") if isinstance(usage, dict) else getattr(usage, "prompt_tokens", None)
@@ -191,8 +207,11 @@ class LiteLLMStructuredLLM:
                     span.set_attribute("llm.total_tokens", total_tokens)
 
             hidden_params = getattr(response, "_hidden_params", None)
+            cost_usd: float | None = None
             if isinstance(hidden_params, dict):
-                cost_usd = hidden_params.get("response_cost")
+                raw_cost_usd = hidden_params.get("response_cost")
+                if isinstance(raw_cost_usd, int | float):
+                    cost_usd = float(raw_cost_usd)
                 if cost_usd is not None:
                     span.set_attribute("llm.cost_usd", cost_usd)
 
@@ -204,6 +223,25 @@ class LiteLLMStructuredLLM:
 
             span.set_attribute("llm.status", "success")
             span.set_attribute("llm.latency_ms", elapsed_ms)
+
+            llm_requests_total().add(
+                1,
+                attributes=metric_attrs(provider=provider, model=self.model, status="success"),
+            )
+            llm_request_duration_seconds().record(elapsed_ms / 1000, attributes=request_metric_attrs)
+
+            if isinstance(prompt_tokens, int | float):
+                llm_tokens_total().add(
+                    prompt_tokens,
+                    attributes=metric_attrs(provider=provider, model=self.model, token_type="prompt"),
+                )
+            if isinstance(completion_tokens, int | float):
+                llm_tokens_total().add(
+                    completion_tokens,
+                    attributes=metric_attrs(provider=provider, model=self.model, token_type="completion"),
+                )
+            if cost_usd is not None:
+                llm_cost_usd_total().add(cost_usd, attributes=request_metric_attrs)
 
         raw_content = response.choices[0].message.content
         if raw_content is None:

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/metrics.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/metrics.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Protocol, cast
+
+otel_metrics: Any | None
+
+try:
+    from opentelemetry import metrics as _otel_metrics
+
+    otel_metrics = _otel_metrics
+except ImportError:
+    otel_metrics = None
+
+_METER_NAME = "younggeul.simulation"
+DEFAULT_APP_LABEL = "kr-seoul-apartment"
+_initialized = False
+
+
+class CounterLike(Protocol):
+    def add(self, amount: int | float, attributes: dict[str, str] | None = None) -> None: ...
+
+
+class HistogramLike(Protocol):
+    def record(self, amount: int | float, attributes: dict[str, str] | None = None) -> None: ...
+
+
+class _NoOpCounter:
+    def add(self, amount: int | float, attributes: dict[str, str] | None = None) -> None:
+        del amount, attributes
+
+
+class _NoOpHistogram:
+    def record(self, amount: int | float, attributes: dict[str, str] | None = None) -> None:
+        del amount, attributes
+
+
+class _NoOpMeter:
+    def create_counter(self, name: str, **kwargs: Any) -> CounterLike:
+        del name, kwargs
+        return _NoOpCounter()
+
+    def create_histogram(self, name: str, **kwargs: Any) -> HistogramLike:
+        del name, kwargs
+        return _NoOpHistogram()
+
+
+class MeterLike(Protocol):
+    def create_counter(self, name: str, **kwargs: Any) -> CounterLike: ...
+
+    def create_histogram(self, name: str, **kwargs: Any) -> HistogramLike: ...
+
+
+_NOOP_METER = _NoOpMeter()
+
+_simulation_runs_total: CounterLike | None = None
+_simulation_duration_seconds: HistogramLike | None = None
+_simulation_node_duration_seconds: HistogramLike | None = None
+_llm_requests_total: CounterLike | None = None
+_llm_request_duration_seconds: HistogramLike | None = None
+_llm_tokens_total: CounterLike | None = None
+_llm_cost_usd_total: CounterLike | None = None
+_citation_gate_failures_total: CounterLike | None = None
+
+
+def _is_enabled() -> bool:
+    return os.environ.get("OTEL_ENABLED", "").lower() in ("true", "1", "yes")
+
+
+def init_metrics() -> None:
+    global _initialized
+
+    if _initialized or not _is_enabled() or otel_metrics is None:
+        return
+
+    try:
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import (
+            ConsoleMetricExporter,
+            MetricExporter,
+            PeriodicExportingMetricReader,
+        )
+    except ImportError:
+        return
+
+    exporter: MetricExporter
+    otlp_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if otlp_endpoint:
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+
+            otlp_insecure = os.environ.get("OTEL_EXPORTER_OTLP_INSECURE", "").lower() in ("true", "1", "yes")
+            exporter = OTLPMetricExporter(endpoint=otlp_endpoint, insecure=otlp_insecure)
+        except ImportError:
+            exporter = ConsoleMetricExporter()
+    else:
+        exporter = ConsoleMetricExporter()
+
+    reader = PeriodicExportingMetricReader(exporter)
+    provider = MeterProvider(metric_readers=[reader])
+    otel_metrics.set_meter_provider(provider)
+    _initialized = True
+
+
+def get_meter() -> MeterLike:
+    if otel_metrics is None:
+        return _NOOP_METER
+
+    return cast(MeterLike, otel_metrics.get_meter(_METER_NAME))
+
+
+def metric_attrs(**attrs: str) -> dict[str, str]:
+    return {"app": DEFAULT_APP_LABEL, **attrs}
+
+
+def simulation_runs_total() -> CounterLike:
+    global _simulation_runs_total
+
+    if _simulation_runs_total is None:
+        _simulation_runs_total = get_meter().create_counter(
+            "simulation_runs_total",
+            description="Total number of simulation runs",
+            unit="{run}",
+        )
+
+    counter = _simulation_runs_total
+    if counter is None:
+        return _NoOpCounter()
+    return counter
+
+
+def simulation_duration_seconds() -> HistogramLike:
+    global _simulation_duration_seconds
+
+    if _simulation_duration_seconds is None:
+        _simulation_duration_seconds = get_meter().create_histogram(
+            "simulation_duration_seconds",
+            description="Duration of full simulation runs",
+            unit="s",
+        )
+
+    histogram = _simulation_duration_seconds
+    if histogram is None:
+        return _NoOpHistogram()
+    return histogram
+
+
+def simulation_node_duration_seconds() -> HistogramLike:
+    global _simulation_node_duration_seconds
+
+    if _simulation_node_duration_seconds is None:
+        _simulation_node_duration_seconds = get_meter().create_histogram(
+            "simulation_node_duration_seconds",
+            description="Duration of simulation node execution",
+            unit="s",
+        )
+
+    histogram = _simulation_node_duration_seconds
+    if histogram is None:
+        return _NoOpHistogram()
+    return histogram
+
+
+def llm_requests_total() -> CounterLike:
+    global _llm_requests_total
+
+    if _llm_requests_total is None:
+        _llm_requests_total = get_meter().create_counter(
+            "llm_requests_total",
+            description="Total number of LLM requests",
+            unit="{request}",
+        )
+
+    counter = _llm_requests_total
+    if counter is None:
+        return _NoOpCounter()
+    return counter
+
+
+def llm_request_duration_seconds() -> HistogramLike:
+    global _llm_request_duration_seconds
+
+    if _llm_request_duration_seconds is None:
+        _llm_request_duration_seconds = get_meter().create_histogram(
+            "llm_request_duration_seconds",
+            description="LLM request duration",
+            unit="s",
+        )
+
+    histogram = _llm_request_duration_seconds
+    if histogram is None:
+        return _NoOpHistogram()
+    return histogram
+
+
+def llm_tokens_total() -> CounterLike:
+    global _llm_tokens_total
+
+    if _llm_tokens_total is None:
+        _llm_tokens_total = get_meter().create_counter(
+            "llm_tokens_total",
+            description="Total number of LLM tokens",
+            unit="{token}",
+        )
+
+    counter = _llm_tokens_total
+    if counter is None:
+        return _NoOpCounter()
+    return counter
+
+
+def llm_cost_usd_total() -> CounterLike:
+    global _llm_cost_usd_total
+
+    if _llm_cost_usd_total is None:
+        _llm_cost_usd_total = get_meter().create_counter(
+            "llm_cost_usd_total",
+            description="Total LLM cost in USD",
+            unit="USD",
+        )
+
+    counter = _llm_cost_usd_total
+    if counter is None:
+        return _NoOpCounter()
+    return counter
+
+
+def citation_gate_failures_total() -> CounterLike:
+    global _citation_gate_failures_total
+
+    if _citation_gate_failures_total is None:
+        _citation_gate_failures_total = get_meter().create_counter(
+            "citation_gate_failures_total",
+            description="Total citation gate failures",
+            unit="{failure}",
+        )
+
+    counter = _citation_gate_failures_total
+    if counter is None:
+        return _NoOpCounter()
+    return counter

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/citation_gate_node.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/citation_gate_node.py
@@ -13,6 +13,7 @@ from younggeul_core.state.simulation import ReportClaim
 from ..evidence.store import EvidenceRecord, EvidenceStore
 from ..events import EventStore, SimulationEvent
 from ..graph_state import SimulationGraphState
+from ..metrics import citation_gate_failures_total, metric_attrs
 
 
 def _matches_subject(
@@ -127,6 +128,9 @@ def make_citation_gate_node(evidence_store: EvidenceStore, event_store: EventSto
                 },
             )
         )
+
+        if failed > 0:
+            citation_gate_failures_total().add(failed, attributes=metric_attrs())
 
         return {"warnings": warnings, "event_refs": [event_id]}
 

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/tracing.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/tracing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import time
 from contextlib import contextmanager
 from typing import Any, Iterator
 
@@ -74,6 +75,8 @@ def trace_node(
         Active span context for the node execution block.
     """
     tracer = get_tracer()
+    started_at = time.monotonic()
+    status = "ok"
 
     span_attributes: dict[str, Any] = {"node.name": node_name}
     if run_id is not None:
@@ -90,6 +93,18 @@ def trace_node(
         try:
             yield span
         except Exception as exc:
+            status = "error"
             span.set_status(Status(StatusCode.ERROR, str(exc)))
             span.record_exception(exc)
             raise
+        finally:
+            elapsed = time.monotonic() - started_at
+            try:
+                from .metrics import metric_attrs, simulation_node_duration_seconds
+
+                simulation_node_duration_seconds().record(
+                    elapsed,
+                    attributes=metric_attrs(node=node_name, status=status),
+                )
+            except Exception:
+                pass

--- a/apps/kr-seoul-apartment/tests/unit/test_metrics.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_metrics.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from importlib import import_module
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+metrics_module = import_module("younggeul_app_kr_seoul_apartment.simulation.metrics")
+tracing_module = import_module("younggeul_app_kr_seoul_apartment.simulation.tracing")
+litellm_adapter_module = import_module("younggeul_app_kr_seoul_apartment.simulation.llm.litellm_adapter")
+citation_gate_module = import_module("younggeul_app_kr_seoul_apartment.simulation.nodes.citation_gate_node")
+evidence_store_module = import_module("younggeul_app_kr_seoul_apartment.simulation.evidence.store")
+event_store_module = import_module("younggeul_app_kr_seoul_apartment.simulation.event_store")
+graph_state_module = import_module("younggeul_app_kr_seoul_apartment.simulation.graph_state")
+simulation_state_module = import_module("younggeul_core.state.simulation")
+
+LiteLLMStructuredLLM = litellm_adapter_module.LiteLLMStructuredLLM
+StructuredLLMTransportError = litellm_adapter_module.StructuredLLMTransportError
+InMemoryEvidenceStore = evidence_store_module.InMemoryEvidenceStore
+InMemoryEventStore = event_store_module.InMemoryEventStore
+seed_graph_state = graph_state_module.seed_graph_state
+SegmentState = simulation_state_module.SegmentState
+ScenarioSpec = simulation_state_module.ScenarioSpec
+ReportClaim = simulation_state_module.ReportClaim
+
+
+def _reset_metric_singletons() -> None:
+    setattr(metrics_module, "_initialized", False)
+    setattr(metrics_module, "_simulation_runs_total", None)
+    setattr(metrics_module, "_simulation_duration_seconds", None)
+    setattr(metrics_module, "_simulation_node_duration_seconds", None)
+    setattr(metrics_module, "_llm_requests_total", None)
+    setattr(metrics_module, "_llm_request_duration_seconds", None)
+    setattr(metrics_module, "_llm_tokens_total", None)
+    setattr(metrics_module, "_llm_cost_usd_total", None)
+    setattr(metrics_module, "_citation_gate_failures_total", None)
+
+
+def _choice(content: str, *, finish_reason: str = "stop") -> SimpleNamespace:
+    return SimpleNamespace(message=SimpleNamespace(content=content), finish_reason=finish_reason)
+
+
+class _StructuredResponse(BaseModel):
+    message: str
+
+
+def test_init_metrics_and_get_meter_work() -> None:
+    _reset_metric_singletons()
+    with (
+        patch.dict("os.environ", {"OTEL_ENABLED": "true"}, clear=False),
+        patch("opentelemetry.sdk.metrics.MeterProvider") as meter_provider_cls,
+        patch("opentelemetry.sdk.metrics.export.PeriodicExportingMetricReader") as metric_reader_cls,
+        patch("opentelemetry.sdk.metrics.export.ConsoleMetricExporter") as exporter_cls,
+        patch("opentelemetry.metrics.set_meter_provider") as set_meter_provider,
+    ):
+        provider = meter_provider_cls.return_value
+        reader = metric_reader_cls.return_value
+        exporter = exporter_cls.return_value
+
+        metrics_module.init_metrics()
+        metrics_module.init_metrics()
+        meter = metrics_module.get_meter()
+
+    exporter_cls.assert_called_once()
+    metric_reader_cls.assert_called_once_with(exporter)
+    meter_provider_cls.assert_called_once_with(metric_readers=[reader])
+    set_meter_provider.assert_called_once_with(provider)
+    assert getattr(metrics_module, "_initialized") is True
+    assert meter is not None
+
+
+def test_all_metrics_record_without_errors() -> None:
+    _reset_metric_singletons()
+    attrs_app = metrics_module.metric_attrs()
+    attrs_ok = metrics_module.metric_attrs(status="ok")
+    attrs_node = metrics_module.metric_attrs(node="scenario_builder", status="ok")
+    attrs_llm_ok = metrics_module.metric_attrs(provider="openai", model="gpt-4", status="success")
+    attrs_llm = metrics_module.metric_attrs(provider="openai", model="gpt-4")
+    attrs_prompt = metrics_module.metric_attrs(provider="openai", model="gpt-4", token_type="prompt")
+
+    metrics_module.simulation_runs_total().add(1, attributes=attrs_ok)
+    metrics_module.simulation_duration_seconds().record(1.25, attributes=attrs_app)
+    metrics_module.simulation_node_duration_seconds().record(0.15, attributes=attrs_node)
+    metrics_module.llm_requests_total().add(1, attributes=attrs_llm_ok)
+    metrics_module.llm_request_duration_seconds().record(0.42, attributes=attrs_llm)
+    metrics_module.llm_tokens_total().add(123, attributes=attrs_prompt)
+    metrics_module.llm_cost_usd_total().add(0.01, attributes=attrs_llm)
+    metrics_module.citation_gate_failures_total().add(2, attributes=attrs_app)
+
+
+def test_graceful_degradation_noop_when_otel_missing() -> None:
+    _reset_metric_singletons()
+    with patch.object(metrics_module, "otel_metrics", None):
+        meter = metrics_module.get_meter()
+        assert meter is getattr(metrics_module, "_NOOP_METER")
+
+        metrics_module.simulation_runs_total().add(1, attributes=metrics_module.metric_attrs(status="ok"))
+        metrics_module.simulation_duration_seconds().record(1.0, attributes=metrics_module.metric_attrs())
+        metrics_module.simulation_node_duration_seconds().record(
+            0.2,
+            attributes=metrics_module.metric_attrs(node="node", status="ok"),
+        )
+        metrics_module.llm_requests_total().add(
+            1,
+            attributes=metrics_module.metric_attrs(provider="openai", model="gpt-4", status="success"),
+        )
+        metrics_module.llm_request_duration_seconds().record(
+            0.4,
+            attributes=metrics_module.metric_attrs(provider="openai", model="gpt-4"),
+        )
+        metrics_module.llm_tokens_total().add(
+            10,
+            attributes=metrics_module.metric_attrs(provider="openai", model="gpt-4", token_type="prompt"),
+        )
+        metrics_module.llm_cost_usd_total().add(
+            0.02,
+            attributes=metrics_module.metric_attrs(provider="openai", model="gpt-4"),
+        )
+        metrics_module.citation_gate_failures_total().add(1, attributes=metrics_module.metric_attrs())
+
+
+def test_trace_node_emits_duration_metric_with_success_status() -> None:
+    mock_histogram = MagicMock()
+    span = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = span
+    cm.__exit__.return_value = False
+    tracer = MagicMock()
+    tracer.start_as_current_span.return_value = cm
+
+    with (
+        patch.object(tracing_module, "get_tracer", return_value=tracer),
+        patch(
+            "younggeul_app_kr_seoul_apartment.simulation.metrics.simulation_node_duration_seconds",
+            return_value=mock_histogram,
+        ),
+    ):
+        with tracing_module.trace_node("scenario_builder"):
+            pass
+
+    _, kwargs = mock_histogram.record.call_args
+    assert kwargs["attributes"]["app"] == "kr-seoul-apartment"
+    assert kwargs["attributes"]["node"] == "scenario_builder"
+    assert kwargs["attributes"]["status"] == "ok"
+
+
+def test_trace_node_emits_duration_metric_with_error_status() -> None:
+    mock_histogram = MagicMock()
+    span = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = span
+    cm.__exit__.return_value = False
+    tracer = MagicMock()
+    tracer.start_as_current_span.return_value = cm
+
+    with (
+        patch.object(tracing_module, "get_tracer", return_value=tracer),
+        patch(
+            "younggeul_app_kr_seoul_apartment.simulation.metrics.simulation_node_duration_seconds",
+            return_value=mock_histogram,
+        ),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        with tracing_module.trace_node("round_resolver"):
+            raise RuntimeError("boom")
+
+    _, kwargs = mock_histogram.record.call_args
+    assert kwargs["attributes"]["status"] == "error"
+
+
+def test_generate_structured_emits_llm_metrics_on_success() -> None:
+    adapter = LiteLLMStructuredLLM(model="anthropic/claude-3")
+    mock_litellm = MagicMock()
+    mock_litellm.completion.return_value = SimpleNamespace(
+        model="anthropic/claude-3",
+        usage={"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18},
+        _hidden_params={"response_cost": 0.015},
+        choices=[_choice('{"message":"ok"}')],
+    )
+    request_counter = MagicMock()
+    duration_histogram = MagicMock()
+    token_counter = MagicMock()
+    cost_counter = MagicMock()
+
+    with (
+        patch.object(litellm_adapter_module, "llm_requests_total", return_value=request_counter),
+        patch.object(litellm_adapter_module, "llm_request_duration_seconds", return_value=duration_histogram),
+        patch.object(litellm_adapter_module, "llm_tokens_total", return_value=token_counter),
+        patch.object(litellm_adapter_module, "llm_cost_usd_total", return_value=cost_counter),
+        patch.dict("sys.modules", {"litellm": mock_litellm}),
+    ):
+        result = adapter.generate_structured(
+            messages=[{"role": "user", "content": "hello"}],
+            response_model=_StructuredResponse,
+        )
+
+    assert result.message == "ok"
+    request_counter.add.assert_called_once_with(
+        1,
+        attributes={
+            "app": "kr-seoul-apartment",
+            "provider": "anthropic",
+            "model": "anthropic/claude-3",
+            "status": "success",
+        },
+    )
+    duration_histogram.record.assert_called_once()
+    token_counter.add.assert_any_call(
+        11,
+        attributes={
+            "app": "kr-seoul-apartment",
+            "provider": "anthropic",
+            "model": "anthropic/claude-3",
+            "token_type": "prompt",
+        },
+    )
+    token_counter.add.assert_any_call(
+        7,
+        attributes={
+            "app": "kr-seoul-apartment",
+            "provider": "anthropic",
+            "model": "anthropic/claude-3",
+            "token_type": "completion",
+        },
+    )
+    cost_counter.add.assert_called_once_with(
+        0.015,
+        attributes={"app": "kr-seoul-apartment", "provider": "anthropic", "model": "anthropic/claude-3"},
+    )
+
+
+def test_generate_structured_emits_error_metric_on_transport_error() -> None:
+    adapter = LiteLLMStructuredLLM(model="gpt-4")
+    mock_litellm = MagicMock()
+    mock_litellm.completion.side_effect = RuntimeError("network down")
+    request_counter = MagicMock()
+    duration_histogram = MagicMock()
+
+    with (
+        patch.object(litellm_adapter_module, "llm_requests_total", return_value=request_counter),
+        patch.object(litellm_adapter_module, "llm_request_duration_seconds", return_value=duration_histogram),
+        patch.dict("sys.modules", {"litellm": mock_litellm}),
+    ):
+        with pytest.raises(StructuredLLMTransportError):
+            adapter.generate_structured(
+                messages=[{"role": "user", "content": "hello"}],
+                response_model=_StructuredResponse,
+            )
+
+    request_counter.add.assert_called_once_with(
+        1,
+        attributes={"app": "kr-seoul-apartment", "provider": "openai", "model": "gpt-4", "status": "error"},
+    )
+    duration_histogram.record.assert_called_once()
+
+
+def _build_citation_state(run_id: str) -> dict[str, Any]:
+    state: dict[str, Any] = seed_graph_state("질문", run_id, f"run-{run_id}", "gpt-test")
+    state["round_no"] = 2
+    state["world"] = {
+        "11680": SegmentState(
+            gu_code="11680",
+            gu_name="강남구",
+            current_median_price=2_000_000,
+            current_volume=100,
+            price_trend="flat",
+            sentiment_index=0.6,
+            supply_pressure=0.0,
+        ),
+    }
+    state["scenario"] = ScenarioSpec(
+        scenario_name="Citation Test",
+        target_gus=["11680"],
+        target_period_start=date(2026, 1, 1),
+        target_period_end=date(2026, 12, 31),
+        shocks=[],
+    )
+    return state
+
+
+def _add_evidence(
+    store: Any,
+    *,
+    evidence_id: str,
+    subject_type: str,
+    subject_id: str,
+    round_no: int = 2,
+) -> None:
+    record = evidence_store_module.EvidenceRecord(
+        evidence_id=evidence_id,
+        kind="segment_fact",
+        subject_type=subject_type,
+        subject_id=subject_id,
+        round_no=round_no,
+        payload={},
+        source_event_ids=[],
+        created_at=datetime.now(timezone.utc),
+    )
+    store.add(record)
+
+
+def test_citation_gate_emits_failure_counter_when_claims_fail() -> None:
+    state = _build_citation_state("metrics-citation-fail")
+    state["report_claims"] = [
+        ReportClaim(
+            claim_id="c-1",
+            claim_json={
+                "type": "direction",
+                "section": "direction",
+                "subject": "11680",
+                "statement": "deterministic statement",
+                "metrics": {"round_no": 2},
+            },
+            evidence_ids=[],
+            gate_status="pending",
+            repair_count=0,
+        )
+    ]
+    evidence_store = InMemoryEvidenceStore()
+    event_store = InMemoryEventStore()
+    failure_counter = MagicMock()
+
+    with patch.object(citation_gate_module, "citation_gate_failures_total", return_value=failure_counter):
+        citation_gate_module.make_citation_gate_node(evidence_store, event_store)(state)
+
+    failure_counter.add.assert_called_once_with(1, attributes={"app": "kr-seoul-apartment"})
+
+
+def test_citation_gate_does_not_emit_failure_counter_when_no_failures() -> None:
+    state = _build_citation_state("metrics-citation-pass")
+    state["report_claims"] = [
+        ReportClaim(
+            claim_id="c-1",
+            claim_json={
+                "type": "direction",
+                "section": "direction",
+                "subject": "11680",
+                "statement": "deterministic statement",
+                "metrics": {"round_no": 2},
+            },
+            evidence_ids=["ev-1"],
+            gate_status="pending",
+            repair_count=0,
+        )
+    ]
+    evidence_store = InMemoryEvidenceStore()
+    _add_evidence(evidence_store, evidence_id="ev-1", subject_type="segment", subject_id="11680")
+    event_store = InMemoryEventStore()
+    failure_counter = MagicMock()
+
+    with patch.object(citation_gate_module, "citation_gate_failures_total", return_value=failure_counter):
+        citation_gate_module.make_citation_gate_node(evidence_store, event_store)(state)
+
+    failure_counter.add.assert_not_called()


### PR DESCRIPTION
## Summary
- Added `simulation/metrics.py` with graceful OpenTelemetry degradation, `init_metrics()`, `get_meter()`, default `app=kr-seoul-apartment` label support, and lazy singleton metric constructors.
- Instrumented `trace_node`, `LiteLLMStructuredLLM.generate_structured`, and `citation_gate_node` to emit node duration, LLM request/token/cost, and citation-gate failure metrics alongside existing tracing behavior.
- Added `test_metrics.py` covering metric initialization, recording, no-op fallback behavior, and metric emission assertions for tracing/LLM/citation instrumentation.

## Metrics
| Metric Name | Type | Labels |
|---|---|---|
| `simulation_runs_total` | Counter | `app`, `status` |
| `simulation_duration_seconds` | Histogram | `app` |
| `simulation_node_duration_seconds` | Histogram | `app`, `node`, `status` |
| `llm_requests_total` | Counter | `app`, `provider`, `model`, `status` |
| `llm_request_duration_seconds` | Histogram | `app`, `provider`, `model` |
| `llm_tokens_total` | Counter | `app`, `provider`, `model`, `token_type` |
| `llm_cost_usd_total` | Counter | `app`, `provider`, `model` |
| `citation_gate_failures_total` | Counter | `app` |

## Validation
- `python3 -m pytest --tb=short -q` → **1164 passed, 6 skipped**
- `python3 -m ruff format --check .` → passed
- `python3 -m ruff check .` → passed
- `python3 -m mypy apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/metrics.py` → passed
- LSP diagnostics (error severity) clean for changed files