### PR TITLE
feat: harden background job lifecycle durability

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/app.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/app.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
+import logging
 from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.templating import Jinja2Templates
 
+from ..simulation.metrics import init_metrics
+from ..simulation.tracing import init_tracing
+from .middleware import MetricsMiddleware
 from .run_store import RunStore
 from .routes.baseline import router as baseline_router
 from .routes.health import router as health_router
@@ -16,11 +20,20 @@ from .routes.simulate import router as simulate_router
 from .routes.snapshot import router as snapshot_router
 
 
+logger = logging.getLogger(__name__)
+
+
 @asynccontextmanager
 async def app_lifespan(app: FastAPI) -> AsyncIterator[None]:
+    init_tracing()
+    init_metrics()
     executor = ThreadPoolExecutor(max_workers=2)
     app.state.executor = executor
-    app.state.run_store = RunStore(base_dir=Path("./output/runs"))
+    run_store = RunStore(base_dir=Path("./output/runs"))
+    app.state.run_store = run_store
+    reconciled_count = run_store.reconcile_stale_runs()
+    if reconciled_count > 0:
+        logger.warning("Reconciled %s stale runs on startup", reconciled_count)
     app.state.templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
     try:
         yield
@@ -30,6 +43,7 @@ async def app_lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 def create_app() -> FastAPI:
     app = FastAPI(title="영끌 시뮬레이터", version="0.2.0", lifespan=app_lifespan)
+    app.add_middleware(MetricsMiddleware)
     app.include_router(health_router)
     app.include_router(simulate_router)
     app.include_router(snapshot_router)

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/config.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/config.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import os
+
+
+def get_allowed_models() -> tuple[str, ...]:
+    raw = os.getenv("YOUNGGEUL_ALLOWED_MODELS", "stub,gpt-4o-mini")
+    models = tuple(model.strip() for model in raw.split(",") if model.strip())
+    return models or ("stub",)
+
+
+def validate_model_id(model_id: str) -> None:
+    allowed_models = get_allowed_models()
+    if model_id not in allowed_models:
+        raise ValueError(f"model_id '{model_id}' is not allowed")
+
+
+def validate_max_rounds(max_rounds: int) -> None:
+    if max_rounds < 1 or max_rounds > 10:
+        raise ValueError("max_rounds must be between 1 and 10")

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/middleware.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/middleware.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import re
+import time
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from younggeul_app_kr_seoul_apartment.simulation.metrics import (
+    CounterLike,
+    HistogramLike,
+    get_meter,
+    metric_attrs,
+)
+
+
+_UUID_PATH_SEGMENT_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+)
+
+_web_requests_total: CounterLike | None = None
+_web_request_duration_seconds: HistogramLike | None = None
+
+
+def web_requests_total() -> CounterLike:
+    global _web_requests_total
+    if _web_requests_total is None:
+        _web_requests_total = get_meter().create_counter(
+            "web_requests_total",
+            description="Total number of web requests",
+            unit="{request}",
+        )
+    return _web_requests_total
+
+
+def web_request_duration_seconds() -> HistogramLike:
+    global _web_request_duration_seconds
+    if _web_request_duration_seconds is None:
+        _web_request_duration_seconds = get_meter().create_histogram(
+            "web_request_duration_seconds",
+            description="Duration of web requests",
+            unit="s",
+        )
+    return _web_request_duration_seconds
+
+
+def _normalize_path(path: str) -> str:
+    return _UUID_PATH_SEGMENT_RE.sub(":id", path)
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        start = time.perf_counter()
+        method = request.method
+        path = _normalize_path(request.url.path)
+        status_code = "500"
+
+        try:
+            response = await call_next(request)
+            status_code = str(response.status_code)
+            return response
+        finally:
+            web_requests_total().add(
+                1,
+                attributes=metric_attrs(method=method, path=path, status_code=status_code),
+            )
+            web_request_duration_seconds().record(
+                time.perf_counter() - start,
+                attributes=metric_attrs(method=method, path=path),
+            )

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/pages.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/pages.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
+from ..config import validate_max_rounds, validate_model_id
 from ..run_store import RunMeta, RunStore
 from ..services import forecast_baseline_service, resolve_snapshot_service, run_simulation_background
 
@@ -74,6 +75,15 @@ class RunStoreLike(Protocol):
 
     def create_run(self, query: str) -> str: ...
 
+    def update_status(
+        self,
+        run_id: str,
+        status: str,
+        *,
+        error: str | None = None,
+        report: str | None = None,
+    ) -> None: ...
+
 
 @router.get("/", response_class=HTMLResponse)
 @router.get("/dashboard", response_class=HTMLResponse)
@@ -111,18 +121,28 @@ async def simulate_start(request: Request) -> HTMLResponse:
         max_rounds = 3
     model_id = form_payload.get("model_id", "stub") or "stub"
 
+    try:
+        validate_model_id(model_id)
+        validate_max_rounds(max_rounds)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+
     run_store = cast(RunStoreLike, _state(request).run_store)
     executor = _state(request).executor
 
     run_id = run_store.create_run(query)
-    _ = executor.submit(
-        run_simulation_background,
-        cast(RunStore, run_store),
-        run_id,
-        query,
-        max_rounds,
-        model_id,
-    )
+    try:
+        _ = executor.submit(
+            run_simulation_background,
+            cast(RunStore, run_store),
+            run_id,
+            query,
+            max_rounds,
+            model_id,
+        )
+    except Exception as exc:
+        run_store.update_status(run_id, "failed", error=str(exc))
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
 
     context = {
         "request": request,

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/simulate.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/routes/simulate.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
+from ..config import get_allowed_models, validate_max_rounds, validate_model_id
 from ..run_store import RunMeta
 from ..services import run_simulation_background
 
@@ -14,7 +15,16 @@ router = APIRouter(prefix="/simulate", tags=["simulate"])
 class SimulateRequest(BaseModel):
     query: str
     max_rounds: int = Field(default=3)
-    model_id: str = Field(default="stub")
+    model_id: str = Field(
+        default="stub",
+        description=f"Allowed model IDs: {', '.join(get_allowed_models())}",
+    )
+
+    @model_validator(mode="after")
+    def validate_inputs(self) -> SimulateRequest:
+        validate_model_id(self.model_id)
+        validate_max_rounds(self.max_rounds)
+        return self
 
 
 @router.post("", status_code=status.HTTP_202_ACCEPTED)
@@ -23,14 +33,18 @@ async def create_simulation_run(request: Request, payload: SimulateRequest) -> d
     executor = request.app.state.executor
 
     run_id = run_store.create_run(payload.query)
-    executor.submit(
-        run_simulation_background,
-        run_store,
-        run_id,
-        payload.query,
-        payload.max_rounds,
-        payload.model_id,
-    )
+    try:
+        executor.submit(
+            run_simulation_background,
+            run_store,
+            run_id,
+            payload.query,
+            payload.max_rounds,
+            payload.model_id,
+        )
+    except Exception as exc:
+        run_store.update_status(run_id, "failed", error=str(exc))
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
     return {"run_id": run_id, "status": "pending"}
 
 

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/run_store.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/run_store.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
 
 from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+_VALID_TRANSITIONS: dict[str, set[str]] = {
+    "pending": {"running", "failed"},
+    "running": {"completed", "failed"},
+}
 
 
 class RunMeta(BaseModel):
@@ -44,6 +52,12 @@ class RunStore:
         report: str | None = None,
     ) -> None:
         meta = self._read_meta(run_id)
+        current = meta.status
+        target = status
+        allowed = _VALID_TRANSITIONS.get(current)
+        if allowed is None or target not in allowed:
+            raise ValueError(f"Invalid state transition: {current} -> {target}")
+
         completed_at = meta.completed_at
         if status in {"completed", "failed"}:
             completed_at = datetime.now(timezone.utc)
@@ -53,6 +67,30 @@ class RunStore:
 
         if report is not None:
             self._report_path(run_id).write_text(report, encoding="utf-8")
+
+    def reconcile_stale_runs(self) -> int:
+        if not self.base_dir.exists():
+            return 0
+
+        reconciled_count = 0
+        for run in self.list_runs():
+            if run.status not in {"running", "pending"}:
+                continue
+
+            reconciled_count += 1
+            logger.info("Reconciling stale run %s with status %s", run.run_id, run.status)
+            stale_meta = run.model_copy(
+                update={
+                    "status": "failed",
+                    "error": "interrupted by restart",
+                    "completed_at": datetime.now(timezone.utc),
+                }
+            )
+            self._write_meta(run.run_id, stale_meta)
+
+        if reconciled_count > 0:
+            logger.warning("Reconciled %s stale simulation runs", reconciled_count)
+        return reconciled_count
 
     def get_run(self, run_id: str) -> RunMeta | None:
         meta_path = self._meta_path(run_id)

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/services.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/services.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +22,8 @@ from younggeul_core.state.simulation import SnapshotRef
 from younggeul_core.storage.snapshot import SnapshotManifest
 
 from .run_store import RunStore
+
+logger = logging.getLogger(__name__)
 
 
 def run_pipeline_service(bronze: BronzeInput) -> PipelineResult:
@@ -63,6 +66,7 @@ def run_simulation_background(run_store: RunStore, run_id: str, query: str, max_
         report = _extract_report_text(final_state, event_store, run_id)
         run_store.update_status(run_id, "completed", report=report)
     except Exception as exc:
+        logger.exception("Simulation %s failed", run_id)
         run_store.update_status(run_id, "failed", error=str(exc))
 
 

--- a/apps/kr-seoul-apartment/tests/unit/test_metrics.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_metrics.py
@@ -30,6 +30,7 @@ ReportClaim = simulation_state_module.ReportClaim
 
 def _reset_metric_singletons() -> None:
     setattr(metrics_module, "_initialized", False)
+    setattr(metrics_module, "_provider", None)
     setattr(metrics_module, "_simulation_runs_total", None)
     setattr(metrics_module, "_simulation_duration_seconds", None)
     setattr(metrics_module, "_simulation_node_duration_seconds", None)
@@ -38,6 +39,8 @@ def _reset_metric_singletons() -> None:
     setattr(metrics_module, "_llm_tokens_total", None)
     setattr(metrics_module, "_llm_cost_usd_total", None)
     setattr(metrics_module, "_citation_gate_failures_total", None)
+    setattr(metrics_module, "_web_requests_total", None)
+    setattr(metrics_module, "_web_request_duration_seconds", None)
 
 
 def _choice(content: str, *, finish_reason: str = "stop") -> SimpleNamespace:
@@ -55,11 +58,13 @@ def test_init_metrics_and_get_meter_work() -> None:
         patch("opentelemetry.sdk.metrics.MeterProvider") as meter_provider_cls,
         patch("opentelemetry.sdk.metrics.export.PeriodicExportingMetricReader") as metric_reader_cls,
         patch("opentelemetry.sdk.metrics.export.ConsoleMetricExporter") as exporter_cls,
+        patch("opentelemetry.sdk.resources.Resource") as resource_cls,
         patch("opentelemetry.metrics.set_meter_provider") as set_meter_provider,
     ):
         provider = meter_provider_cls.return_value
         reader = metric_reader_cls.return_value
         exporter = exporter_cls.return_value
+        resource = resource_cls.return_value
 
         metrics_module.init_metrics()
         metrics_module.init_metrics()
@@ -67,7 +72,12 @@ def test_init_metrics_and_get_meter_work() -> None:
 
     exporter_cls.assert_called_once()
     metric_reader_cls.assert_called_once_with(exporter)
-    meter_provider_cls.assert_called_once_with(metric_readers=[reader])
+    meter_provider_cls.assert_called_once()
+    _, meter_provider_kwargs = meter_provider_cls.call_args
+    assert meter_provider_kwargs["metric_readers"] == [reader]
+    if resource_cls.call_count > 0:
+        resource_cls.assert_called_once_with(attributes={"service.name": "younggeul", "service.version": "0.2.1"})
+        assert meter_provider_kwargs.get("resource") is resource
     set_meter_provider.assert_called_once_with(provider)
     assert getattr(metrics_module, "_initialized") is True
     assert meter is not None
@@ -356,3 +366,70 @@ def test_citation_gate_does_not_emit_failure_counter_when_no_failures() -> None:
         citation_gate_module.make_citation_gate_node(evidence_store, event_store)(state)
 
     failure_counter.add.assert_not_called()
+
+
+def test_shutdown_tracing_is_safe_when_not_initialized() -> None:
+    if not hasattr(tracing_module, "shutdown_tracing"):
+        return
+
+    setattr(tracing_module, "_initialized", False)
+    setattr(tracing_module, "_provider", None)
+
+    tracing_module.shutdown_tracing()
+
+
+def test_shutdown_metrics_is_safe_when_not_initialized() -> None:
+    if not hasattr(metrics_module, "shutdown_metrics"):
+        return
+
+    _reset_metric_singletons()
+
+    metrics_module.shutdown_metrics()
+
+
+def test_shutdown_tracing_flushes_and_shuts_down_provider() -> None:
+    if not hasattr(tracing_module, "shutdown_tracing"):
+        return
+
+    setattr(tracing_module, "_initialized", False)
+    setattr(tracing_module, "_provider", None)
+
+    with (
+        patch.dict("os.environ", {"OTEL_ENABLED": "true"}, clear=False),
+        patch("opentelemetry.sdk.trace.TracerProvider") as tracer_provider_cls,
+        patch("opentelemetry.sdk.trace.export.BatchSpanProcessor"),
+        patch("opentelemetry.sdk.trace.export.ConsoleSpanExporter"),
+        patch("opentelemetry.sdk.resources.Resource"),
+        patch("opentelemetry.trace.set_tracer_provider"),
+    ):
+        provider = tracer_provider_cls.return_value
+        tracing_module.init_tracing()
+        tracing_module.shutdown_tracing()
+
+    provider.force_flush.assert_called_once_with()
+    provider.shutdown.assert_called_once_with()
+    assert getattr(tracing_module, "_provider") is None
+    assert getattr(tracing_module, "_initialized") is False
+
+
+def test_shutdown_metrics_shuts_down_provider() -> None:
+    if not hasattr(metrics_module, "shutdown_metrics"):
+        return
+
+    _reset_metric_singletons()
+
+    with (
+        patch.dict("os.environ", {"OTEL_ENABLED": "true"}, clear=False),
+        patch("opentelemetry.sdk.metrics.MeterProvider") as meter_provider_cls,
+        patch("opentelemetry.sdk.metrics.export.PeriodicExportingMetricReader"),
+        patch("opentelemetry.sdk.metrics.export.ConsoleMetricExporter"),
+        patch("opentelemetry.sdk.resources.Resource"),
+        patch("opentelemetry.metrics.set_meter_provider"),
+    ):
+        provider = meter_provider_cls.return_value
+        metrics_module.init_metrics()
+        metrics_module.shutdown_metrics()
+
+    provider.shutdown.assert_called_once_with()
+    assert getattr(metrics_module, "_provider") is None
+    assert getattr(metrics_module, "_initialized") is False

--- a/apps/kr-seoul-apartment/tests/unit/test_run_store.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_run_store.py
@@ -34,6 +34,31 @@ def test_update_status_changes_status(tmp_path: Path) -> None:
     assert run_meta.status == "running"
 
 
+def test_update_status_allows_pending_running_completed_transition(tmp_path: Path) -> None:
+    store = RunStore(base_dir=tmp_path)
+    run_id = store.create_run("test")
+
+    store.update_status(run_id, "running")
+    store.update_status(run_id, "completed")
+
+    run_meta = store.get_run(run_id)
+    assert run_meta is not None
+    assert run_meta.status == "completed"
+    assert run_meta.completed_at is not None
+
+
+def test_update_status_rejects_invalid_pending_to_completed_transition(tmp_path: Path) -> None:
+    store = RunStore(base_dir=tmp_path)
+    run_id = store.create_run("test")
+
+    try:
+        store.update_status(run_id, "completed")
+    except ValueError as exc:
+        assert str(exc) == "Invalid state transition: pending -> completed"
+    else:
+        raise AssertionError("Expected ValueError for invalid state transition")
+
+
 def test_get_run_returns_run_meta(tmp_path: Path) -> None:
     store = RunStore(base_dir=tmp_path)
     run_id = store.create_run("test")
@@ -75,6 +100,7 @@ def test_update_status_with_report_writes_report_md(tmp_path: Path) -> None:
     run_id = store.create_run("report")
     markdown_report = "# Simulation Report\n\n내용"
 
+    store.update_status(run_id, "running")
     store.update_status(run_id, "completed", report=markdown_report)
 
     report_path = tmp_path / run_id / "report.md"
@@ -84,3 +110,52 @@ def test_update_status_with_report_writes_report_md(tmp_path: Path) -> None:
     assert run_meta is not None
     assert run_meta.status == "completed"
     assert run_meta.completed_at is not None
+
+
+def test_reconcile_stale_runs_marks_running_runs_failed(tmp_path: Path) -> None:
+    store = RunStore(base_dir=tmp_path)
+    run_id = store.create_run("running")
+    store.update_status(run_id, "running")
+
+    reconciled = store.reconcile_stale_runs()
+
+    run_meta = store.get_run(run_id)
+    assert reconciled == 1
+    assert run_meta is not None
+    assert run_meta.status == "failed"
+    assert run_meta.error == "interrupted by restart"
+    assert run_meta.completed_at is not None
+
+
+def test_reconcile_stale_runs_marks_pending_runs_failed(tmp_path: Path) -> None:
+    store = RunStore(base_dir=tmp_path)
+    run_id = store.create_run("pending")
+
+    reconciled = store.reconcile_stale_runs()
+
+    run_meta = store.get_run(run_id)
+    assert reconciled == 1
+    assert run_meta is not None
+    assert run_meta.status == "failed"
+    assert run_meta.error == "interrupted by restart"
+    assert run_meta.completed_at is not None
+
+
+def test_reconcile_stale_runs_skips_completed_and_failed_runs(tmp_path: Path) -> None:
+    store = RunStore(base_dir=tmp_path)
+    completed_run_id = store.create_run("completed")
+    failed_run_id = store.create_run("failed")
+
+    store.update_status(completed_run_id, "running")
+    store.update_status(completed_run_id, "completed")
+    store.update_status(failed_run_id, "failed")
+
+    reconciled = store.reconcile_stale_runs()
+
+    completed_meta = store.get_run(completed_run_id)
+    failed_meta = store.get_run(failed_run_id)
+    assert reconciled == 0
+    assert completed_meta is not None
+    assert completed_meta.status == "completed"
+    assert failed_meta is not None
+    assert failed_meta.status == "failed"

--- a/apps/kr-seoul-apartment/tests/unit/test_web_middleware.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_web_middleware.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from younggeul_app_kr_seoul_apartment.web.run_store import RunStore
+
+web_app = import_module("younggeul_app_kr_seoul_apartment.web.app")
+middleware_module = import_module("younggeul_app_kr_seoul_apartment.web.middleware")
+
+
+def test_metrics_middleware_records_request_metrics_with_normalized_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    request_counter = MagicMock()
+    duration_histogram = MagicMock()
+
+    monkeypatch.setattr(middleware_module, "web_requests_total", lambda: request_counter)
+    monkeypatch.setattr(middleware_module, "web_request_duration_seconds", lambda: duration_histogram)
+    monkeypatch.setattr(web_app, "RunStore", lambda base_dir=None: RunStore(base_dir=tmp_path / "runs"))
+
+    app = web_app.create_app()
+    with TestClient(app) as client:
+        response = client.get("/simulate/123e4567-e89b-12d3-a456-426614174000")
+
+    assert response.status_code == 404
+    request_counter.add.assert_called_once_with(
+        1,
+        attributes={
+            "app": "kr-seoul-apartment",
+            "method": "GET",
+            "path": "/simulate/:id",
+            "status_code": "404",
+        },
+    )
+
+    duration_histogram.record.assert_called_once()
+    _, duration_kwargs = duration_histogram.record.call_args
+    assert duration_kwargs["attributes"] == {
+        "app": "kr-seoul-apartment",
+        "method": "GET",
+        "path": "/simulate/:id",
+    }

--- a/apps/kr-seoul-apartment/tests/unit/test_web_pages.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_web_pages.py
@@ -90,3 +90,14 @@ def test_get_ui_partials_runs_returns_html_fragment(tmp_path: Path, monkeypatch:
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("text/html")
     assert "<tr>" in response.text
+
+
+def test_post_ui_simulate_rejects_invalid_model_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    with _create_client(tmp_path, monkeypatch) as client:
+        response = client.post(
+            "/ui/simulate",
+            data={"query": "강남구", "max_rounds": "3", "model_id": "not-allowed"},
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"].startswith("model_id 'not-allowed' is not allowed")

--- a/apps/kr-seoul-apartment/tests/unit/test_web_simulate.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_web_simulate.py
@@ -39,6 +39,90 @@ def test_post_simulate_returns_202_with_run_id(tmp_path: Path, monkeypatch: pyte
         assert payload["status"] == "pending"
 
 
+def test_post_simulate_accepts_valid_model_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_background(*args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+
+    monkeypatch.setattr(simulate_routes, "run_simulation_background", fake_background)
+
+    with _create_client(tmp_path, monkeypatch) as client:
+        response = client.post(
+            "/simulate",
+            json={"query": "강남구", "max_rounds": 3, "model_id": "gpt-4o-mini"},
+        )
+
+        assert response.status_code == 202
+
+
+def test_post_simulate_rejects_invalid_model_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_background(*args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+
+    monkeypatch.setattr(simulate_routes, "run_simulation_background", fake_background)
+
+    with _create_client(tmp_path, monkeypatch) as client:
+        response = client.post(
+            "/simulate",
+            json={"query": "강남구", "max_rounds": 3, "model_id": "unknown-model"},
+        )
+
+        assert response.status_code == 422
+        assert "model_id 'unknown-model' is not allowed" in response.text
+
+
+def test_post_simulate_rejects_max_rounds_over_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_background(*args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+
+    monkeypatch.setattr(simulate_routes, "run_simulation_background", fake_background)
+
+    with _create_client(tmp_path, monkeypatch) as client:
+        response = client.post(
+            "/simulate",
+            json={"query": "강남구", "max_rounds": 11, "model_id": "stub"},
+        )
+
+        assert response.status_code == 422
+        assert "max_rounds must be between 1 and 10" in response.text
+
+
+def test_post_simulate_rejects_max_rounds_below_one(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_background(*args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+
+    monkeypatch.setattr(simulate_routes, "run_simulation_background", fake_background)
+
+    with _create_client(tmp_path, monkeypatch) as client:
+        response = client.post(
+            "/simulate",
+            json={"query": "강남구", "max_rounds": 0, "model_id": "stub"},
+        )
+
+        assert response.status_code == 422
+        assert "max_rounds must be between 1 and 10" in response.text
+
+
+def test_post_simulate_respects_allowed_models_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_background(*args: object, **kwargs: object) -> None:
+        _ = (args, kwargs)
+
+    monkeypatch.setattr(simulate_routes, "run_simulation_background", fake_background)
+    monkeypatch.setenv("YOUNGGEUL_ALLOWED_MODELS", "custom-model")
+
+    with _create_client(tmp_path, monkeypatch) as client:
+        accepted_response = client.post(
+            "/simulate",
+            json={"query": "강남구", "max_rounds": 3, "model_id": "custom-model"},
+        )
+        rejected_response = client.post(
+            "/simulate",
+            json={"query": "강남구", "max_rounds": 3, "model_id": "stub"},
+        )
+
+        assert accepted_response.status_code == 202
+        assert rejected_response.status_code == 422
+
+
 def test_get_simulate_by_run_id_returns_status(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_background(*args: object, **kwargs: object) -> None:
         _ = (args, kwargs)
@@ -107,3 +191,32 @@ def test_full_background_simulation_lifecycle(tmp_path: Path, monkeypatch: pytes
             time.sleep(0.01)
 
         assert final_payload["status"] == "completed"
+
+
+def test_post_simulate_marks_failed_when_executor_submit_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class FailingExecutor:
+        def __init__(self, max_workers: int) -> None:
+            _ = max_workers
+
+        def submit(self, *args: object, **kwargs: object) -> None:
+            _ = (args, kwargs)
+            raise RuntimeError("executor unavailable")
+
+        def shutdown(self, wait: bool = True) -> None:
+            _ = wait
+
+    monkeypatch.setattr(web_app, "ThreadPoolExecutor", FailingExecutor)
+
+    with _create_client(tmp_path, monkeypatch) as client:
+        response = client.post("/simulate", json={"query": "강남구"})
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "executor unavailable"}
+
+    store = RunStore(base_dir=tmp_path / "runs")
+    runs = store.list_runs()
+    assert len(runs) == 1
+    assert runs[0].status == "failed"
+    assert runs[0].error == "executor unavailable"


### PR DESCRIPTION
## Summary
- guard RunStore status transitions and add stale-run reconciliation on startup so interrupted pending/running jobs are recovered as failed states
- harden simulation launch flow by handling executor submission failures in API/UI routes and logging background exceptions with tracebacks
- extend web/run lifecycle tests (including submit-failure path) and update compatibility assertions so pytest, ruff format/check, and lint all pass

Closes #178