### PR TITLE
docs: add MoM consecutive-month example for live ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,11 @@ younggeul ingest --source live --gu 11680 --month 202503 --output-dir ./output/l
 `--gu` is a 5-digit MOLIT sigungu code (e.g. `11680` = 강남구) and `--month` is `YYYYMM`. To populate YoY/MoM change ratios in the Gold output, fetch multiple months in one invocation via `--months`:
 
 ```bash
+# Year-over-year (same month, different years)
 younggeul ingest --source live --gu 11680 --months 202403,202503 --output-dir ./output/live-yoy
+
+# Month-over-month (consecutive months)
+younggeul ingest --source live --gu 11680 --months 202502,202503 --output-dir ./output/live-mom
 ```
 
 `--month` and `--months` are mutually exclusive. v0.1 covers one gu per invocation. See [ADR-007](docs/adr/007-kpubdata-live-ingest.md) for the design and current scope (KOSTAT migration is not emitted in live mode for v0.1).

--- a/apps/kr-seoul-apartment/tests/integration/test_live_ingest.py
+++ b/apps/kr-seoul-apartment/tests/integration/test_live_ingest.py
@@ -26,6 +26,7 @@ from younggeul_app_kr_seoul_apartment.pipeline_live import (
 GANGNAM_LAWD_CODE = "11680"
 TARGET_DEAL_YM = "202503"
 PRIOR_DEAL_YM = "202403"
+PRIOR_MONTH_DEAL_YM = "202502"
 
 
 def _env_keys_present() -> bool:
@@ -88,3 +89,21 @@ def test_live_ingest_months_yoy_change_is_populated() -> None:
     assert prior_period in by_period
     assert by_period[target_period].yoy_price_change is not None
     assert by_period[target_period].yoy_volume_change is not None
+
+
+def test_live_ingest_consecutive_months_populates_mom_change() -> None:
+    client = build_client()
+
+    bronze = run_live_ingest_months(
+        client=client,
+        lawd_code=GANGNAM_LAWD_CODE,
+        deal_yms=[PRIOR_MONTH_DEAL_YM, TARGET_DEAL_YM],
+    )
+
+    result = run_pipeline(bronze)
+
+    by_period = {gold.period: gold for gold in result.gold}
+    target_period = f"{TARGET_DEAL_YM[:4]}-{TARGET_DEAL_YM[4:]}"
+    assert target_period in by_period
+    assert by_period[target_period].mom_price_change is not None
+    assert by_period[target_period].mom_volume_change is not None

--- a/docs/adr/007-kpubdata-live-ingest.md
+++ b/docs/adr/007-kpubdata-live-ingest.md
@@ -67,8 +67,11 @@ set -a; source .env; set +a
 # Single month
 younggeul ingest --source live --gu 11680 --month 202503 --output-dir ./output/live
 
-# Multi-month (populates YoY/MoM in Gold)
+# Year-over-year (populates yoy_*_change in Gold)
 younggeul ingest --source live --gu 11680 --months 202403,202503 --output-dir ./output/live-yoy
+
+# Month-over-month (populates mom_*_change in Gold)
+younggeul ingest --source live --gu 11680 --months 202502,202503 --output-dir ./output/live-mom
 ```
 
 The default fixture path remains:


### PR DESCRIPTION
## Summary
- Add MoM (consecutive-month) example to README and ADR-007 alongside the existing YoY example.
- New live integration test `test_live_ingest_consecutive_months_populates_mom_change` verifies `mom_price_change`/`mom_volume_change` are populated.

## Verification
Live e2e on 강남 202502+202503: mom_price_change ≈ +6.65%, mom_volume_change ≈ -5.32%.