### PR TITLE
chore: ignore local tooling artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ site/
 # Environment
 .env
 .env.local
+.envrc
+
+# Local tooling artifacts (agent orchestration, MCP servers)
+.sisyphus/
+.playwright-mcp/
 
 # OS
 .DS_Store


### PR DESCRIPTION
## Summary
Add `.envrc`, `.sisyphus/`, `.playwright-mcp/` to `.gitignore` so local agent/tooling artifacts stop showing up in `git status`.

## Out of scope
- `applyform.yml`, `applylist.yml` (look like personal/unrelated files - leaving for owner to decide)
- `uv.lock` (separate decision: commit for reproducibility vs ignore - the project currently uses pip, no policy yet)