### PR TITLE
feat: github models support for simulation

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -12,12 +12,15 @@ on:
       max_rounds:
         description: "Maximum simulation rounds"
         default: "6"
+permissions:
+  contents: read
+  models: read
 jobs:
   simulate:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+      GH_MODELS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -26,14 +29,20 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - name: Install dependencies
         run: uv pip install --system -e ".[dev]"
-      - name: Check LLM API key
+      - name: Check GitHub Models token
         run: |
-          if [ -z "$LITELLM_API_KEY" ]; then
-            echo "::warning::LITELLM_API_KEY not set. Cannot run simulation."
+          if [ -z "$GH_MODELS_TOKEN" ]; then
+            echo "::warning::GH_MODELS_TOKEN not set. Cannot run simulation."
             exit 1
           fi
       - name: Run simulation
-        run: 'echo "TODO: younggeul simulate --snapshot ${{ inputs.snapshot_id }} --query ''${{ inputs.query }}'' --max-rounds ${{ inputs.max_rounds }}"'
+        run: >-
+          younggeul simulate
+          --query "${{ inputs.query }}"
+          --max-rounds ${{ inputs.max_rounds }}
+          --model-id github/openai/gpt-4o-mini
+          --run-name "gha-${{ github.run_id }}-${{ inputs.snapshot_id }}"
+          --output-dir reports
       - name: Upload report
         uses: actions/upload-artifact@v7
         if: always()

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ younggeul report --report-file ./output/simulation/simulation_report_*.md
 younggeul eval --output-dir ./eval_results
 ```
 
+Simulation runs can also target GitHub Models by setting `GH_MODELS_TOKEN` (or reusing `GITHUB_TOKEN`) and passing a GitHub Models id such as `--model-id github/openai/gpt-4o-mini`. See [ADR-009](docs/adr/009-github-models-llm.md) for the routing and migration details.
+
 ## Data Sources
 
 | Source | Provider | Data |
@@ -182,6 +184,7 @@ Key architectural decisions are documented as ADRs:
 | [ADR-006](docs/adr/006-public-data-policy.md) | No raw data in git; manifests only |
 | [ADR-007](docs/adr/007-kpubdata-live-ingest.md) | Live ingest via kpubdata unified client |
 | [ADR-008](docs/adr/008-kostat-live-activation.md) | Activate KOSTAT migration at 시도 granularity |
+| [ADR-009](docs/adr/009-github-models-llm.md) | GitHub Models support for simulation LLM routing |
 
 ## License
 

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
@@ -28,6 +29,7 @@ _KNOWN_PROVIDERS: frozenset[str] = frozenset(
         "azure",
         "bedrock",
         "deepseek",
+        "github",
         "openrouter",
         "replicate",
         "sagemaker",
@@ -35,6 +37,9 @@ _KNOWN_PROVIDERS: frozenset[str] = frozenset(
         "vertex_ai",
     }
 )
+
+_GITHUB_MODELS_PREFIX = "github/"
+_GITHUB_MODELS_API_BASE = "https://models.github.ai/inference"
 
 
 def _normalize_provider(model: str) -> str:
@@ -100,6 +105,40 @@ def _set_error_status(span: _SpanLike, exc: Exception) -> None:
         pass
 
 
+def _is_github_models_model(model: str) -> bool:
+    return model.lower().startswith(_GITHUB_MODELS_PREFIX)
+
+
+def _bridge_github_models_token() -> str | None:
+    token = os.getenv("GH_MODELS_TOKEN") or os.getenv("GITHUB_TOKEN")
+    if token and not os.getenv("GITHUB_TOKEN"):
+        os.environ["GITHUB_TOKEN"] = token
+    return token
+
+
+def _resolve_completion_kwargs(model: str, default_kwargs: dict[str, Any]) -> dict[str, Any]:
+    completion_kwargs = dict(default_kwargs)
+    completion_kwargs["model"] = model
+
+    if not _is_github_models_model(model):
+        return completion_kwargs
+
+    token = _bridge_github_models_token()
+    if token is None:
+        msg = "GitHub Models requires GH_MODELS_TOKEN or GITHUB_TOKEN"
+        raise StructuredLLMTransportError(msg)
+
+    completion_kwargs.update(
+        {
+            "model": model[len(_GITHUB_MODELS_PREFIX) :],
+            "custom_llm_provider": "openai",
+            "api_base": _GITHUB_MODELS_API_BASE,
+            "api_key": token,
+        }
+    )
+    return completion_kwargs
+
+
 class StructuredLLMTransportError(RuntimeError):
     """Raised when transport-level LLM invocation fails."""
 
@@ -155,15 +194,15 @@ class LiteLLMStructuredLLM:
         provider = _normalize_provider(self.model)
         request_metric_attrs = metric_attrs(provider=provider, model=self.model)
         start = time.monotonic()
+        completion_kwargs = _resolve_completion_kwargs(self.model, self._default_kwargs)
 
         with _make_span_ctx("llm.completion", attributes=span_attrs) as span:
             try:
                 response = litellm.completion(
-                    model=self.model,
                     messages=list(messages),
                     temperature=temperature,
                     response_format=response_format,
-                    **self._default_kwargs,
+                    **completion_kwargs,
                 )
             except Exception as exc:
                 elapsed_ms = (time.monotonic() - start) * 1000

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/config.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/web/config.py
@@ -4,7 +4,7 @@ import os
 
 
 def get_allowed_models() -> tuple[str, ...]:
-    raw = os.getenv("YOUNGGEUL_ALLOWED_MODELS", "stub,gpt-4o-mini")
+    raw = os.getenv("YOUNGGEUL_ALLOWED_MODELS", "stub,gpt-4o-mini,github/openai/gpt-4o-mini")
     models = tuple(model.strip() for model in raw.split(",") if model.strip())
     return models or ("stub",)
 

--- a/apps/kr-seoul-apartment/tests/unit/test_config.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_config.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from importlib import import_module
+
+import pytest
+
+config_module = import_module("younggeul_app_kr_seoul_apartment.web.config")
+
+get_allowed_models = config_module.get_allowed_models
+validate_model_id = config_module.validate_model_id
+
+
+def test_get_allowed_models_includes_github_models_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("YOUNGGEUL_ALLOWED_MODELS", raising=False)
+
+    allowed_models = get_allowed_models()
+
+    assert allowed_models == ("stub", "gpt-4o-mini", "github/openai/gpt-4o-mini")
+
+
+def test_validate_model_id_accepts_github_models_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("YOUNGGEUL_ALLOWED_MODELS", raising=False)
+
+    validate_model_id("github/openai/gpt-4o-mini")
+
+
+def test_validate_model_id_rejects_unknown_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("YOUNGGEUL_ALLOWED_MODELS", raising=False)
+
+    with pytest.raises(ValueError, match="model_id 'unknown-model' is not allowed"):
+        validate_model_id("unknown-model")

--- a/apps/kr-seoul-apartment/tests/unit/test_litellm_adapter.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_litellm_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from importlib import import_module
+import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -91,6 +92,9 @@ class TestNormalizeProvider:
         assert _normalize_provider("VLLM/model") == "vllm"
         assert _normalize_provider("Azure/gpt-4") == "azure"
 
+    def test_github_prefix(self) -> None:
+        assert _normalize_provider("github/openai/gpt-4o-mini") == "github"
+
     def test_unknown_org_prefix_defaults_to_openai(self) -> None:
         assert _normalize_provider("meta-llama/Meta-Llama-3") == "openai"
 
@@ -107,6 +111,49 @@ class TestNormalizeProvider:
 
 
 class TestGenerateStructuredSpans:
+    def test_github_models_route_uses_openai_compatible_endpoint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GH_MODELS_TOKEN", "ghs_test_token")
+
+        adapter = LiteLLMStructuredLLM(model="github/openai/gpt-4o-mini")
+        mock_litellm = MagicMock()
+        mock_litellm.completion.return_value = SimpleNamespace(
+            model="openai/gpt-4o-mini",
+            usage=SimpleNamespace(prompt_tokens=3, completion_tokens=4, total_tokens=7),
+            _hidden_params={},
+            choices=[_choice('{"message":"ok"}', finish_reason="stop")],
+        )
+
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            result = adapter.generate_structured(
+                messages=[{"role": "user", "content": "hello"}],
+                response_model=_StructuredResponse,
+            )
+
+        assert result == _StructuredResponse(message="ok")
+        kwargs = mock_litellm.completion.call_args.kwargs
+        assert kwargs["model"] == "openai/gpt-4o-mini"
+        assert kwargs["custom_llm_provider"] == "openai"
+        assert kwargs["api_base"] == "https://models.github.ai/inference"
+        assert kwargs["api_key"] == "ghs_test_token"
+        assert os.environ["GITHUB_TOKEN"] == "ghs_test_token"
+
+    def test_github_models_route_requires_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_MODELS_TOKEN", raising=False)
+
+        adapter = LiteLLMStructuredLLM(model="github/openai/gpt-4o-mini")
+        mock_litellm = MagicMock()
+
+        with patch.dict("sys.modules", {"litellm": mock_litellm}):
+            with pytest.raises(StructuredLLMTransportError, match="GH_MODELS_TOKEN or GITHUB_TOKEN"):
+                adapter.generate_structured(
+                    messages=[{"role": "user", "content": "hello"}],
+                    response_model=_StructuredResponse,
+                )
+
+        mock_litellm.completion.assert_not_called()
+
     def test_creates_child_span_with_all_attributes(self) -> None:
         adapter = LiteLLMStructuredLLM(model="vllm/meta-llama")
         tracer, exporter = _make_test_tracer()

--- a/docs/adr/009-github-models-llm.md
+++ b/docs/adr/009-github-models-llm.md
@@ -1,0 +1,82 @@
+# ADR-009: Use GitHub Models for simulation LLM access
+
+## Status
+Accepted
+
+## Date
+2026-04-20
+
+## Context
+
+The simulation workflow currently assumes a generic `LITELLM_API_KEY` and passes the selected `model_id` directly into LiteLLM. That design is serviceable for bring-your-own-provider integrations, but it is awkward for this repository's default automation path:
+
+1. The project already runs on GitHub, so Actions always has a workflow token available.
+2. GitHub Models offers a free experimentation tier, which lowers the barrier for trying the simulation with a real hosted model.
+3. Requiring contributors to mint and distribute a separate generic LLM key adds setup friction for the common "run this in GitHub" case.
+
+At the same time, the repo is pinned only to `litellm` without a first-class `github/...` provider contract in the installed LiteLLM 1.83 runtime. We therefore need a routing layer that preserves the public `github/...` model ids while still using LiteLLM as the transport abstraction.
+
+## Decision
+
+Simulation now accepts GitHub Models ids such as `github/openai/gpt-4o-mini` and routes them through LiteLLM using GitHub Models' OpenAI-compatible inference endpoint.
+
+### 1. Public model id shape
+
+- Callers keep using `github/...` ids at the CLI and web layer.
+- `get_allowed_models()` now includes `github/openai/gpt-4o-mini` by default alongside `stub` and `gpt-4o-mini` for backward compatibility.
+
+### 2. LiteLLM routing strategy
+
+- The adapter detects `github/` prefixes before invoking `litellm.completion(...)`.
+- Because the installed LiteLLM version does not provide a native GitHub provider route here, the adapter rewrites the outbound call to:
+  - `custom_llm_provider="openai"`
+  - `api_base="https://models.github.ai/inference"`
+  - `model=<original model id without the leading github/>`
+- Metrics and tracing still record the caller-facing model id and provider as `github`, so observability reflects the intended provider rather than the transport workaround.
+
+### 3. Auth environment bridge
+
+- `GH_MODELS_TOKEN` is the preferred explicit secret name for simulation.
+- `GITHUB_TOKEN` remains supported because GitHub Actions injects it automatically.
+- The adapter mirrors `GH_MODELS_TOKEN` into `GITHUB_TOKEN` when only the former is set, so local shells and Actions use one consistent auth path.
+- Existing non-GitHub flows may still use `LITELLM_API_KEY`; this ADR does not remove that fallback.
+
+### 4. Workflow changes
+
+- `.github/workflows/simulation.yml` now exports `GH_MODELS_TOKEN: ${{ secrets.GITHUB_TOKEN }}`.
+- The workflow requests `permissions:` for `contents: read` and `models: read` so the runtime token can access GitHub Models.
+- The workflow runs the real `younggeul simulate` command instead of a placeholder echo.
+
+## Rate limit notes
+
+GitHub Models' free API usage is rate limited by request volume, daily quotas, token budgets per request, and concurrent requests. Those limits vary by model tier and account plan, and they are explicitly documented by GitHub as subject to change during preview. This is acceptable for the repository's simulation smoke workflow, but it means:
+
+- repeated workflow_dispatch runs can hit transient 429-style throttling,
+- heavier models may have materially tighter daily limits than lightweight models,
+- teams that outgrow the free tier should expect to move either to paid GitHub Models usage or to an existing provider key path.
+
+## Consequences
+
+**Pros.**
+
+- The default GitHub-hosted simulation path no longer requires a separate `LITELLM_API_KEY` secret.
+- Contributors can try a real model from the CLI or Actions with a token name that matches GitHub's ecosystem.
+- The adapter keeps LiteLLM as the single LLM transport abstraction, so the rest of the graph code stays unchanged.
+
+**Cons.**
+
+- The adapter now owns a small amount of provider-specific routing logic until LiteLLM's native GitHub provider support is dependable in this repo.
+- Free-tier rate limits may be too small for frequent or large simulation runs.
+- Not every catalog model name is guaranteed to behave identically through the OpenAI-compatible endpoint, so future model additions should be validated before being added to the default allow-list.
+
+## Migration from generic `LITELLM_API_KEY`
+
+1. For GitHub Models usage, stop depending on `LITELLM_API_KEY` and provide either `GH_MODELS_TOKEN` or `GITHUB_TOKEN`.
+2. Use a GitHub Models id such as `github/openai/gpt-4o-mini` when invoking `younggeul simulate`.
+3. Keep `LITELLM_API_KEY` only for non-GitHub model routes that still rely on LiteLLM's existing provider integrations.
+
+## Related
+
+- `apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py` — provider routing and token bridge.
+- `.github/workflows/simulation.yml` — workflow token wiring and `younggeul simulate` invocation.
+- [README](../../README.md) — top-level setup note.


### PR DESCRIPTION
## Summary
- add GitHub Models routing in the simulation LiteLLM adapter, including `GH_MODELS_TOKEN`/`GITHUB_TOKEN` bridging and a default `github/openai/gpt-4o-mini` allow-list entry
- update the simulation workflow to use `GH_MODELS_TOKEN: \\${{ secrets.GITHUB_TOKEN }}` with `models: read` permission and run the real `younggeul simulate` command
- document the migration in README and ADR-009, and add unit coverage for GitHub Models adapter/config behavior

## Migration notes
- GitHub Models simulation runs now prefer `GH_MODELS_TOKEN` or `GITHUB_TOKEN` instead of a generic `LITELLM_API_KEY`
- `LITELLM_API_KEY` remains available for non-GitHub LiteLLM flows; this change only adds the `github/...` path
- the adapter currently routes `github/...` ids through GitHub Models' OpenAI-compatible endpoint because the repo's LiteLLM runtime does not expose a native GitHub provider path here

## Test plan
- `.venv/bin/ruff check . && .venv/bin/ruff format --check .`
- `.venv/bin/mypy core/src apps/kr-seoul-apartment/src`
- `.venv/bin/python -m pytest -m "not slow and not integration and not live" -q --no-cov`

## ADR
- [ADR-009: Use GitHub Models for simulation LLM access](https://github.com/kpubdata-lab/younggeul/blob/feat/github-models-simulation/docs/adr/009-github-models-llm.md)