### PR TITLE
feat: add OTEL resource metadata and shutdown lifecycle

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py
@@ -24,7 +24,9 @@ from .simulation.event_store import InMemoryEventStore
 from .simulation.evidence.store import InMemoryEvidenceStore
 from .simulation.graph import build_simulation_graph
 from .simulation.graph_state import seed_graph_state
+from .simulation.metrics import init_metrics, shutdown_metrics
 from .simulation.schemas.report import RenderedReport
+from .simulation.tracing import init_tracing, shutdown_tracing
 from .snapshot import publish_snapshot, resolve_snapshot
 
 
@@ -35,6 +37,17 @@ def _output(ctx: click.Context, data: dict[str, Any], text_lines: list[str]) -> 
 
     for line in text_lines:
         click.echo(line)
+
+
+def _shutdown_observability() -> None:
+    try:
+        shutdown_tracing()
+    except Exception:
+        pass
+    try:
+        shutdown_metrics()
+    except Exception:
+        pass
 
 
 def _emit_version(ctx: click.Context, _: click.Option, value: bool) -> None:
@@ -197,6 +210,9 @@ def main(ctx: click.Context, output: str) -> None:
     """Run the top-level Younggeul CLI group."""
     ctx.ensure_object(dict)
     ctx.obj["output"] = output
+    init_tracing()
+    init_metrics()
+    ctx.call_on_close(_shutdown_observability)
 
 
 @main.command("ingest")

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/metrics.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/metrics.py
@@ -15,6 +15,7 @@ except ImportError:
 _METER_NAME = "younggeul.simulation"
 DEFAULT_APP_LABEL = "kr-seoul-apartment"
 _initialized = False
+_provider: Any | None = None
 
 
 class CounterLike(Protocol):
@@ -61,6 +62,8 @@ _llm_request_duration_seconds: HistogramLike | None = None
 _llm_tokens_total: CounterLike | None = None
 _llm_cost_usd_total: CounterLike | None = None
 _citation_gate_failures_total: CounterLike | None = None
+_web_requests_total: CounterLike | None = None
+_web_request_duration_seconds: HistogramLike | None = None
 
 
 def _is_enabled() -> bool:
@@ -68,7 +71,7 @@ def _is_enabled() -> bool:
 
 
 def init_metrics() -> None:
-    global _initialized
+    global _initialized, _provider
 
     if _initialized or not _is_enabled() or otel_metrics is None:
         return
@@ -80,6 +83,7 @@ def init_metrics() -> None:
             MetricExporter,
             PeriodicExportingMetricReader,
         )
+        from opentelemetry.sdk.resources import Resource
     except ImportError:
         return
 
@@ -97,9 +101,23 @@ def init_metrics() -> None:
         exporter = ConsoleMetricExporter()
 
     reader = PeriodicExportingMetricReader(exporter)
-    provider = MeterProvider(metric_readers=[reader])
+    resource = Resource(attributes={"service.name": "younggeul", "service.version": "0.2.1"})
+    provider = MeterProvider(resource=resource, metric_readers=[reader])
     otel_metrics.set_meter_provider(provider)
+    _provider = provider
     _initialized = True
+
+
+def shutdown_metrics() -> None:
+    global _initialized, _provider
+
+    provider = _provider
+    if provider is None:
+        return
+
+    _provider = None
+    _initialized = False
+    provider.shutdown()
 
 
 def get_meter() -> MeterLike:
@@ -239,3 +257,36 @@ def citation_gate_failures_total() -> CounterLike:
     if counter is None:
         return _NoOpCounter()
     return counter
+
+
+
+def web_requests_total() -> CounterLike:
+    global _web_requests_total
+
+    if _web_requests_total is None:
+        _web_requests_total = get_meter().create_counter(
+            "web_requests_total",
+            description="Total number of web requests",
+            unit="{request}",
+        )
+
+    counter = _web_requests_total
+    if counter is None:
+        return _NoOpCounter()
+    return counter
+
+
+def web_request_duration_seconds() -> HistogramLike:
+    global _web_request_duration_seconds
+
+    if _web_request_duration_seconds is None:
+        _web_request_duration_seconds = get_meter().create_histogram(
+            "web_request_duration_seconds",
+            description="Duration of web requests",
+            unit="s",
+        )
+
+    histogram = _web_request_duration_seconds
+    if histogram is None:
+        return _NoOpHistogram()
+    return histogram

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/tracing.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/tracing.py
@@ -12,6 +12,7 @@ from opentelemetry.trace import Span, Status, StatusCode, Tracer
 
 _TRACER_NAME = "younggeul.simulation"
 _initialized = False
+_provider: Any | None = None
 
 
 def _is_enabled() -> bool:
@@ -21,15 +22,17 @@ def _is_enabled() -> bool:
 def init_tracing() -> None:
     """Initialize OpenTelemetry tracing when OTEL is enabled."""
 
-    global _initialized
+    global _initialized, _provider
 
     if _initialized or not _is_enabled():
         return
 
+    from opentelemetry.sdk.resources import Resource
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter, SpanExporter
 
-    provider = TracerProvider()
+    resource = Resource(attributes={"service.name": "younggeul", "service.version": "0.2.1"})
+    provider = TracerProvider(resource=resource)
     exporter: SpanExporter
 
     otlp_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
@@ -43,7 +46,24 @@ def init_tracing() -> None:
 
     provider.add_span_processor(BatchSpanProcessor(exporter))
     trace.set_tracer_provider(provider)
+    _provider = provider
     _initialized = True
+
+
+def shutdown_tracing() -> None:
+    global _initialized, _provider
+
+    provider = _provider
+    if provider is None:
+        return
+
+    _provider = None
+    _initialized = False
+
+    try:
+        provider.force_flush()
+    finally:
+        provider.shutdown()
 
 
 def get_tracer() -> Tracer:

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/app.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/app.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.templating import Jinja2Templates
 
+from ..simulation.metrics import init_metrics, shutdown_metrics
+from ..simulation.tracing import init_tracing, shutdown_tracing
+
 from .run_store import RunStore
 from .routes.baseline import router as baseline_router
 from .routes.health import router as health_router
@@ -18,6 +21,8 @@ from .routes.snapshot import router as snapshot_router
 
 @asynccontextmanager
 async def app_lifespan(app: FastAPI) -> AsyncIterator[None]:
+    init_tracing()
+    init_metrics()
     executor = ThreadPoolExecutor(max_workers=2)
     app.state.executor = executor
     app.state.run_store = RunStore(base_dir=Path("./output/runs"))
@@ -25,6 +30,14 @@ async def app_lifespan(app: FastAPI) -> AsyncIterator[None]:
     try:
         yield
     finally:
+        try:
+            shutdown_tracing()
+        except Exception:
+            pass
+        try:
+            shutdown_metrics()
+        except Exception:
+            pass
         executor.shutdown(wait=True)
 
 

--- a/apps/kr-seoul-apartment/tests/unit/test_metrics.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_metrics.py
@@ -30,6 +30,7 @@ ReportClaim = simulation_state_module.ReportClaim
 
 def _reset_metric_singletons() -> None:
     setattr(metrics_module, "_initialized", False)
+    setattr(metrics_module, "_provider", None)
     setattr(metrics_module, "_simulation_runs_total", None)
     setattr(metrics_module, "_simulation_duration_seconds", None)
     setattr(metrics_module, "_simulation_node_duration_seconds", None)
@@ -38,6 +39,8 @@ def _reset_metric_singletons() -> None:
     setattr(metrics_module, "_llm_tokens_total", None)
     setattr(metrics_module, "_llm_cost_usd_total", None)
     setattr(metrics_module, "_citation_gate_failures_total", None)
+    setattr(metrics_module, "_web_requests_total", None)
+    setattr(metrics_module, "_web_request_duration_seconds", None)
 
 
 def _choice(content: str, *, finish_reason: str = "stop") -> SimpleNamespace:
@@ -55,11 +58,13 @@ def test_init_metrics_and_get_meter_work() -> None:
         patch("opentelemetry.sdk.metrics.MeterProvider") as meter_provider_cls,
         patch("opentelemetry.sdk.metrics.export.PeriodicExportingMetricReader") as metric_reader_cls,
         patch("opentelemetry.sdk.metrics.export.ConsoleMetricExporter") as exporter_cls,
+        patch("opentelemetry.sdk.resources.Resource") as resource_cls,
         patch("opentelemetry.metrics.set_meter_provider") as set_meter_provider,
     ):
         provider = meter_provider_cls.return_value
         reader = metric_reader_cls.return_value
         exporter = exporter_cls.return_value
+        resource = resource_cls.return_value
 
         metrics_module.init_metrics()
         metrics_module.init_metrics()
@@ -67,7 +72,7 @@ def test_init_metrics_and_get_meter_work() -> None:
 
     exporter_cls.assert_called_once()
     metric_reader_cls.assert_called_once_with(exporter)
-    meter_provider_cls.assert_called_once_with(metric_readers=[reader])
+    meter_provider_cls.assert_called_once_with(resource=resource, metric_readers=[reader])
     set_meter_provider.assert_called_once_with(provider)
     assert getattr(metrics_module, "_initialized") is True
     assert meter is not None
@@ -356,3 +361,59 @@ def test_citation_gate_does_not_emit_failure_counter_when_no_failures() -> None:
         citation_gate_module.make_citation_gate_node(evidence_store, event_store)(state)
 
     failure_counter.add.assert_not_called()
+
+
+
+def test_shutdown_tracing_is_safe_when_not_initialized() -> None:
+    setattr(tracing_module, "_initialized", False)
+    setattr(tracing_module, "_provider", None)
+
+    tracing_module.shutdown_tracing()
+
+
+def test_shutdown_metrics_is_safe_when_not_initialized() -> None:
+    _reset_metric_singletons()
+
+    metrics_module.shutdown_metrics()
+
+
+def test_shutdown_tracing_flushes_and_shuts_down_provider() -> None:
+    setattr(tracing_module, "_initialized", False)
+    setattr(tracing_module, "_provider", None)
+
+    with (
+        patch.dict("os.environ", {"OTEL_ENABLED": "true"}, clear=False),
+        patch("opentelemetry.sdk.trace.TracerProvider") as tracer_provider_cls,
+        patch("opentelemetry.sdk.trace.export.BatchSpanProcessor"),
+        patch("opentelemetry.sdk.trace.export.ConsoleSpanExporter"),
+        patch("opentelemetry.sdk.resources.Resource"),
+        patch("opentelemetry.trace.set_tracer_provider"),
+    ):
+        provider = tracer_provider_cls.return_value
+        tracing_module.init_tracing()
+        tracing_module.shutdown_tracing()
+
+    provider.force_flush.assert_called_once_with()
+    provider.shutdown.assert_called_once_with()
+    assert getattr(tracing_module, "_provider") is None
+    assert getattr(tracing_module, "_initialized") is False
+
+
+def test_shutdown_metrics_shuts_down_provider() -> None:
+    _reset_metric_singletons()
+
+    with (
+        patch.dict("os.environ", {"OTEL_ENABLED": "true"}, clear=False),
+        patch("opentelemetry.sdk.metrics.MeterProvider") as meter_provider_cls,
+        patch("opentelemetry.sdk.metrics.export.PeriodicExportingMetricReader"),
+        patch("opentelemetry.sdk.metrics.export.ConsoleMetricExporter"),
+        patch("opentelemetry.sdk.resources.Resource"),
+        patch("opentelemetry.metrics.set_meter_provider"),
+    ):
+        provider = meter_provider_cls.return_value
+        metrics_module.init_metrics()
+        metrics_module.shutdown_metrics()
+
+    provider.shutdown.assert_called_once_with()
+    assert getattr(metrics_module, "_provider") is None
+    assert getattr(metrics_module, "_initialized") is False

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,8 +10,15 @@ services:
       - "127.0.0.1:4318:4318"
     expose:
       - "8889"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:13133/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     depends_on:
-      - jaeger
+      jaeger:
+        condition: service_healthy
 
   jaeger:
     profiles: [obs]
@@ -26,6 +33,12 @@ services:
       default:
         aliases:
           - jaeger-otlp
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:16687/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
   prometheus:
     profiles: [obs]
@@ -34,8 +47,15 @@ services:
       - ./infra/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:
       - "127.0.0.1:9090:9090"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/healthy"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     depends_on:
-      - otel-collector
+      otel-collector:
+        condition: service_healthy
 
   # NOTE: Grafana is configured for LOCAL DEVELOPMENT only.
   # For shared/remote deployments, disable anonymous access and set a strong admin password.
@@ -50,8 +70,15 @@ services:
       - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro
     ports:
       - "127.0.0.1:3000:3000"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
     depends_on:
-      - prometheus
+      prometheus:
+        condition: service_healthy
 
   web:
     profiles: [web]
@@ -64,6 +91,12 @@ services:
       - ./output:/app/output
     environment:
       OTEL_ENABLED: "false"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
 
   web-obs:
     profiles: [web-obs]
@@ -78,5 +111,12 @@ services:
       OTEL_ENABLED: "true"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       OTEL_EXPORTER_OTLP_INSECURE: "true"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
     depends_on:
-      - otel-collector
+      otel-collector:
+        condition: service_healthy

--- a/infra/otel-collector-config.yaml
+++ b/infra/otel-collector-config.yaml
@@ -20,7 +20,12 @@ exporters:
     endpoint: 0.0.0.0:8889
     namespace: younggeul
 
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
 service:
+  extensions: [health_check]
   pipelines:
     traces:
       receivers: [otlp]


### PR DESCRIPTION
## Summary
- Add OpenTelemetry resource metadata (`service.name=younggeul`, `service.version=0.2.1`) to tracing and metrics providers, and keep provider instances for lifecycle control.
- Add idempotent `shutdown_tracing()` and `shutdown_metrics()` functions and wire them into FastAPI lifespan and CLI close hooks so providers flush/shutdown on exit.
- Extend unit tests to reset new singleton provider state and verify shutdown safety and provider flush/shutdown behavior.

## Validation
- `python3 -m pytest apps/kr-seoul-apartment/tests/ -x -q`
- `python3 -m ruff format .`
- `python3 -m ruff check . --fix`

Closes #179