### PR TITLE
feat: Docker Compose web profile + deployment docs (#166)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+__pycache__
+*.pyc
+.mypy_cache
+.ruff_cache
+.pytest_cache
+output/
+*.egg-info
+.venv
+venv
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml ./
+COPY core/ core/
+COPY apps/ apps/
+
+RUN pip install --no-cache-dir -e ".[web,observability,kr-seoul-apartment]"
+
+EXPOSE 8000
+
+CMD ["python", "-m", "younggeul_app_kr_seoul_apartment.cli", "serve", "--host", "0.0.0.0", "--port", "8000"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -50,3 +50,31 @@ services:
       - "3000:3000"
     depends_on:
       - prometheus
+
+  web:
+    profiles: [web]
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./output:/app/output
+    environment:
+      OTEL_ENABLED: "false"
+
+  web-obs:
+    profiles: [web-obs]
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./output:/app/output
+    environment:
+      OTEL_ENABLED: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+      OTEL_EXPORTER_OTLP_INSECURE: "true"
+    depends_on:
+      - otel-collector

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -1,0 +1,101 @@
+# Web UI Deployment Guide
+
+## Overview
+
+younggeul ships a browser-based Web UI built on:
+
+- **FastAPI** for HTTP routing and API endpoints
+- **Jinja2** for server-side HTML templates
+- **HTMX** for incremental page updates (run list/status polling, form-driven partial updates)
+
+The UI is served by the same application package as the CLI (`younggeul_app_kr_seoul_apartment`) and can be started with `younggeul serve`.
+
+## Architecture
+
+The web app is created in `web/app.py` via `create_app()` and uses a FastAPI lifespan hook to initialize shared runtime components:
+
+- `ThreadPoolExecutor(max_workers=2)` for background simulation execution
+- `RunStore(base_dir=./output/runs)` for run metadata/report persistence
+- `Jinja2Templates` for rendering pages and HTMX partials
+
+Background simulations are submitted from UI/API handlers and executed through `run_simulation_background(...)`, while run status and report content are persisted under `./output/runs/<run_id>/`.
+
+## Pages
+
+- **Dashboard** (`/ui`, `/ui/dashboard`): list all runs and quick status overview
+- **Simulate** (`/ui/simulate`): start a simulation and receive HTMX run link/partial updates
+- **Run Detail** (`/ui/simulate/{run_id}`): inspect a single run, including report/error status
+- **Baseline** (`/ui/baseline`): submit snapshot ID and render baseline forecast results
+
+## API Endpoints
+
+### JSON API routes
+
+| Method | Path | Description | Status |
+|---|---|---|---|
+| `GET` | `/health` | Service liveness/version check | Implemented |
+| `POST` | `/simulate` | Create simulation run (async) | Implemented |
+| `GET` | `/simulate` | List simulation runs | Implemented |
+| `GET` | `/simulate/{run_id}` | Get single run metadata | Implemented |
+| `POST` | `/baseline` | Baseline API route placeholder | `501 Not Implemented` |
+| `GET` | `/snapshot` | Snapshot list API placeholder | `501 Not Implemented` |
+| `POST` | `/snapshot/publish` | Snapshot publish API placeholder | `501 Not Implemented` |
+
+### HTML UI routes
+
+| Method | Path | Template/Response | Description |
+|---|---|---|---|
+| `GET` | `/ui` | `dashboard.html` | Dashboard entry page |
+| `GET` | `/ui/dashboard` | `dashboard.html` | Dashboard alias |
+| `GET` | `/ui/partials/runs` | `partials/run_list.html` | HTMX run list refresh |
+| `GET` | `/ui/simulate` | `simulate.html` | Simulation form page |
+| `POST` | `/ui/simulate` | `partials/simulate_result.html` | Start simulation from form |
+| `GET` | `/ui/simulate/{run_id}` | `run_detail.html` | Run detail page |
+| `GET` | `/ui/partials/runs/{run_id}` | `partials/run_status.html` | HTMX run status polling |
+| `GET` | `/ui/baseline` | `baseline.html` | Baseline page |
+| `POST` | `/ui/baseline` | `baseline.html` | Baseline form submit/result |
+
+## Run locally
+
+```bash
+younggeul serve --host 0.0.0.0 --port 8000
+# or
+python -m younggeul_app_kr_seoul_apartment.cli serve --host 0.0.0.0 --port 8000
+```
+
+Then open: http://localhost:8000/ui
+
+## Run with Docker Compose
+
+Start web UI only:
+
+```bash
+docker compose --profile web up -d
+```
+
+Start web UI with observability stack:
+
+```bash
+docker compose --profile web-obs --profile obs up -d
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `OTEL_ENABLED` | `false` (`web` profile) / `true` (`web-obs`) | Toggle OpenTelemetry metrics/tracing bootstrap |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | _(unset)_ | OTLP gRPC collector endpoint (e.g. `http://otel-collector:4317`) |
+| `OTEL_EXPORTER_OTLP_INSECURE` | `false` | Use insecure OTLP gRPC transport when `true` |
+
+## Development notes
+
+- App entrypoint: `younggeul_app_kr_seoul_apartment.web.app:create_app`
+- Route modules live in `.../web/routes/` and are included in `create_app()`
+- Template root: `.../web/templates/`
+  - Top-level pages: `dashboard.html`, `simulate.html`, `run_detail.html`, `baseline.html`
+  - HTMX partials: `partials/*.html`
+- To add a new page:
+  1. Add route handler(s) under `web/routes/pages.py` (or a new route module)
+  2. Add/extend templates under `web/templates/`
+  3. Include router in `web/app.py` if introducing a new module
+  4. Add/extend tests in `apps/kr-seoul-apartment/tests/unit/test_web_*.py`


### PR DESCRIPTION
## Summary
- Add a Python 3.12-slim Dockerfile and `.dockerignore` for running the web UI via `younggeul ... serve`.
- Extend `compose.yaml` with `web` and `web-obs` profile services while preserving the existing `obs` stack.
- Add `docs/web-ui.md` covering architecture, pages/routes, local + Docker run modes, environment variables, and development notes.

## Verification
- `ruff check . && ruff format --check .`
- `python3 -m pytest` (1177 passed, 6 skipped)

Closes #166