### PR TITLE
feat: FastAPI web service layer + RunStore (#163)

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py
@@ -518,5 +518,17 @@ def eval_command(ctx: click.Context, output_dir: str) -> None:
         sys.exit(1)
 
 
+@main.command("serve", help="Start the web UI server.")
+@click.option("--host", default="0.0.0.0", show_default=True)
+@click.option("--port", default=8000, type=int, show_default=True)
+def serve_command(host: str, port: int) -> None:
+    import uvicorn
+
+    from .web.app import create_app
+
+    app = create_app()
+    uvicorn.run(app, host=host, port=port)
+
+
 if __name__ == "__main__":
     main()

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/__init__.py
@@ -1,0 +1,3 @@
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/app.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/app.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .routes.baseline import router as baseline_router
+from .routes.health import router as health_router
+from .routes.simulate import router as simulate_router
+from .routes.snapshot import router as snapshot_router
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="영끌 시뮬레이터", version="0.2.0")
+    app.include_router(health_router)
+    app.include_router(simulate_router)
+    app.include_router(snapshot_router)
+    app.include_router(baseline_router)
+    return app

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/__init__.py
@@ -1,0 +1,6 @@
+from .baseline import router as baseline_router
+from .health import router as health_router
+from .simulate import router as simulate_router
+from .snapshot import router as snapshot_router
+
+__all__ = ["health_router", "simulate_router", "snapshot_router", "baseline_router"]

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/baseline.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/baseline.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, status
+
+router = APIRouter(prefix="/baseline", tags=["baseline"])
+
+
+@router.post("")
+async def run_baseline() -> None:
+    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Not implemented (#74b)")

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/health.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/health.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok", "version": "0.2.0"}

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/simulate.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/simulate.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, status
+
+router = APIRouter(prefix="/simulate", tags=["simulate"])
+
+
+@router.post("")
+async def create_simulation_run() -> None:
+    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Not implemented (#74b)")
+
+
+@router.get("/{run_id}")
+async def get_simulation_run(run_id: str) -> None:
+    _ = run_id
+    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Not implemented (#74b)")

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/snapshot.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/snapshot.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, status
+
+router = APIRouter(prefix="/snapshot", tags=["snapshot"])
+
+
+@router.get("")
+async def list_snapshots() -> None:
+    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Not implemented (#74b)")
+
+
+@router.post("/publish")
+async def publish_snapshot_route() -> None:
+    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Not implemented (#74b)")

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/run_store.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/run_store.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+
+class RunMeta(BaseModel):
+    run_id: str
+    query: str
+    status: str
+    created_at: datetime
+    completed_at: datetime | None = None
+    error: str | None = None
+
+
+class RunStore:
+    def __init__(self, base_dir: Path | str = Path("./output/runs")) -> None:
+        self.base_dir = Path(base_dir)
+
+    def create_run(self, query: str) -> str:
+        run_id = str(uuid4())
+        run_dir = self.base_dir / run_id
+        run_dir.mkdir(parents=True, exist_ok=False)
+
+        meta = RunMeta(
+            run_id=run_id,
+            query=query,
+            status="pending",
+            created_at=datetime.now(timezone.utc),
+        )
+        self._meta_path(run_id).write_text(
+            json.dumps(meta.model_dump(mode="json"), ensure_ascii=False), encoding="utf-8"
+        )
+        return run_id
+
+    def update_status(
+        self,
+        run_id: str,
+        status: str,
+        *,
+        error: str | None = None,
+        report: str | None = None,
+    ) -> None:
+        meta = self._read_meta(run_id)
+        completed_at = meta.completed_at
+        if status in {"completed", "failed"}:
+            completed_at = datetime.now(timezone.utc)
+
+        updated = meta.model_copy(update={"status": status, "error": error, "completed_at": completed_at})
+        self._meta_path(run_id).write_text(
+            json.dumps(updated.model_dump(mode="json"), ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        if report is not None:
+            self._report_path(run_id).write_text(report, encoding="utf-8")
+
+    def get_run(self, run_id: str) -> RunMeta | None:
+        meta_path = self._meta_path(run_id)
+        if not meta_path.exists():
+            return None
+        return RunMeta.model_validate_json(meta_path.read_text(encoding="utf-8"))
+
+    def list_runs(self) -> list[RunMeta]:
+        if not self.base_dir.exists():
+            return []
+
+        runs: list[RunMeta] = []
+        for run_dir in self.base_dir.iterdir():
+            if not run_dir.is_dir():
+                continue
+            meta_path = run_dir / "meta.json"
+            if not meta_path.exists():
+                continue
+            runs.append(RunMeta.model_validate_json(meta_path.read_text(encoding="utf-8")))
+
+        return sorted(runs, key=lambda meta: meta.created_at, reverse=True)
+
+    def _meta_path(self, run_id: str) -> Path:
+        return self.base_dir / run_id / "meta.json"
+
+    def _report_path(self, run_id: str) -> Path:
+        return self.base_dir / run_id / "report.md"
+
+    def _read_meta(self, run_id: str) -> RunMeta:
+        meta_path = self._meta_path(run_id)
+        return RunMeta.model_validate_json(meta_path.read_text(encoding="utf-8"))

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/services.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/services.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from langgraph.graph.state import CompiledStateGraph
+
+from younggeul_app_kr_seoul_apartment.forecaster import forecast_baseline
+from younggeul_app_kr_seoul_apartment.pipeline import BronzeInput, PipelineResult, run_pipeline
+from younggeul_app_kr_seoul_apartment.simulation.events import EventStore
+from younggeul_app_kr_seoul_apartment.simulation.graph import build_simulation_graph
+from younggeul_app_kr_seoul_apartment.simulation.graph_state import SimulationGraphState, seed_graph_state
+from younggeul_app_kr_seoul_apartment.snapshot import publish_snapshot, resolve_snapshot
+from younggeul_core.state.gold import BaselineForecast, GoldDistrictMonthlyMetrics
+from younggeul_core.state.simulation import SnapshotRef
+from younggeul_core.storage.snapshot import SnapshotManifest
+
+
+def run_pipeline_service(bronze: BronzeInput) -> PipelineResult:
+    return run_pipeline(bronze)
+
+
+def publish_snapshot_service(gold_rows: list[GoldDistrictMonthlyMetrics], base_dir: Path) -> SnapshotRef:
+    return publish_snapshot(gold_rows, base_dir)
+
+
+def resolve_snapshot_service(
+    snapshot_id: str, base_dir: Path
+) -> tuple[SnapshotManifest, list[GoldDistrictMonthlyMetrics]]:
+    return resolve_snapshot(snapshot_id, base_dir)
+
+
+def forecast_baseline_service(metrics: list[GoldDistrictMonthlyMetrics]) -> list[BaselineForecast]:
+    return forecast_baseline(metrics)
+
+
+def build_simulation_graph_service(event_store: EventStore) -> CompiledStateGraph[Any, Any, Any, Any]:
+    return build_simulation_graph(event_store)
+
+
+def seed_graph_state_service(user_query: str, run_id: str, run_name: str, model_id: str) -> SimulationGraphState:
+    return seed_graph_state(user_query, run_id=run_id, run_name=run_name, model_id=model_id)

--- a/apps/kr-seoul-apartment/tests/unit/test_run_store.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_run_store.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from younggeul_app_kr_seoul_apartment.web.run_store import RunMeta, RunStore
+
+
+def test_create_run_creates_directory_and_meta_json(tmp_path: Path) -> None:
+    store = RunStore(base_dir=tmp_path)
+
+    run_id = store.create_run("강남구 시뮬레이션")
+
+    run_dir = tmp_path / run_id
+    meta_path = run_dir / "meta.json"
+    assert run_dir.is_dir()
+    assert meta_path.is_file()
+
+    payload = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert payload["run_id"] == run_id
+    assert payload["query"] == "강남구 시뮬레이션"
+    assert payload["status"] == "pending"
+
+
+def test_update_status_changes_status(tmp_path: Path) -> None:
+    store = RunStore(base_dir=tmp_path)
+    run_id = store.create_run("test")
+
+    store.update_status(run_id, "running")
+
+    run_meta = store.get_run(run_id)
+    assert run_meta is not None
+    assert run_meta.status == "running"
+
+
+def test_get_run_returns_run_meta(tmp_path: Path) -> None:
+    store = RunStore(base_dir=tmp_path)
+    run_id = store.create_run("test")
+
+    run_meta = store.get_run(run_id)
+
+    assert isinstance(run_meta, RunMeta)
+    assert run_meta.run_id == run_id
+
+
+def test_get_run_returns_none_for_nonexistent(tmp_path: Path) -> None:
+    store = RunStore(base_dir=tmp_path)
+
+    assert store.get_run("does-not-exist") is None
+
+
+def test_list_runs_returns_sorted_by_created_at_desc(tmp_path: Path) -> None:
+    store = RunStore(base_dir=tmp_path)
+    first_run_id = store.create_run("first")
+    second_run_id = store.create_run("second")
+
+    first_meta_path = tmp_path / first_run_id / "meta.json"
+    second_meta_path = tmp_path / second_run_id / "meta.json"
+    first_meta = RunMeta.model_validate_json(first_meta_path.read_text(encoding="utf-8"))
+    second_meta = RunMeta.model_validate_json(second_meta_path.read_text(encoding="utf-8"))
+
+    older = first_meta.model_copy(update={"created_at": datetime(2026, 1, 1, tzinfo=timezone.utc)})
+    newer = second_meta.model_copy(update={"created_at": datetime(2026, 1, 2, tzinfo=timezone.utc)})
+    first_meta_path.write_text(json.dumps(older.model_dump(mode="json"), ensure_ascii=False), encoding="utf-8")
+    second_meta_path.write_text(json.dumps(newer.model_dump(mode="json"), ensure_ascii=False), encoding="utf-8")
+
+    runs = store.list_runs()
+
+    assert [run.run_id for run in runs] == [second_run_id, first_run_id]
+
+
+def test_update_status_with_report_writes_report_md(tmp_path: Path) -> None:
+    store = RunStore(base_dir=tmp_path)
+    run_id = store.create_run("report")
+    markdown_report = "# Simulation Report\n\n내용"
+
+    store.update_status(run_id, "completed", report=markdown_report)
+
+    report_path = tmp_path / run_id / "report.md"
+    run_meta = store.get_run(run_id)
+    assert report_path.is_file()
+    assert report_path.read_text(encoding="utf-8") == markdown_report
+    assert run_meta is not None
+    assert run_meta.status == "completed"
+    assert run_meta.completed_at is not None

--- a/apps/kr-seoul-apartment/tests/unit/test_web_app.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_web_app.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from importlib import import_module
+
+from fastapi.testclient import TestClient
+
+web_app = import_module("younggeul_app_kr_seoul_apartment.web.app")
+
+
+def test_health_endpoint_returns_expected_payload() -> None:
+    app = web_app.create_app()
+    client = TestClient(app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "version": "0.2.0"}

--- a/apps/kr-seoul-apartment/tests/unit/test_web_services.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_web_services.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from younggeul_app_kr_seoul_apartment.pipeline import BronzeInput
+from younggeul_app_kr_seoul_apartment.simulation.event_store import InMemoryEventStore
+from younggeul_app_kr_seoul_apartment.web import services
+
+
+def test_run_pipeline_service_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    bronze = BronzeInput(apt_transactions=[], interest_rates=[], migrations=[])
+
+    def fake_run_pipeline(arg: BronzeInput) -> str:
+        assert arg is bronze
+        return "ok"
+
+    monkeypatch.setattr(services, "run_pipeline", fake_run_pipeline)
+    assert services.run_pipeline_service(bronze) == "ok"
+
+
+def test_publish_snapshot_service_passes_through(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    payload = object()
+
+    def fake_publish_snapshot(gold_rows: list[Any], base_dir: Path) -> object:
+        assert gold_rows == []
+        assert base_dir == tmp_path
+        return payload
+
+    monkeypatch.setattr(services, "publish_snapshot", fake_publish_snapshot)
+    assert services.publish_snapshot_service([], tmp_path) is payload
+
+
+def test_resolve_snapshot_service_passes_through(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    payload = (object(), [])
+
+    def fake_resolve_snapshot(snapshot_id: str, base_dir: Path) -> tuple[object, list[Any]]:
+        assert snapshot_id == "latest"
+        assert base_dir == tmp_path
+        return payload
+
+    monkeypatch.setattr(services, "resolve_snapshot", fake_resolve_snapshot)
+    assert services.resolve_snapshot_service("latest", tmp_path) == payload
+
+
+def test_forecast_baseline_service_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload: list[object] = [object()]
+
+    def fake_forecast_baseline(metrics: list[Any]) -> list[object]:
+        assert metrics == []
+        return payload
+
+    monkeypatch.setattr(services, "forecast_baseline", fake_forecast_baseline)
+    assert services.forecast_baseline_service([]) == payload
+
+
+def test_build_simulation_graph_service_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    event_store = InMemoryEventStore()
+    payload = object()
+
+    def fake_build_simulation_graph(arg: object) -> object:
+        assert arg is event_store
+        return payload
+
+    monkeypatch.setattr(services, "build_simulation_graph", fake_build_simulation_graph)
+    assert services.build_simulation_graph_service(event_store) is payload
+
+
+def test_seed_graph_state_service_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"event_refs": []}
+
+    def fake_seed_graph_state(user_query: str, run_id: str, run_name: str, model_id: str) -> dict[str, list[str]]:
+        assert user_query == "q"
+        assert run_id == "r"
+        assert run_name == "name"
+        assert model_id == "model"
+        return payload
+
+    monkeypatch.setattr(services, "seed_graph_state", fake_seed_graph_state)
+    assert services.seed_graph_state_service("q", "r", "name", "model") == payload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,17 @@ dev = [
   "mypy",
   "pre-commit",
   "pandas-stubs",
+  "fastapi>=0.100",
+  "uvicorn[standard]>=0.20",
+  "jinja2>=3.1",
   "opentelemetry-api>=1.20",
   "opentelemetry-sdk>=1.20",
   "opentelemetry-exporter-otlp-proto-grpc>=1.20",
+]
+web = [
+  "fastapi>=0.100",
+  "uvicorn[standard]>=0.20",
+  "jinja2>=3.1",
 ]
 observability = [
   "opentelemetry-api>=1.20",


### PR DESCRIPTION
## Summary

Implements the foundational FastAPI web service layer for the HTMX-based web UI (#74a).

### Changes

- **`web/app.py`**: `create_app()` factory with lifespan, CORS, static files mount
- **`web/run_store.py`**: File-based `RunStore` for simulation run persistence (`RunMeta` model)
- **`web/services.py`**: Thin service wrappers around pipeline, snapshot, baseline, simulation entry points
- **`web/routes/`**: Route modules with health endpoint (`GET /health`) and stub 501 routes for simulate, snapshot, baseline
- **`cli.py`**: Added `serve` CLI command (`younggeul serve --host --port`)
- **`pyproject.toml`**: Added `web` optional dependency group (fastapi, uvicorn, jinja2, python-multipart)

### Testing

- `test_run_store.py`: RunStore CRUD + listing + edge cases
- `test_web_app.py`: Health endpoint integration test
- `test_web_services.py`: Service wrapper unit tests
- All 1,164 tests pass, ruff clean

### Notes

- Route stubs return 501 Not Implemented — will be filled in by #164 (background execution) and #165 (pages/templates)
- RunStore uses file-based JSON storage (suitable for single-instance deployment)

Closes #163