### PR TITLE
feat: HTMX web UI pages (Dashboard, Simulate, Report, Baseline) (#165)

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/app.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/app.py
@@ -6,10 +6,12 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI
+from fastapi.templating import Jinja2Templates
 
 from .run_store import RunStore
 from .routes.baseline import router as baseline_router
 from .routes.health import router as health_router
+from .routes.pages import router as pages_router
 from .routes.simulate import router as simulate_router
 from .routes.snapshot import router as snapshot_router
 
@@ -19,6 +21,7 @@ async def app_lifespan(app: FastAPI) -> AsyncIterator[None]:
     executor = ThreadPoolExecutor(max_workers=2)
     app.state.executor = executor
     app.state.run_store = RunStore(base_dir=Path("./output/runs"))
+    app.state.templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
     try:
         yield
     finally:
@@ -31,4 +34,5 @@ def create_app() -> FastAPI:
     app.include_router(simulate_router)
     app.include_router(snapshot_router)
     app.include_router(baseline_router)
+    app.include_router(pages_router)
     return app

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/__init__.py
@@ -1,6 +1,7 @@
 from .baseline import router as baseline_router
 from .health import router as health_router
+from .pages import router as pages_router
 from .simulate import router as simulate_router
 from .snapshot import router as snapshot_router
 
-__all__ = ["health_router", "simulate_router", "snapshot_router", "baseline_router"]
+__all__ = ["health_router", "simulate_router", "snapshot_router", "baseline_router", "pages_router"]

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/pages.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/pages.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Protocol, cast
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request, status
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from ..run_store import RunMeta, RunStore
+from ..services import forecast_baseline_service, resolve_snapshot_service, run_simulation_background
+
+router = APIRouter(prefix="/ui", tags=["pages"])
+
+
+class _AppState(Protocol):
+    templates: Jinja2Templates
+    run_store: object
+    executor: ThreadPoolExecutor
+
+
+def _state(request: Request) -> _AppState:
+    return cast(_AppState, request.app.state)
+
+
+def _templates(request: Request) -> Jinja2Templates:
+    return _state(request).templates
+
+
+def _badge_class(status_name: str) -> str:
+    mapping = {
+        "pending": "badge-pending",
+        "running": "badge-running",
+        "completed": "badge-completed",
+        "failed": "badge-failed",
+    }
+    return mapping.get(status_name, "badge-pending")
+
+
+def _run_report(run_store: object, run_id: str) -> str | None:
+    typed_run_store = cast("RunStoreLike", run_store)
+    report_path = typed_run_store.base_dir / run_id / "report.md"
+    if not report_path.exists():
+        return None
+    return report_path.read_text(encoding="utf-8")
+
+
+def _run_context(run_store: object, run_id: str) -> dict[str, object]:
+    typed_run_store = cast("RunStoreLike", run_store)
+    run_meta = typed_run_store.get_run(run_id)
+    if run_meta is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Run not found")
+
+    report_text: str | None = None
+    if run_meta.status == "completed":
+        report_text = _run_report(typed_run_store, run_id)
+
+    return {
+        "run": run_meta,
+        "badge_class": _badge_class(run_meta.status),
+        "report_text": report_text,
+        "is_polling": run_meta.status in {"pending", "running"},
+    }
+
+
+class RunStoreLike(Protocol):
+    base_dir: Path
+
+    def get_run(self, run_id: str) -> RunMeta | None: ...
+
+    def list_runs(self) -> list[RunMeta]: ...
+
+    def create_run(self, query: str) -> str: ...
+
+
+@router.get("/", response_class=HTMLResponse)
+@router.get("/dashboard", response_class=HTMLResponse)
+async def dashboard_page(request: Request) -> HTMLResponse:
+    run_store = cast(RunStoreLike, _state(request).run_store)
+    runs: list[RunMeta] = run_store.list_runs()
+    context = {"request": request, "runs": runs}
+    return _templates(request).TemplateResponse(request, "dashboard.html", context)
+
+
+@router.get("/partials/runs", response_class=HTMLResponse)
+async def run_list_partial(request: Request) -> HTMLResponse:
+    run_store = cast(RunStoreLike, _state(request).run_store)
+    runs: list[RunMeta] = run_store.list_runs()
+    context = {"request": request, "runs": runs}
+    return _templates(request).TemplateResponse(request, "partials/run_list.html", context)
+
+
+@router.get("/simulate", response_class=HTMLResponse)
+async def simulate_page(request: Request) -> HTMLResponse:
+    return _templates(request).TemplateResponse(request, "simulate.html", {"request": request})
+
+
+@router.post("/simulate", response_class=HTMLResponse)
+async def simulate_start(request: Request) -> HTMLResponse:
+    form_payload = _parse_form_payload(await request.body())
+    query = form_payload.get("query", "").strip()
+    if not query:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="query is required")
+
+    max_rounds_raw = form_payload.get("max_rounds", "3")
+    try:
+        max_rounds = int(max_rounds_raw)
+    except ValueError:
+        max_rounds = 3
+    model_id = form_payload.get("model_id", "stub") or "stub"
+
+    run_store = cast(RunStoreLike, _state(request).run_store)
+    executor = _state(request).executor
+
+    run_id = run_store.create_run(query)
+    _ = executor.submit(
+        run_simulation_background,
+        cast(RunStore, run_store),
+        run_id,
+        query,
+        max_rounds,
+        model_id,
+    )
+
+    context = {
+        "request": request,
+        "run_id": run_id,
+        "run_url": f"/ui/simulate/{run_id}",
+    }
+    return _templates(request).TemplateResponse(request, "partials/simulate_result.html", context)
+
+
+@router.get("/simulate/{run_id}", response_class=HTMLResponse)
+async def run_detail_page(request: Request, run_id: str) -> HTMLResponse:
+    run_store = cast(RunStoreLike, _state(request).run_store)
+    context = {"request": request, **_run_context(run_store, run_id)}
+    return _templates(request).TemplateResponse(request, "run_detail.html", context)
+
+
+@router.get("/partials/runs/{run_id}", response_class=HTMLResponse)
+async def run_detail_partial(request: Request, run_id: str) -> HTMLResponse:
+    run_store = cast(RunStoreLike, _state(request).run_store)
+    context = {"request": request, **_run_context(run_store, run_id)}
+    return _templates(request).TemplateResponse(request, "partials/run_status.html", context)
+
+
+@router.get("/baseline", response_class=HTMLResponse)
+async def baseline_page(request: Request) -> HTMLResponse:
+    context: dict[str, object] = {"request": request, "snapshot_id": "", "results": [], "error": None}
+    return _templates(request).TemplateResponse(request, "baseline.html", context)
+
+
+@router.post("/baseline", response_class=HTMLResponse)
+async def baseline_run(request: Request) -> HTMLResponse:
+    form_payload = _parse_form_payload(await request.body())
+    snapshot_id = form_payload.get("snapshot_id", "").strip()
+
+    context: dict[str, object] = {
+        "request": request,
+        "snapshot_id": snapshot_id,
+        "results": [],
+        "error": None,
+    }
+
+    if not snapshot_id:
+        context["error"] = "snapshot_id is required"
+        return _templates(request).TemplateResponse(request, "baseline.html", context)
+
+    try:
+        _, metrics = resolve_snapshot_service(snapshot_id, Path("./output/snapshots"))
+        forecasts = forecast_baseline_service(metrics)
+        context["results"] = forecasts
+    except (FileNotFoundError, ValueError) as exc:
+        context["error"] = str(exc)
+
+    return _templates(request).TemplateResponse(request, "baseline.html", context)
+
+
+def _parse_form_payload(body: bytes) -> dict[str, str]:
+    parsed = parse_qs(body.decode("utf-8"), keep_blank_values=True)
+    return {key: values[-1] if values else "" for key, values in parsed.items()}

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/base.html
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/base.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}영끌 시뮬레이터{% endblock %}</title>
+  <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f8fafc;
+      --panel: #ffffff;
+      --text: #0f172a;
+      --muted: #64748b;
+      --border: #e2e8f0;
+      --primary: #2563eb;
+      --primary-soft: #dbeafe;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0 auto;
+      max-width: 960px;
+      padding: 24px 20px 40px;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+      color: var(--text);
+      background: var(--bg);
+    }
+
+    h1, h2, h3 { margin-top: 0; }
+
+    nav {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 24px;
+      padding: 12px 16px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: var(--panel);
+    }
+
+    nav a {
+      text-decoration: none;
+      color: var(--primary);
+      font-weight: 600;
+      padding: 6px 10px;
+      border-radius: 8px;
+    }
+
+    nav a:hover {
+      background: var(--primary-soft);
+    }
+
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 20px;
+      margin-bottom: 16px;
+      box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+    }
+
+    .muted { color: var(--muted); }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      padding: 2px 10px;
+      font-size: 0.8rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+    }
+
+    .badge-pending { background: #fef3c7; color: #92400e; }
+    .badge-running { background: #dbeafe; color: #1d4ed8; }
+    .badge-completed { background: #dcfce7; color: #166534; }
+    .badge-failed { background: #fee2e2; color: #991b1b; }
+
+    form { display: grid; gap: 12px; }
+
+    label {
+      display: block;
+      font-size: 0.92rem;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+
+    input, textarea, button {
+      width: 100%;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 10px 12px;
+      font: inherit;
+      background: #fff;
+      color: var(--text);
+    }
+
+    textarea { min-height: 110px; }
+
+    button {
+      width: auto;
+      min-width: 120px;
+      cursor: pointer;
+      border-color: #1d4ed8;
+      background: var(--primary);
+      color: #fff;
+      font-weight: 700;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.95rem;
+    }
+
+    th, td {
+      text-align: left;
+      vertical-align: top;
+      padding: 10px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    th {
+      color: var(--muted);
+      font-weight: 700;
+      font-size: 0.82rem;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+
+    code, pre {
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: #f8fafc;
+    }
+
+    pre {
+      padding: 12px;
+      overflow-x: auto;
+      margin: 0;
+      white-space: pre-wrap;
+    }
+
+    .error {
+      border: 1px solid #fecaca;
+      color: #991b1b;
+      background: #fef2f2;
+      border-radius: 10px;
+      padding: 10px 12px;
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <a href="/ui/dashboard">Dashboard</a>
+    <a href="/ui/simulate">Simulate</a>
+    <a href="/ui/baseline">Baseline</a>
+  </nav>
+
+  {% block content %}{% endblock %}
+</body>
+</html>

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/baseline.html
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/baseline.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+
+{% block title %}Baseline | 영끌 시뮬레이터{% endblock %}
+
+{% block content %}
+  <section class="panel">
+    <h1>Baseline Forecast</h1>
+    <form method="post" action="/ui/baseline">
+      <div>
+        <label for="snapshot_id">snapshot_id</label>
+        <input id="snapshot_id" name="snapshot_id" type="text" value="{{ snapshot_id }}" placeholder="latest 또는 스냅샷 ID" required>
+      </div>
+      <button type="submit">예측 실행</button>
+    </form>
+  </section>
+
+  <section class="panel">
+    <h2>결과</h2>
+    {% if error %}
+      <p class="error">{{ error }}</p>
+    {% endif %}
+
+    <table>
+      <thead>
+        <tr>
+          <th>gu_code</th>
+          <th>gu_name</th>
+          <th>forecast_date</th>
+          <th>forecast_median_price</th>
+          <th>method</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for item in results %}
+          <tr>
+            <td>{{ item.gu_code }}</td>
+            <td>{{ item.gu_name }}</td>
+            <td>{{ item.target_period }}</td>
+            <td>{{ item.predicted_median_price }}</td>
+            <td>{{ item.model_name }}</td>
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="5" class="muted">표시할 결과가 없습니다.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+{% endblock %}

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/dashboard.html
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/dashboard.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}Dashboard | 영끌 시뮬레이터{% endblock %}
+
+{% block content %}
+  <section class="panel">
+    <h1>시뮬레이션 대시보드</h1>
+    <p class="muted">최근 실행 기록을 5초마다 자동으로 갱신합니다.</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Run ID</th>
+          <th>Query</th>
+          <th>Status</th>
+          <th>Created</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody
+        id="run-list"
+        hx-get="/ui/partials/runs"
+        hx-trigger="every 5s"
+        hx-swap="innerHTML"
+      >
+        {% include "partials/run_list.html" %}
+      </tbody>
+    </table>
+  </section>
+{% endblock %}

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/partials/run_list.html
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/partials/run_list.html
@@ -1,0 +1,15 @@
+{% for run in runs %}
+  <tr>
+    <td><code>{{ run.run_id[:8] }}...</code></td>
+    <td>{{ run.query }}</td>
+    <td>
+      <span class="badge badge-{{ run.status }}">{{ run.status }}</span>
+    </td>
+    <td>{{ run.created_at }}</td>
+    <td><a href="/ui/simulate/{{ run.run_id }}">View</a></td>
+  </tr>
+{% else %}
+  <tr>
+    <td colspan="5" class="muted">아직 실행된 시뮬레이션이 없습니다.</td>
+  </tr>
+{% endfor %}

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/partials/run_status.html
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/partials/run_status.html
@@ -1,0 +1,33 @@
+<table>
+  <tbody>
+    <tr>
+      <th>Run ID</th>
+      <td><code>{{ run.run_id }}</code></td>
+    </tr>
+    <tr>
+      <th>Query</th>
+      <td>{{ run.query }}</td>
+    </tr>
+    <tr>
+      <th>Status</th>
+      <td><span class="badge {{ badge_class }}">{{ run.status }}</span></td>
+    </tr>
+    <tr>
+      <th>Created</th>
+      <td>{{ run.created_at }}</td>
+    </tr>
+    <tr>
+      <th>Completed</th>
+      <td>{{ run.completed_at or "-" }}</td>
+    </tr>
+  </tbody>
+</table>
+
+{% if run.status == "completed" and report_text %}
+  <div class="panel" style="margin-top: 12px; margin-bottom: 0;">
+    <h3>Report</h3>
+    <pre>{{ report_text }}</pre>
+  </div>
+{% elif run.status == "failed" %}
+  <p class="error" style="margin-top: 12px;">실행 실패: {{ run.error or "unknown error" }}</p>
+{% endif %}

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/partials/simulate_result.html
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/partials/simulate_result.html
@@ -1,0 +1,11 @@
+<h2>실행이 생성되었습니다</h2>
+<p>
+  Run ID: <code>{{ run_id }}</code><br>
+  상세 페이지: <a href="{{ run_url }}">{{ run_url }}</a>
+</p>
+<div
+  id="run-status"
+  hx-get="/ui/partials/runs/{{ run_id }}"
+  hx-trigger="load, every 2s"
+  hx-swap="innerHTML"
+></div>

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/run_detail.html
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/run_detail.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block title %}Run Detail | 영끌 시뮬레이터{% endblock %}
+
+{% block content %}
+  <section class="panel">
+    <h1>시뮬레이션 상세</h1>
+    <div
+      id="run-detail-status"
+      {% if is_polling %}
+      hx-get="/ui/partials/runs/{{ run.run_id }}"
+      hx-trigger="load, every 2s"
+      hx-swap="innerHTML"
+      {% endif %}
+    >
+      {% include "partials/run_status.html" %}
+    </div>
+  </section>
+{% endblock %}

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/simulate.html
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/templates/simulate.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block title %}Simulate | 영끌 시뮬레이터{% endblock %}
+
+{% block content %}
+  <section class="panel">
+    <h1>시뮬레이션 실행</h1>
+    <form hx-post="/ui/simulate" hx-target="#result" hx-swap="innerHTML">
+      <div>
+        <label for="query">Query</label>
+        <textarea id="query" name="query" placeholder="예: 2026년 강남구 매매시장 전망" required></textarea>
+      </div>
+      <div>
+        <label for="max_rounds">Max Rounds</label>
+        <input id="max_rounds" name="max_rounds" type="number" min="1" value="3" required>
+      </div>
+      <div>
+        <label for="model_id">Model ID</label>
+        <input id="model_id" name="model_id" type="text" value="stub" required>
+      </div>
+      <button type="submit">실행 시작</button>
+    </form>
+  </section>
+
+  <section id="result" class="panel">
+    <p class="muted">실행 결과가 여기에 표시됩니다.</p>
+  </section>
+{% endblock %}

--- a/apps/kr-seoul-apartment/tests/unit/test_web_pages.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_web_pages.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from younggeul_app_kr_seoul_apartment.web.run_store import RunStore
+
+web_app = import_module("younggeul_app_kr_seoul_apartment.web.app")
+simulate_routes = import_module("younggeul_app_kr_seoul_apartment.web.routes.simulate")
+
+
+def _create_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    runs_dir = tmp_path / "runs"
+
+    def run_store_factory(base_dir: Path | str | None = None) -> RunStore:
+        _ = base_dir
+        return RunStore(base_dir=runs_dir)
+
+    monkeypatch.setattr(web_app, "RunStore", run_store_factory)
+    return TestClient(web_app.create_app())
+
+
+def test_get_ui_dashboard_returns_html(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    with _create_client(tmp_path, monkeypatch) as client:
+        response = client.get("/ui/dashboard")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "시뮬레이션 대시보드" in response.text
+
+
+def test_get_ui_simulate_returns_html(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    with _create_client(tmp_path, monkeypatch) as client:
+        response = client.get("/ui/simulate")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "시뮬레이션 실행" in response.text
+
+
+def test_get_ui_baseline_returns_html(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    with _create_client(tmp_path, monkeypatch) as client:
+        response = client.get("/ui/baseline")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "Baseline Forecast" in response.text
+
+
+def test_get_ui_simulate_run_detail_returns_200_for_existing_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_background(*args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+
+    monkeypatch.setattr(simulate_routes, "run_simulation_background", fake_background)
+
+    with _create_client(tmp_path, monkeypatch) as client:
+        run_id = client.post("/simulate", json={"query": "강남구"}).json()["run_id"]
+        response = client.get(f"/ui/simulate/{run_id}")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert run_id in response.text
+
+
+def test_get_ui_simulate_run_detail_returns_404_for_missing_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with _create_client(tmp_path, monkeypatch) as client:
+        response = client.get("/ui/simulate/does-not-exist")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Run not found"
+
+
+def test_get_ui_partials_runs_returns_html_fragment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_background(*args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+
+    monkeypatch.setattr(simulate_routes, "run_simulation_background", fake_background)
+
+    with _create_client(tmp_path, monkeypatch) as client:
+        _ = client.post("/simulate", json={"query": "송파구"})
+        response = client.get("/ui/partials/runs")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "<tr>" in response.text


### PR DESCRIPTION
## Summary
- add a Jinja2 template system with a shared base layout plus HTMX-driven Dashboard, Simulate, Run Detail (Report), and Baseline pages under `/ui/*`
- introduce dedicated HTML page routes and partial endpoints while keeping existing JSON API routes unchanged (`/simulate`, `/simulate/{run_id}`, `/simulate` list)
- add unit tests for all new HTML-serving endpoints and partial fragments

## Verification
- `ruff check .`
- `ruff format --check .`
- `python3 -m pytest`

Closes #165