### PR TITLE
Tune alert thresholds with minimum-volume guards

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -94,9 +94,9 @@ Alert rules are provisioned from:
 Configured rules:
 
 1. **HighSimulationFailureRate**
-   - Expression: `rate(younggeul_simulation_runs_total{status="error"}[5m]) / rate(younggeul_simulation_runs_total[5m]) > 0.5`
+   - Expression: `(sum(rate(younggeul_simulation_runs_total{status="error"}[5m])) / sum(rate(younggeul_simulation_runs_total[5m]))) > 0.3 and sum(rate(younggeul_simulation_runs_total[5m])) > 0.01`
    - For: `5m`
-   - Meaning: more than 50% of recent simulations are failing.
+   - Meaning: more than 30% of recent simulations are failing (aggregated across all status labels), with at least 0.01 runs/sec total volume.
 
 2. **HighLLMLatency**
    - Expression: `histogram_quantile(0.95, rate(younggeul_llm_request_duration_seconds_bucket[5m])) > 30`
@@ -104,9 +104,14 @@ Configured rules:
    - Meaning: p95 LLM latency is above 30 seconds.
 
 3. **CitationGateFailureSpike**
-   - Expression: `rate(younggeul_citation_gate_failures_total[5m]) > 0.1`
+   - Expression: `sum(rate(younggeul_citation_gate_failures_total[5m])) > 0.1 and sum(increase(younggeul_citation_gate_failures_total[5m])) > 3`
    - For: `5m`
-   - Meaning: citation gate failures are spiking.
+   - Meaning: citation gate failures are spiking (aggregated across all labels) with a minimum absolute count guard (> 3 failures in 5m).
+
+4. **StuckRunningSimulation**
+   - Expression: `younggeul_simulation_active_runs > 0`
+   - For: `10m`
+   - Meaning: a simulation has been in running state for more than 10 minutes (requires `simulation_active_runs` UpDownCounter from job-system metrics).
 
 ## Architecture diagram
 

--- a/infra/grafana/provisioning/alerting/alerts.yaml
+++ b/infra/grafana/provisioning/alerting/alerts.yaml
@@ -21,7 +21,7 @@ groups:
                 type: prometheus
                 uid: prometheus
               editorMode: code
-              expr: rate(younggeul_simulation_runs_total{status="error"}[5m]) / rate(younggeul_simulation_runs_total[5m]) > 0.5
+              expr: (sum(rate(younggeul_simulation_runs_total{status="error"}[5m])) / sum(rate(younggeul_simulation_runs_total[5m]))) > 0.3 and sum(rate(younggeul_simulation_runs_total[5m])) > 0.01
               instant: true
               intervalMs: 1000
               maxDataPoints: 43200
@@ -29,7 +29,7 @@ groups:
         noDataState: NoData
         execErrState: Error
         annotations:
-          summary: Simulation error rate is above 50% for 5 minutes.
+          summary: Simulation error rate is above 30% for 5 minutes with minimum run volume (> 0.01 runs/sec).
         labels:
           severity: critical
 
@@ -75,7 +75,7 @@ groups:
                 type: prometheus
                 uid: prometheus
               editorMode: code
-              expr: rate(younggeul_citation_gate_failures_total[5m]) > 0.1
+              expr: sum(rate(younggeul_citation_gate_failures_total[5m])) > 0.1 and sum(increase(younggeul_citation_gate_failures_total[5m])) > 3
               instant: true
               intervalMs: 1000
               maxDataPoints: 43200
@@ -83,6 +83,33 @@ groups:
         noDataState: NoData
         execErrState: Error
         annotations:
-          summary: Citation gate failures exceed 0.1 events/second for 5 minutes.
+          summary: Citation gate failures exceed 0.1 events/second for 5 minutes with minimum absolute failures (> 3 in 5m).
+        labels:
+          severity: warning
+
+      - uid: stuck-running-simulation
+        title: StuckRunningSimulation
+        condition: A
+        for: 10m
+        data:
+          - refId: A
+            datasourceUid: prometheus
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: younggeul_simulation_active_runs > 0
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+        noDataState: NoData
+        execErrState: Error
+        annotations:
+          summary: A simulation has been in running state for more than 10 minutes.
         labels:
           severity: warning


### PR DESCRIPTION
## Summary
- Lowered `HighSimulationFailureRate` threshold from 50% to 30% and added a minimum run-volume guard to reduce low-volume noise.
- Added an absolute-count guard to `CitationGateFailureSpike` while keeping the rate threshold for meaningful spikes.
- Updated observability docs to match the provisioned alert expressions and semantics.

Closes #182