### PR TITLE
feat: add OTEL resource metadata and provider shutdown lifecycle

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py
@@ -24,7 +24,9 @@ from .simulation.event_store import InMemoryEventStore
 from .simulation.evidence.store import InMemoryEvidenceStore
 from .simulation.graph import build_simulation_graph
 from .simulation.graph_state import seed_graph_state
+from .simulation.metrics import init_metrics, shutdown_metrics
 from .simulation.schemas.report import RenderedReport
+from .simulation.tracing import init_tracing, shutdown_tracing
 from .snapshot import publish_snapshot, resolve_snapshot
 
 
@@ -35,6 +37,17 @@ def _output(ctx: click.Context, data: dict[str, Any], text_lines: list[str]) -> 
 
     for line in text_lines:
         click.echo(line)
+
+
+def _shutdown_observability() -> None:
+    try:
+        shutdown_tracing()
+    except Exception:
+        pass
+    try:
+        shutdown_metrics()
+    except Exception:
+        pass
 
 
 def _emit_version(ctx: click.Context, _: click.Option, value: bool) -> None:
@@ -197,6 +210,9 @@ def main(ctx: click.Context, output: str) -> None:
     """Run the top-level Younggeul CLI group."""
     ctx.ensure_object(dict)
     ctx.obj["output"] = output
+    init_tracing()
+    init_metrics()
+    ctx.call_on_close(_shutdown_observability)
 
 
 @main.command("ingest")

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/metrics.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/metrics.py
@@ -15,6 +15,7 @@ except ImportError:
 _METER_NAME = "younggeul.simulation"
 DEFAULT_APP_LABEL = "kr-seoul-apartment"
 _initialized = False
+_provider: Any = None
 
 
 class CounterLike(Protocol):
@@ -68,7 +69,7 @@ def _is_enabled() -> bool:
 
 
 def init_metrics() -> None:
-    global _initialized
+    global _initialized, _provider
 
     if _initialized or not _is_enabled() or otel_metrics is None:
         return
@@ -80,6 +81,7 @@ def init_metrics() -> None:
             MetricExporter,
             PeriodicExportingMetricReader,
         )
+        from opentelemetry.sdk.resources import Resource
     except ImportError:
         return
 
@@ -97,9 +99,25 @@ def init_metrics() -> None:
         exporter = ConsoleMetricExporter()
 
     reader = PeriodicExportingMetricReader(exporter)
-    provider = MeterProvider(metric_readers=[reader])
+    resource = Resource(attributes={"service.name": "younggeul", "service.version": "0.2.1"})
+    provider = MeterProvider(metric_readers=[reader], resource=resource)
     otel_metrics.set_meter_provider(provider)
+    _provider = provider
     _initialized = True
+
+
+def shutdown_metrics() -> None:
+    global _initialized, _provider
+
+    if _provider is None:
+        return
+
+    try:
+        _provider.shutdown()
+    except Exception:
+        pass
+    _provider = None
+    _initialized = False
 
 
 def get_meter() -> MeterLike:

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/tracing.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/tracing.py
@@ -12,6 +12,7 @@ from opentelemetry.trace import Span, Status, StatusCode, Tracer
 
 _TRACER_NAME = "younggeul.simulation"
 _initialized = False
+_provider: Any = None
 
 
 def _is_enabled() -> bool:
@@ -21,15 +22,17 @@ def _is_enabled() -> bool:
 def init_tracing() -> None:
     """Initialize OpenTelemetry tracing when OTEL is enabled."""
 
-    global _initialized
+    global _initialized, _provider
 
     if _initialized or not _is_enabled():
         return
 
+    from opentelemetry.sdk.resources import Resource
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter, SpanExporter
 
-    provider = TracerProvider()
+    resource = Resource(attributes={"service.name": "younggeul", "service.version": "0.2.1"})
+    provider = TracerProvider(resource=resource)
     exporter: SpanExporter
 
     otlp_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
@@ -43,7 +46,23 @@ def init_tracing() -> None:
 
     provider.add_span_processor(BatchSpanProcessor(exporter))
     trace.set_tracer_provider(provider)
+    _provider = provider
     _initialized = True
+
+
+def shutdown_tracing() -> None:
+    global _initialized, _provider
+
+    if _provider is None:
+        return
+
+    try:
+        _provider.force_flush()
+        _provider.shutdown()
+    except Exception:
+        pass
+    _provider = None
+    _initialized = False
 
 
 def get_tracer() -> Tracer:

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/app.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/app.py
@@ -9,8 +9,8 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.templating import Jinja2Templates
 
-from ..simulation.metrics import init_metrics
-from ..simulation.tracing import init_tracing
+from ..simulation.metrics import init_metrics, shutdown_metrics
+from ..simulation.tracing import init_tracing, shutdown_tracing
 from .middleware import MetricsMiddleware
 from .run_store import RunStore
 from .routes.baseline import router as baseline_router
@@ -38,6 +38,14 @@ async def app_lifespan(app: FastAPI) -> AsyncIterator[None]:
     try:
         yield
     finally:
+        try:
+            shutdown_tracing()
+        except Exception:
+            pass
+        try:
+            shutdown_metrics()
+        except Exception:
+            pass
         executor.shutdown(wait=True)
 
 

--- a/apps/kr-seoul-apartment/tests/unit/test_metrics.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_metrics.py
@@ -72,12 +72,8 @@ def test_init_metrics_and_get_meter_work() -> None:
 
     exporter_cls.assert_called_once()
     metric_reader_cls.assert_called_once_with(exporter)
-    meter_provider_cls.assert_called_once()
-    _, meter_provider_kwargs = meter_provider_cls.call_args
-    assert meter_provider_kwargs["metric_readers"] == [reader]
-    if resource_cls.call_count > 0:
-        resource_cls.assert_called_once_with(attributes={"service.name": "younggeul", "service.version": "0.2.1"})
-        assert meter_provider_kwargs.get("resource") is resource
+    resource_cls.assert_called_once_with(attributes={"service.name": "younggeul", "service.version": "0.2.1"})
+    meter_provider_cls.assert_called_once_with(metric_readers=[reader], resource=resource)
     set_meter_provider.assert_called_once_with(provider)
     assert getattr(metrics_module, "_initialized") is True
     assert meter is not None
@@ -369,9 +365,6 @@ def test_citation_gate_does_not_emit_failure_counter_when_no_failures() -> None:
 
 
 def test_shutdown_tracing_is_safe_when_not_initialized() -> None:
-    if not hasattr(tracing_module, "shutdown_tracing"):
-        return
-
     setattr(tracing_module, "_initialized", False)
     setattr(tracing_module, "_provider", None)
 
@@ -379,18 +372,12 @@ def test_shutdown_tracing_is_safe_when_not_initialized() -> None:
 
 
 def test_shutdown_metrics_is_safe_when_not_initialized() -> None:
-    if not hasattr(metrics_module, "shutdown_metrics"):
-        return
-
     _reset_metric_singletons()
 
     metrics_module.shutdown_metrics()
 
 
 def test_shutdown_tracing_flushes_and_shuts_down_provider() -> None:
-    if not hasattr(tracing_module, "shutdown_tracing"):
-        return
-
     setattr(tracing_module, "_initialized", False)
     setattr(tracing_module, "_provider", None)
 
@@ -413,9 +400,6 @@ def test_shutdown_tracing_flushes_and_shuts_down_provider() -> None:
 
 
 def test_shutdown_metrics_shuts_down_provider() -> None:
-    if not hasattr(metrics_module, "shutdown_metrics"):
-        return
-
     _reset_metric_singletons()
 
     with (
@@ -433,3 +417,40 @@ def test_shutdown_metrics_shuts_down_provider() -> None:
     provider.shutdown.assert_called_once_with()
     assert getattr(metrics_module, "_provider") is None
     assert getattr(metrics_module, "_initialized") is False
+
+
+def test_init_metrics_uses_resource() -> None:
+    _reset_metric_singletons()
+
+    with (
+        patch.dict("os.environ", {"OTEL_ENABLED": "true"}, clear=False),
+        patch("opentelemetry.sdk.metrics.MeterProvider") as meter_provider_cls,
+        patch("opentelemetry.sdk.metrics.export.PeriodicExportingMetricReader"),
+        patch("opentelemetry.sdk.metrics.export.ConsoleMetricExporter"),
+        patch("opentelemetry.sdk.resources.Resource") as resource_cls,
+        patch("opentelemetry.metrics.set_meter_provider"),
+    ):
+        resource = resource_cls.return_value
+        metrics_module.init_metrics()
+
+    _, kwargs = meter_provider_cls.call_args
+    assert kwargs["resource"] is resource
+
+
+def test_init_tracing_uses_resource() -> None:
+    setattr(tracing_module, "_initialized", False)
+    setattr(tracing_module, "_provider", None)
+
+    with (
+        patch.dict("os.environ", {"OTEL_ENABLED": "true"}, clear=False),
+        patch("opentelemetry.sdk.trace.TracerProvider") as tracer_provider_cls,
+        patch("opentelemetry.sdk.trace.export.BatchSpanProcessor"),
+        patch("opentelemetry.sdk.trace.export.ConsoleSpanExporter"),
+        patch("opentelemetry.sdk.resources.Resource") as resource_cls,
+        patch("opentelemetry.trace.set_tracer_provider"),
+    ):
+        resource = resource_cls.return_value
+        tracing_module.init_tracing()
+
+    _, kwargs = tracer_provider_cls.call_args
+    assert kwargs["resource"] is resource


### PR DESCRIPTION
## Summary

- Add `service.name` and `service.version` Resource attributes to both `MeterProvider` and `TracerProvider` for proper OTEL service identification
- Add `shutdown_metrics()` and `shutdown_tracing()` functions with graceful error handling for clean provider teardown
- Integrate shutdown calls into web app lifespan (finally block) and CLI `call_on_close`
- Store `_provider` reference in both modules for clean shutdown with `force_flush()` (tracing) + `shutdown()`

## Changes

| File | Change |
|------|--------|
| `simulation/metrics.py` | Add `_provider` global, `Resource` in `init_metrics()`, `shutdown_metrics()` |
| `simulation/tracing.py` | Add `_provider` global, `Resource` in `init_tracing()`, `shutdown_tracing()` |
| `web/app.py` | Import and call `shutdown_tracing()`/`shutdown_metrics()` in lifespan finally |
| `cli.py` | Import shutdown functions, add `_shutdown_observability()` helper, register via `call_on_close` |
| `tests/unit/test_metrics.py` | Remove `hasattr` guards, add resource usage tests, tighten shutdown assertions |

## Testing

- 1196 tests passed, 6 skipped
- All 15 metrics-specific tests pass

Closes #179