### PR TITLE
feat: support multi-month live ingest for YoY/MoM

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,13 @@ export KPUBDATA_KOSIS_API_KEY=...    # 통계청 KOSIS
 younggeul ingest --source live --gu 11680 --month 202503 --output-dir ./output/live
 ```
 
-`--gu` is a 5-digit MOLIT sigungu code (e.g. `11680` = 강남구) and `--month` is `YYYYMM`. v0.1 covers one gu × one month per invocation. See [ADR-007](docs/adr/007-kpubdata-live-ingest.md) for the design and current scope (KOSTAT migration is not emitted in live mode for v0.1).
+`--gu` is a 5-digit MOLIT sigungu code (e.g. `11680` = 강남구) and `--month` is `YYYYMM`. To populate YoY/MoM change ratios in the Gold output, fetch multiple months in one invocation via `--months`:
+
+```bash
+younggeul ingest --source live --gu 11680 --months 202403,202503 --output-dir ./output/live-yoy
+```
+
+`--month` and `--months` are mutually exclusive. v0.1 covers one gu per invocation. See [ADR-007](docs/adr/007-kpubdata-live-ingest.md) for the design and current scope (KOSTAT migration is not emitted in live mode for v0.1).
 
 ## v0.1 Scope
 

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py
@@ -236,7 +236,13 @@ def main(ctx: click.Context, output: str) -> None:
     "--month",
     "deal_ym",
     default=None,
-    help="Target month in YYYYMM format (required when --source=live, e.g. 202503).",
+    help="Single target month in YYYYMM format (live mode, e.g. 202503). Mutually exclusive with --months.",
+)
+@click.option(
+    "--months",
+    "deal_yms_csv",
+    default=None,
+    help="Comma-separated list of YYYYMM months (live mode, e.g. 202403,202503). Enables YoY/MoM in Gold output. Mutually exclusive with --month.",
 )
 @click.pass_context
 def ingest_command(
@@ -245,22 +251,34 @@ def ingest_command(
     source: str,
     lawd_code: str | None,
     deal_ym: str | None,
+    deal_yms_csv: str | None,
 ) -> None:
     """Ingest Bronze data and write Gold JSONL output.
 
     Default ``--source=fixture`` uses bundled toy data and requires no API keys.
-    ``--source=live`` requires ``--gu`` and ``--month`` plus the
-    ``KPUBDATA_DATAGO_API_KEY`` and ``KPUBDATA_BOK_API_KEY`` environment variables.
+    ``--source=live`` requires ``--gu`` and exactly one of ``--month`` or
+    ``--months`` plus the ``KPUBDATA_DATAGO_API_KEY`` and
+    ``KPUBDATA_BOK_API_KEY`` environment variables.
     """
     try:
         if source == "live":
-            if not lawd_code or not deal_ym:
-                raise click.ClickException("--gu and --month are required when --source=live")
+            if not lawd_code:
+                raise click.ClickException("--gu is required when --source=live")
+            if deal_ym and deal_yms_csv:
+                raise click.ClickException("--month and --months are mutually exclusive")
+            if not deal_ym and not deal_yms_csv:
+                raise click.ClickException("exactly one of --month or --months is required when --source=live")
             from younggeul_app_kr_seoul_apartment.connectors.client_factory import build_client
-            from younggeul_app_kr_seoul_apartment.pipeline_live import run_live_ingest
+            from younggeul_app_kr_seoul_apartment.pipeline_live import run_live_ingest_months
+
+            if deal_yms_csv:
+                deal_yms = [ym.strip() for ym in deal_yms_csv.split(",") if ym.strip()]
+            else:
+                assert deal_ym is not None
+                deal_yms = [deal_ym]
 
             client = build_client()
-            bronze = run_live_ingest(client=client, lawd_code=lawd_code, deal_ym=deal_ym)
+            bronze = run_live_ingest_months(client=client, lawd_code=lawd_code, deal_yms=deal_yms)
         else:
             bronze = _fixture_bronze_input()
         result = run_pipeline(bronze)

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/pipeline_live.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/pipeline_live.py
@@ -1,4 +1,4 @@
-"""Live ingest pipeline: fetches one Seoul gu × one month from real APIs via kpubdata.
+"""Live ingest pipeline: fetches Seoul gu × month(s) from real APIs via kpubdata.
 
 v0.1 scope (option C — see docs/adr/007):
 - MOLIT apartment trades and BOK base rate are fetched live.
@@ -55,25 +55,56 @@ def run_live_ingest(
 ) -> BronzeInput:
     """Fetch MOLIT and BOK data for one gu × one month and return a BronzeInput.
 
-    KOSTAT migrations are omitted in live mode (see module docstring); the
-    returned ``BronzeInput.migrations`` list is always empty.
+    Thin wrapper over :func:`run_live_ingest_months` for the single-month case.
+    See that function for full semantics.
+    """
+    return run_live_ingest_months(
+        client=client,
+        lawd_code=lawd_code,
+        deal_yms=[deal_ym],
+        rate_limit_interval=rate_limit_interval,
+    )
+
+
+def run_live_ingest_months(
+    *,
+    client: Client,
+    lawd_code: str,
+    deal_yms: list[str],
+    rate_limit_interval: float = _DEFAULT_RATE_LIMIT_INTERVAL,
+) -> BronzeInput:
+    """Fetch MOLIT and BOK data for one gu × N months and return a BronzeInput.
+
+    MOLIT is queried once per month (the API does not accept a range); BOK is
+    queried with ``start_date=min(deal_yms)`` and ``end_date=max(deal_yms)``
+    so a single request covers the whole window. KOSTAT migrations are omitted
+    in live mode (see module docstring).
 
     Args:
         client: Authenticated kpubdata client (built via ``client_factory.build_client``).
         lawd_code: 5-digit MOLIT sigungu code (e.g. ``"11680"`` for Gangnam-gu).
-        deal_ym: Target month in ``YYYYMM`` format (e.g. ``"202503"``).
+        deal_yms: One or more target months in ``YYYYMM`` format. Order is
+            preserved in the output. Duplicates are rejected.
         rate_limit_interval: Minimum seconds between consecutive API calls per
             connector. Defaults to 1.0 to stay well within data.go.kr quotas.
 
     Returns:
-        ``BronzeInput`` populated with apt transactions and interest rates,
-        ready for ``run_pipeline``.
+        ``BronzeInput`` populated with apt transactions across all requested
+        months and interest rates spanning the full window, ready for
+        ``run_pipeline``. With multiple months, downstream Gold output will
+        include YoY/MoM change ratios where comparison anchors are available.
 
     Raises:
-        ValueError: If ``lawd_code`` or ``deal_ym`` are malformed.
+        ValueError: If ``lawd_code`` or any ``deal_ym`` is malformed, if
+            ``deal_yms`` is empty, or if it contains duplicates.
     """
     _validate_lawd_code(lawd_code)
-    _validate_deal_ym(deal_ym)
+    if not deal_yms:
+        raise ValueError("deal_yms must not be empty")
+    if len(set(deal_yms)) != len(deal_yms):
+        raise ValueError(f"deal_yms must not contain duplicates, got {deal_yms!r}")
+    for ym in deal_yms:
+        _validate_deal_ym(ym)
 
     limiter = RateLimiter(min_interval=rate_limit_interval)
 
@@ -83,24 +114,28 @@ def run_live_ingest(
     apt_connector = MolitAptConnector(client=apt_dataset, rate_limiter=limiter)
     bok_connector = BokInterestRateConnector(client=rate_dataset, rate_limiter=limiter)
 
-    apt_result = apt_connector.fetch(MolitAptRequest(sigungu_code=lawd_code, year_month=deal_ym))
+    apt_records = []
+    for ym in deal_yms:
+        apt_result = apt_connector.fetch(MolitAptRequest(sigungu_code=lawd_code, year_month=ym))
+        apt_records.extend(apt_result.records)
+
     rate_result = bok_connector.fetch(
         BokInterestRateRequest(
             stat_code=_BOK_BASE_RATE_STAT_CODE,
             item_code1=_BOK_BASE_RATE_ITEM_CODE,
             frequency=_BOK_BASE_RATE_FREQUENCY,
-            start_date=deal_ym,
-            end_date=deal_ym,
+            start_date=min(deal_yms),
+            end_date=max(deal_yms),
             rate_type=_BOK_BASE_RATE_TYPE,
             source_id=_BOK_BASE_RATE_SOURCE_ID,
         )
     )
 
     return BronzeInput(
-        apt_transactions=apt_result.records,
+        apt_transactions=apt_records,
         interest_rates=rate_result.records,
         migrations=[],
     )
 
 
-__all__ = ["run_live_ingest"]
+__all__ = ["run_live_ingest", "run_live_ingest_months"]

--- a/apps/kr-seoul-apartment/tests/integration/test_live_ingest.py
+++ b/apps/kr-seoul-apartment/tests/integration/test_live_ingest.py
@@ -18,10 +18,14 @@ from younggeul_app_kr_seoul_apartment.connectors.client_factory import (
     build_client,
 )
 from younggeul_app_kr_seoul_apartment.pipeline import run_pipeline
-from younggeul_app_kr_seoul_apartment.pipeline_live import run_live_ingest
+from younggeul_app_kr_seoul_apartment.pipeline_live import (
+    run_live_ingest,
+    run_live_ingest_months,
+)
 
 GANGNAM_LAWD_CODE = "11680"
 TARGET_DEAL_YM = "202503"
+PRIOR_DEAL_YM = "202403"
 
 
 def _env_keys_present() -> bool:
@@ -61,3 +65,26 @@ def test_live_ingest_gangnam_202503_produces_gold_output() -> None:
     assert gold.gu_code.startswith(GANGNAM_LAWD_CODE[:2])
     assert gold.period == f"{TARGET_DEAL_YM[:4]}-{TARGET_DEAL_YM[4:]}"
     assert gold.median_price > 0
+
+
+def test_live_ingest_months_yoy_change_is_populated() -> None:
+    client = build_client()
+
+    bronze = run_live_ingest_months(
+        client=client,
+        lawd_code=GANGNAM_LAWD_CODE,
+        deal_yms=[PRIOR_DEAL_YM, TARGET_DEAL_YM],
+    )
+
+    assert len(bronze.apt_transactions) > 0
+    assert len(bronze.interest_rates) >= 2
+
+    result = run_pipeline(bronze)
+
+    by_period = {gold.period: gold for gold in result.gold}
+    target_period = f"{TARGET_DEAL_YM[:4]}-{TARGET_DEAL_YM[4:]}"
+    prior_period = f"{PRIOR_DEAL_YM[:4]}-{PRIOR_DEAL_YM[4:]}"
+    assert target_period in by_period
+    assert prior_period in by_period
+    assert by_period[target_period].yoy_price_change is not None
+    assert by_period[target_period].yoy_volume_change is not None

--- a/apps/kr-seoul-apartment/tests/unit/test_cli.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_cli.py
@@ -71,6 +71,56 @@ def test_ingest_json_output_is_valid_json(runner: CliRunner, tmp_path: Path) -> 
     assert payload["gold_count"] >= 1
 
 
+def test_ingest_live_requires_gu(runner: CliRunner, tmp_path: Path) -> None:
+    result = runner.invoke(
+        cli.main,
+        [
+            "ingest",
+            "--source",
+            "live",
+            "--month",
+            "202503",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--gu is required" in result.output
+
+
+def test_ingest_live_requires_month_or_months(runner: CliRunner, tmp_path: Path) -> None:
+    result = runner.invoke(
+        cli.main,
+        ["ingest", "--source", "live", "--gu", "11680", "--output-dir", str(tmp_path)],
+    )
+
+    assert result.exit_code != 0
+    assert "exactly one of --month or --months" in result.output
+
+
+def test_ingest_live_rejects_month_and_months_together(runner: CliRunner, tmp_path: Path) -> None:
+    result = runner.invoke(
+        cli.main,
+        [
+            "ingest",
+            "--source",
+            "live",
+            "--gu",
+            "11680",
+            "--month",
+            "202503",
+            "--months",
+            "202403,202503",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
 def test_simulate_runs_successfully(runner: CliRunner, tmp_path: Path) -> None:
     output_dir = tmp_path / "simulation"
 

--- a/apps/kr-seoul-apartment/tests/unit/test_pipeline_live.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_pipeline_live.py
@@ -7,7 +7,10 @@ import pytest
 from kpubdata.core.dataset import Dataset
 
 from younggeul_app_kr_seoul_apartment.pipeline import BronzeInput
-from younggeul_app_kr_seoul_apartment.pipeline_live import run_live_ingest
+from younggeul_app_kr_seoul_apartment.pipeline_live import (
+    run_live_ingest,
+    run_live_ingest_months,
+)
 from younggeul_core.connectors.protocol import ConnectorResult
 from younggeul_core.state.bronze import (
     BronzeAptTransaction,
@@ -134,3 +137,57 @@ def test_run_live_ingest_rejects_invalid_lawd_code(bad_code: str) -> None:
 def test_run_live_ingest_rejects_invalid_deal_ym(bad_month: str) -> None:
     with pytest.raises(ValueError, match="deal_ym must be YYYYMM"):
         run_live_ingest(client=MagicMock(), lawd_code="11680", deal_ym=bad_month)
+
+
+def test_run_live_ingest_months_fetches_apt_per_month_and_bok_range(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from younggeul_app_kr_seoul_apartment import pipeline_live
+    from younggeul_app_kr_seoul_apartment.connectors.bok import BokInterestRateRequest
+    from younggeul_app_kr_seoul_apartment.connectors.molit import MolitAptRequest
+
+    apt_mock = MagicMock()
+    rate_mock = MagicMock()
+    apt_mock.return_value.fetch.return_value = ConnectorResult(records=[_apt_record()], manifest=MagicMock())
+    rate_mock.return_value.fetch.return_value = ConnectorResult(records=[_rate_record()], manifest=MagicMock())
+    monkeypatch.setattr(pipeline_live, "MolitAptConnector", apt_mock)
+    monkeypatch.setattr(pipeline_live, "BokInterestRateConnector", rate_mock)
+
+    client = MagicMock()
+    client.dataset.side_effect = lambda _id: MagicMock(spec=Dataset)
+
+    bronze = run_live_ingest_months(client=client, lawd_code="11680", deal_yms=["202503", "202403"])
+
+    apt_calls = apt_mock.return_value.fetch.call_args_list
+    assert len(apt_calls) == 2
+    apt_year_months = [call.args[0].year_month for call in apt_calls]
+    assert apt_year_months == ["202503", "202403"]
+    for call in apt_calls:
+        assert isinstance(call.args[0], MolitAptRequest)
+        assert call.args[0].sigungu_code == "11680"
+
+    rate_calls = rate_mock.return_value.fetch.call_args_list
+    assert len(rate_calls) == 1
+    rate_request = rate_calls[0].args[0]
+    assert isinstance(rate_request, BokInterestRateRequest)
+    assert rate_request.start_date == "202403"
+    assert rate_request.end_date == "202503"
+
+    assert isinstance(bronze, BronzeInput)
+    assert len(bronze.apt_transactions) == 2
+    assert bronze.migrations == []
+
+
+def test_run_live_ingest_months_rejects_empty_list() -> None:
+    with pytest.raises(ValueError, match="deal_yms must not be empty"):
+        run_live_ingest_months(client=MagicMock(), lawd_code="11680", deal_yms=[])
+
+
+def test_run_live_ingest_months_rejects_duplicates() -> None:
+    with pytest.raises(ValueError, match="must not contain duplicates"):
+        run_live_ingest_months(client=MagicMock(), lawd_code="11680", deal_yms=["202503", "202503"])
+
+
+def test_run_live_ingest_months_rejects_invalid_member() -> None:
+    with pytest.raises(ValueError, match="deal_ym must be YYYYMM"):
+        run_live_ingest_months(client=MagicMock(), lawd_code="11680", deal_yms=["202503", "20250"])

--- a/docs/adr/007-kpubdata-live-ingest.md
+++ b/docs/adr/007-kpubdata-live-ingest.md
@@ -24,7 +24,7 @@ The live ingest path will use **kpubdata as the single client library** for all 
 1. **Pinned dependency**: `kpubdata>=0.2.3` in `pyproject.toml`. The 0.2.3 release is the first that correctly handles the `resultCode == "000"` envelope returned by MOLIT's RTMS family endpoints (PR #130 in kpubdata).
 2. **Single client factory**: `younggeul_app_kr_seoul_apartment.connectors.client_factory.build_client()` is the only place that constructs a `kpubdata.Client`. It validates that `KPUBDATA_DATAGO_API_KEY`, `KPUBDATA_BOK_API_KEY`, and `KPUBDATA_KOSIS_API_KEY` are all present and raises a single actionable error message otherwise.
 3. **Live ingest entry point**: `pipeline_live.run_live_ingest(client, lawd_code, deal_ym)` fetches one Seoul `gu × month` slice and returns a `BronzeInput` ready for `run_pipeline`.
-4. **CLI surface**: `younggeul ingest --source live --gu <5-digit LAWD> --month <YYYYMM>`. The default `--source=fixture` path is unchanged so `make demo` keeps working without API keys.
+4. **CLI surface**: `younggeul ingest --source live --gu <5-digit LAWD>` with either `--month <YYYYMM>` (single month) or `--months <YYYYMM,YYYYMM,...>` (multi-month, mutually exclusive). Multi-month invocations issue one MOLIT call per month and a single BOK range query, then concatenate into one `BronzeInput` so the aggregator can populate YoY/MoM change ratios. The default `--source=fixture` path is unchanged so `make demo` keeps working without API keys.
 5. **KOSTAT scope (option C)**: For v0.1, KOSTAT migration is **not emitted** in live mode (`BronzeInput.migrations` is an empty list). The kpubdata `kosis.population_migration` dataset only exposes `T70` (이동자수) and `T80` (순이동자수), while our `BronzeMigration` schema requires per-region in/out/net counts. Wiring real KOSTAT migration requires either a different KOSIS table or a Bronze schema change, which is tracked separately. The Silver normalizer drops migration rows with all-null counts anyway, so emitting a placeholder Bronze row would be dead code.
 6. **Live integration test**: One gated test (`apps/kr-seoul-apartment/tests/integration/test_live_ingest.py`) exercises the full live path under the `live` pytest marker. It is excluded from `make test` and `make test-all`, and skipped when env vars are absent.
 
@@ -63,7 +63,12 @@ result = run_pipeline(bronze)
 
 ```bash
 set -a; source .env; set +a
+
+# Single month
 younggeul ingest --source live --gu 11680 --month 202503 --output-dir ./output/live
+
+# Multi-month (populates YoY/MoM in Gold)
+younggeul ingest --source live --gu 11680 --months 202403,202503 --output-dir ./output/live-yoy
 ```
 
 The default fixture path remains:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -59,7 +59,13 @@ export KPUBDATA_KOSIS_API_KEY="your-kosis-key"
 younggeul ingest --source live --gu 11680 --month 202503 --output-dir ./output/live
 ```
 
-`--gu` is a 5-digit MOLIT sigungu code (e.g. `11680` = 강남구) and `--month` is `YYYYMM`. v0.1 covers one gu × one month per invocation. See [ADR-007](../adr/007-kpubdata-live-ingest.md) for the design and current scope.
+`--gu` is a 5-digit MOLIT sigungu code (e.g. `11680` = 강남구) and `--month` is `YYYYMM`. To populate YoY/MoM change ratios in the Gold output, fetch multiple months in one invocation via `--months` (mutually exclusive with `--month`):
+
+```bash
+younggeul ingest --source live --gu 11680 --months 202403,202503 --output-dir ./output/live-yoy
+```
+
+v0.1 covers one gu per invocation. See [ADR-007](../adr/007-kpubdata-live-ingest.md) for the design and current scope.
 
 !!! note
     All tutorial examples use fixture data; no API key is required.


### PR DESCRIPTION
## Summary
- Add `--months YYYYMM,YYYYMM,...` to `younggeul ingest --source live` (mutually exclusive with `--month`).
- New `run_live_ingest_months` issues one MOLIT call per month and a single BOK range query, concatenating into one `BronzeInput` so the Gold aggregator populates `yoy_price_change` / `yoy_volume_change` / `mom_*` (previously always `null` with the single-month surface).
- `run_live_ingest` becomes a thin wrapper for back-compat; existing single-month CLI usage is unchanged.

## Why
PR #214 wired live ingest but capped each invocation at one month, leaving every YoY/MoM ratio null in Gold. The simulator's downstream agents need trend signals; this unblocks them without changing the deterministic pipeline shape.

## Verification
- 1229 unit tests pass (`make test` excludes live).
- ruff + mypy clean.
- Live e2e on 강남구 (11680):
  - `--months 202403,202503` → 2 Gold rows; 2025-03 yoy_price_change ≈ +31.3%, yoy_volume_change ≈ -10.1%.
  - `--month 202503` (back-compat) → 1 Gold row, identical to v0.1 behavior.

## Scope
- KOSTAT migration still empty in live mode (per ADR-007 §5).
- `--source=fixture` default unchanged; `make demo` unaffected.