### PR TITLE
feat: add job-system observability metrics

### DIFF
--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/metrics.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/metrics.py
@@ -22,11 +22,20 @@ class CounterLike(Protocol):
     def add(self, amount: int | float, attributes: dict[str, str] | None = None) -> None: ...
 
 
+class UpDownCounterLike(Protocol):
+    def add(self, amount: int | float, attributes: dict[str, str] | None = None) -> None: ...
+
+
 class HistogramLike(Protocol):
     def record(self, amount: int | float, attributes: dict[str, str] | None = None) -> None: ...
 
 
 class _NoOpCounter:
+    def add(self, amount: int | float, attributes: dict[str, str] | None = None) -> None:
+        del amount, attributes
+
+
+class _NoOpUpDownCounter:
     def add(self, amount: int | float, attributes: dict[str, str] | None = None) -> None:
         del amount, attributes
 
@@ -41,6 +50,10 @@ class _NoOpMeter:
         del name, kwargs
         return _NoOpCounter()
 
+    def create_up_down_counter(self, name: str, **kwargs: Any) -> UpDownCounterLike:
+        del name, kwargs
+        return _NoOpUpDownCounter()
+
     def create_histogram(self, name: str, **kwargs: Any) -> HistogramLike:
         del name, kwargs
         return _NoOpHistogram()
@@ -48,6 +61,8 @@ class _NoOpMeter:
 
 class MeterLike(Protocol):
     def create_counter(self, name: str, **kwargs: Any) -> CounterLike: ...
+
+    def create_up_down_counter(self, name: str, **kwargs: Any) -> UpDownCounterLike: ...
 
     def create_histogram(self, name: str, **kwargs: Any) -> HistogramLike: ...
 
@@ -62,6 +77,7 @@ _llm_request_duration_seconds: HistogramLike | None = None
 _llm_tokens_total: CounterLike | None = None
 _llm_cost_usd_total: CounterLike | None = None
 _citation_gate_failures_total: CounterLike | None = None
+_simulation_active_runs: UpDownCounterLike | None = None
 
 
 def _is_enabled() -> bool:
@@ -257,3 +273,19 @@ def citation_gate_failures_total() -> CounterLike:
     if counter is None:
         return _NoOpCounter()
     return counter
+
+
+def simulation_active_runs() -> UpDownCounterLike:
+    global _simulation_active_runs
+
+    if _simulation_active_runs is None:
+        _simulation_active_runs = get_meter().create_up_down_counter(
+            "simulation_active_runs",
+            description="Number of currently running simulations",
+            unit="{run}",
+        )
+
+    udc = _simulation_active_runs
+    if udc is None:
+        return _NoOpUpDownCounter()
+    return udc

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/services.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/services.py
@@ -14,6 +14,7 @@ from younggeul_app_kr_seoul_apartment.simulation.evidence.store import InMemoryE
 from younggeul_app_kr_seoul_apartment.simulation.events import EventStore
 from younggeul_app_kr_seoul_apartment.simulation.graph import build_simulation_graph
 from younggeul_app_kr_seoul_apartment.simulation.graph_state import SimulationGraphState, seed_graph_state
+from younggeul_app_kr_seoul_apartment.simulation.metrics import metric_attrs, simulation_active_runs
 from younggeul_app_kr_seoul_apartment.simulation.schemas.report import RenderedReport
 from younggeul_app_kr_seoul_apartment.snapshot import publish_snapshot, resolve_snapshot
 from younggeul_core.state.gold import BaselineForecast, GoldDistrictMonthlyMetrics
@@ -53,7 +54,8 @@ def seed_graph_state_service(user_query: str, run_id: str, run_name: str, model_
 
 
 def run_simulation_background(run_store: RunStore, run_id: str, query: str, max_rounds: int, model_id: str) -> None:
-    """Execute simulation in background thread, updating RunStore on completion/failure."""
+    attrs = metric_attrs()
+    simulation_active_runs().add(1, attributes=attrs)
     try:
         run_store.update_status(run_id, "running")
         event_store = InMemoryEventStore()
@@ -68,6 +70,8 @@ def run_simulation_background(run_store: RunStore, run_id: str, query: str, max_
     except Exception as exc:
         logger.exception("Simulation %s failed", run_id)
         run_store.update_status(run_id, "failed", error=str(exc))
+    finally:
+        simulation_active_runs().add(-1, attributes=attrs)
 
 
 def _extract_report_text(final_state: dict[str, Any], event_store: InMemoryEventStore, run_id: str) -> str:

--- a/apps/kr-seoul-apartment/tests/unit/test_metrics.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_metrics.py
@@ -39,6 +39,7 @@ def _reset_metric_singletons() -> None:
     setattr(metrics_module, "_llm_tokens_total", None)
     setattr(metrics_module, "_llm_cost_usd_total", None)
     setattr(metrics_module, "_citation_gate_failures_total", None)
+    setattr(metrics_module, "_simulation_active_runs", None)
     setattr(metrics_module, "_web_requests_total", None)
     setattr(metrics_module, "_web_request_duration_seconds", None)
 
@@ -454,3 +455,28 @@ def test_init_tracing_uses_resource() -> None:
 
     _, kwargs = tracer_provider_cls.call_args
     assert kwargs["resource"] is resource
+
+
+def test_simulation_active_runs_returns_noop_when_otel_missing() -> None:
+    _reset_metric_singletons()
+    with patch.object(metrics_module, "otel_metrics", None):
+        udc = metrics_module.simulation_active_runs()
+        udc.add(1, attributes=metrics_module.metric_attrs())
+        udc.add(-1, attributes=metrics_module.metric_attrs())
+
+
+def test_simulation_active_runs_creates_up_down_counter() -> None:
+    _reset_metric_singletons()
+    meter = MagicMock()
+    udc_mock = MagicMock()
+    meter.create_up_down_counter.return_value = udc_mock
+
+    with patch.object(metrics_module, "get_meter", return_value=meter):
+        result = metrics_module.simulation_active_runs()
+
+    meter.create_up_down_counter.assert_called_once_with(
+        "simulation_active_runs",
+        description="Number of currently running simulations",
+        unit="{run}",
+    )
+    assert result is udc_mock

--- a/apps/kr-seoul-apartment/tests/unit/test_web_services.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_web_services.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -134,3 +135,58 @@ def test_run_simulation_background_marks_failed_on_exception(monkeypatch: pytest
     assert run_meta.status == "failed"
     assert run_meta.error is not None
     assert "boom" in run_meta.error
+
+
+def test_run_simulation_background_tracks_active_runs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    store = RunStore(base_dir=tmp_path)
+    run_id = store.create_run("q")
+
+    udc = MagicMock()
+    calls: list[int] = []
+    udc.add.side_effect = lambda amount, **_kw: calls.append(amount)
+
+    class FakeGraph:
+        def invoke(self, initial_state: dict[str, object]) -> dict[str, object]:
+            assert len(calls) == 1 and calls[0] == 1
+            return {
+                "rendered_report": {
+                    "run_id": run_id,
+                    "round_no": 1,
+                    "rendered_at": datetime.now(timezone.utc).isoformat(),
+                    "total_claims": 0,
+                    "passed_claims": 0,
+                    "failed_claims": 0,
+                    "sections": [],
+                    "markdown": "# OK",
+                }
+            }
+
+    monkeypatch.setattr(services, "build_simulation_graph", lambda *_args, **_kwargs: FakeGraph())
+
+    with patch.object(services, "simulation_active_runs", return_value=udc):
+        services.run_simulation_background(store, run_id, "q", 1, "stub")
+
+    assert calls == [1, -1]
+
+
+def test_run_simulation_background_decrements_active_runs_on_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    store = RunStore(base_dir=tmp_path)
+    run_id = store.create_run("q")
+
+    udc = MagicMock()
+    calls: list[int] = []
+    udc.add.side_effect = lambda amount, **_kw: calls.append(amount)
+
+    class FakeGraph:
+        def invoke(self, initial_state: dict[str, object]) -> dict[str, object]:
+            _ = initial_state
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(services, "build_simulation_graph", lambda *_args, **_kwargs: FakeGraph())
+
+    with patch.object(services, "simulation_active_runs", return_value=udc):
+        services.run_simulation_background(store, run_id, "q", 1, "stub")
+
+    assert calls == [1, -1]

--- a/infra/grafana/provisioning/dashboards/simulation-overview.json
+++ b/infra/grafana/provisioning/dashboards/simulation-overview.json
@@ -497,6 +497,184 @@
       ],
       "title": "Citation Gate Failures",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 2
+              },
+              {
+                "color": "red",
+                "value": 4
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 24
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(younggeul_simulation_active_runs)",
+          "legendFormat": "active",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Runs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 6,
+        "y": 24
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(younggeul_web_requests_total[5m])) by (method, status_code)",
+          "legendFormat": "{{method}} {{status_code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Web Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 24
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(younggeul_web_request_duration_seconds_bucket[5m])) by (path, le))",
+          "legendFormat": "{{path}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Web Latency P95",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",


### PR DESCRIPTION
## Summary

Closes #181

- **UpDownCounter active-run tracking**: Added `UpDownCounterLike` protocol, `_NoOpUpDownCounter`, and `simulation_active_runs()` lazy singleton to the metrics module. The background simulation runner (`run_simulation_background`) now increments on entry and decrements in a `finally` block, providing a real-time gauge of concurrent simulations.
- **Grafana dashboard panels**: Added 3 new panels to `simulation-overview.json`:
  - **Active Runs** (stat): `sum(younggeul_simulation_active_runs)` with orange/red thresholds at 2/4
  - **Web Request Rate** (timeseries): `sum(rate(younggeul_web_requests_total[5m])) by (method, status_code)`
  - **Web Latency P95** (timeseries): `histogram_quantile(0.95, ...)` on `younggeul_web_request_duration_seconds_bucket`
- **Tests**: 4 new unit tests covering NoOp fallback, counter creation, success-path tracking, and failure-path decrement

## Changed Files

| File | Change |
|------|--------|
| `simulation/metrics.py` | `UpDownCounterLike`, `_NoOpUpDownCounter`, `simulation_active_runs()` |
| `web/services.py` | Active-run increment/decrement in `run_simulation_background` |
| `tests/unit/test_metrics.py` | 2 new tests for UpDownCounter |
| `tests/unit/test_web_services.py` | 2 new tests for active-run tracking |
| `infra/grafana/.../simulation-overview.json` | 3 new dashboard panels |

## Test Results

```
1200 passed, 6 skipped, 1 warning in 18.69s
```