### PR TITLE
fix: data-pipeline workflow real ingest invocation

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -1,4 +1,5 @@
 name: Data Pipeline
+
 on:
   schedule:
     - cron: "0 6 * * 0" # Sunday 6 AM UTC
@@ -6,39 +7,117 @@ on:
     inputs:
       source:
         description: "Data source to ingest"
-        default: "molit_apt_trade"
-      start_month:
-        description: "Start month (YYYY-MM)"
+        type: choice
+        options:
+          - fixture
+          - live
+        default: live
+      gus:
+        description: "Comma-separated 5-digit MOLIT sigungu codes"
         required: false
-      end_month:
-        description: "End month (YYYY-MM)"
+        default: "11680"
+      months:
+        description: "Comma-separated YYYYMM months (empty = last completed UTC month)"
         required: false
+        default: ""
+      output_dir:
+        description: "Output directory for ingest artifacts"
+        required: false
+        default: "output/pipeline"
+
+permissions:
+  contents: read
+
 jobs:
   ingest:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
-      DATA_GO_KR_API_KEY: ${{ secrets.DATA_GO_KR_API_KEY }}
+      KPUBDATA_DATAGO_API_KEY: ${{ secrets.KPUBDATA_DATAGO_API_KEY }}
+      KPUBDATA_BOK_API_KEY: ${{ secrets.KPUBDATA_BOK_API_KEY }}
+      KPUBDATA_KOSIS_API_KEY: ${{ secrets.KPUBDATA_KOSIS_API_KEY }}
     steps:
       - uses: actions/checkout@v6
+
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+
       - uses: astral-sh/setup-uv@v7
+
       - name: Install dependencies
         run: uv pip install --system -e ".[dev]"
-      - name: Check API key
+
+      - name: Resolve ingest parameters
+        id: params
+        env:
+          INPUT_SOURCE: ${{ inputs.source || '' }}
+          INPUT_GUS: ${{ inputs.gus || '' }}
+          INPUT_MONTHS: ${{ inputs.months || '' }}
+          INPUT_OUTPUT_DIR: ${{ inputs.output_dir || '' }}
         run: |
-          if [ -z "$DATA_GO_KR_API_KEY" ]; then
-            echo "::warning::DATA_GO_KR_API_KEY not set. Skipping ingestion."
-            exit 0
+          last_completed_month="$(date -u -d "$(date -u +%Y-%m-01) -1 month" +%Y%m)"
+
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            source="live"
+            gus="11680"
+            months="$last_completed_month"
+            output_dir="output/pipeline"
+          else
+            source="${INPUT_SOURCE:-live}"
+            gus="${INPUT_GUS:-11680}"
+            months="${INPUT_MONTHS:-$last_completed_month}"
+            output_dir="${INPUT_OUTPUT_DIR:-output/pipeline}"
           fi
-      - name: Run collector
-        run: 'echo "TODO: python -m younggeul_app_kr_seoul_apartment.pipeline.collector"'
-      - name: Upload manifest
+
+          {
+            echo "source=$source"
+            echo "gus=$gus"
+            echo "months=$months"
+            echo "output_dir=$output_dir"
+            echo "last_completed_month=$last_completed_month"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate live ingest configuration
+        if: ${{ steps.params.outputs.source == 'live' }}
+        run: |
+          missing=0
+
+          for var_name in KPUBDATA_DATAGO_API_KEY KPUBDATA_BOK_API_KEY KPUBDATA_KOSIS_API_KEY; do
+            if [ -z "${!var_name}" ]; then
+              echo "::error::$var_name is required when running younggeul ingest --source live"
+              missing=1
+            fi
+          done
+
+          if [ -z "${{ steps.params.outputs.gus }}" ]; then
+            echo "::error::At least one gu code is required when running live ingest"
+            missing=1
+          fi
+
+          if [ -z "${{ steps.params.outputs.months }}" ]; then
+            echo "::error::At least one YYYYMM month is required when running live ingest"
+            missing=1
+          fi
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Run ingest
+        run: >-
+          younggeul ingest
+          --source "${{ steps.params.outputs.source }}"
+          --gus "${{ steps.params.outputs.gus }}"
+          --months "${{ steps.params.outputs.months }}"
+          --output-dir "${{ steps.params.outputs.output_dir }}"
+
+      - name: Upload ingest artifacts
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: ingest-manifest
-          path: data/bronze/**/manifest.json
-          if-no-files-found: ignore
+          name: ingest-output
+          path: |
+            ${{ steps.params.outputs.output_dir }}/**/*.jsonl
+            ${{ steps.params.outputs.output_dir }}/**/manifest.json
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ set -a; source .env; set +a   # load KPUBDATA_* keys
 make demo-live                # or: GU=11680 MONTHS=202403,202503 bash scripts/demo_live.sh
 ```
 
+GitHub Actions can also run the live ingest on a schedule or via manual dispatch through `.github/workflows/data-pipeline.yml`. The workflow defaults to Gangnam (`11680`) and the last completed UTC month, and its operational rationale is documented in [ADR-010](docs/adr/010-data-pipeline-live-workflow.md).
+
 ## v0.1 Scope
 
 - **Region**: Seoul apartments only (서울 아파트 매매)
@@ -185,6 +187,7 @@ Key architectural decisions are documented as ADRs:
 | [ADR-007](docs/adr/007-kpubdata-live-ingest.md) | Live ingest via kpubdata unified client |
 | [ADR-008](docs/adr/008-kostat-live-activation.md) | Activate KOSTAT migration at 시도 granularity |
 | [ADR-009](docs/adr/009-github-models-llm.md) | GitHub Models support for simulation LLM routing |
+| [ADR-010](docs/adr/010-data-pipeline-live-workflow.md) | Real live ingest wiring for the GitHub Actions data pipeline |
 
 ## License
 

--- a/docs/adr/010-data-pipeline-live-workflow.md
+++ b/docs/adr/010-data-pipeline-live-workflow.md
@@ -1,0 +1,143 @@
+# ADR-010: Run live ingest from the GitHub Actions data pipeline workflow
+
+## Status
+Accepted
+
+## Date
+2026-04-20
+
+## Context
+
+The repository already exposes a production-shaped `younggeul ingest` CLI, but `.github/workflows/data-pipeline.yml` was still a placeholder workflow:
+
+- `workflow_dispatch` inputs did not match the real CLI contract (`molit_apt_trade`, `start_month`, `end_month`).
+- The workflow only exported `DATA_GO_KR_API_KEY`, while the live ingest path validates `KPUBDATA_DATAGO_API_KEY`, `KPUBDATA_BOK_API_KEY`, and `KPUBDATA_KOSIS_API_KEY`.
+- The main run step was an `echo "TODO"`, so scheduled runs never fetched live data.
+- Artifact upload pointed at `data/bronze/**/manifest.json`, which is not where `younggeul ingest` writes output.
+
+That gap meant we had a documented live-ingest path in ADR-007 and ADR-008, but no repository-native automation that actually exercised it on a schedule.
+
+## Decision
+
+The `Data Pipeline` GitHub Actions workflow now runs the real `younggeul ingest` command and adapts its inputs to the existing CLI rather than changing the CLI surface.
+
+### 1. Workflow inputs mirror the CLI shape
+
+`workflow_dispatch` now exposes:
+
+- `source` as `fixture|live` (default `live`),
+- `gus` as a CSV of 5-digit MOLIT sigungu codes,
+- `months` as a CSV of `YYYYMM` values,
+- `output_dir` as the ingest destination directory.
+
+This keeps the workflow aligned with `younggeul ingest --source --gus --months --output-dir` and avoids the previous mismatch between workflow UX and CLI validation.
+
+### 2. Scheduled runs use conservative live defaults
+
+The Sunday 06:00 UTC cron is preserved, but it now resolves to:
+
+- `--source live`
+- `--gus 11680` (Gangnam-gu)
+- `--months <last completed UTC month>`
+- `--output-dir output/pipeline`
+
+Gangnam (`11680`) is the default because it is already the most common live-ingest example in the repo, has active transaction volume, and gives us one stable district slice for a smoke-style scheduled ingest. Using the last completed month avoids querying an in-progress calendar month where MOLIT publication lag or partial upstream availability would create avoidable empty runs.
+
+### 3. Empty manual `months` falls back to the last completed month
+
+Manual triggers may leave `months` empty. In that case the workflow computes the previous UTC calendar month in `YYYYMM` format before invoking the CLI. Non-empty `months` values are passed through unchanged so operators can request YoY/MoM windows explicitly.
+
+### 4. Live mode validates all required secrets up front
+
+Before the ingest command runs, the workflow fails fast if any of these secrets are missing:
+
+- `KPUBDATA_DATAGO_API_KEY`
+- `KPUBDATA_BOK_API_KEY`
+- `KPUBDATA_KOSIS_API_KEY`
+
+This matches the live client factory and avoids a slower failure deep inside the Python process.
+
+### 5. Artifacts follow the CLI output directory
+
+The workflow uploads `output/pipeline/**/*.jsonl` plus any `manifest.json` produced under the selected output directory, with `if-no-files-found: warn`. A warning is preferable to `ignore` because missing JSONL output is a workflow health signal, not something to suppress silently.
+
+## Manual trigger examples
+
+### 1. Default live smoke run
+
+Leave the defaults as-is in `workflow_dispatch` to ingest Gangnam for the last completed UTC month:
+
+- `source=live`
+- `gus=11680`
+- `months=`
+- `output_dir=output/pipeline`
+
+### 2. Multi-month YoY run for one district
+
+- `source=live`
+- `gus=11680`
+- `months=202403,202503`
+- `output_dir=output/pipeline`
+
+### 3. Multi-district run
+
+- `source=live`
+- `gus=11680,11440`
+- `months=202502,202503`
+- `output_dir=output/pipeline`
+
+### 4. Fixture-mode workflow smoke test
+
+- `source=fixture`
+- `gus=11680`
+- `months=`
+- `output_dir=output/pipeline`
+
+The workflow still passes `--gus` and `--months` in fixture mode, but the CLI ignores those live-only options because validation only applies when `--source=live`.
+
+## Secret requirements
+
+Repository Actions secrets must include:
+
+- `KPUBDATA_DATAGO_API_KEY` for data.go.kr / MOLIT RTMS
+- `KPUBDATA_BOK_API_KEY` for BOK ECOS
+- `KPUBDATA_KOSIS_API_KEY` for KOSIS migration data
+
+The older `DATA_GO_KR_API_KEY` secret may remain in the repository for backward compatibility, but this workflow no longer depends on it.
+
+## Failure modes
+
+### Missing keys
+
+The workflow exits before calling Python and surfaces explicit GitHub Actions errors for each missing `KPUBDATA_*` secret.
+
+### kpubdata or upstream API limits
+
+Live ingest depends on external public APIs behind `kpubdata`. Transient provider throttling, quota exhaustion, or upstream envelope changes can fail the run even when the workflow wiring is correct.
+
+### MOLIT release lag
+
+The most recent calendar month is not always fully published when the cron fires. Defaulting to the last completed month reduces this risk, but delayed MOLIT publication can still produce sparse or empty trade slices for very recent periods.
+
+### Partial output generation
+
+If ingest fails before JSONL output is written, artifact upload emits a warning instead of silently succeeding. That makes broken runs easier to diagnose from the Actions UI.
+
+## Consequences
+
+**Pros.**
+
+- The scheduled workflow now exercises the same live ingest path documented in ADR-007 and ADR-008.
+- Manual dispatch parameters map directly to the public CLI, reducing operator confusion.
+- Fail-fast secret validation makes misconfiguration visible before a long-running job spends time installing dependencies.
+
+**Cons.**
+
+- Scheduled automation is now exposed to upstream API availability, throttling, and publication lag.
+- The default cron run only covers one district (`11680`), so it is a health check rather than comprehensive Seoul coverage.
+
+## Related
+
+- [ADR-007: Live Ingest via kpubdata](007-kpubdata-live-ingest.md)
+- [ADR-008: Activate KOSTAT Migration in Live Ingest at 시도 Granularity](008-kostat-live-activation.md)
+- `.github/workflows/data-pipeline.yml`


### PR DESCRIPTION
## Summary
- replace the `data-pipeline.yml` placeholder collector step with a real `younggeul ingest` invocation wired to the existing live-ingest CLI contract
- add schedule/manual parameter resolution, fail-fast `KPUBDATA_*` secret validation, and artifact upload paths that match the ingest output directory
- document the workflow behavior in ADR-010 and add a README pointer for operators

## Why
The repository already documents live ingest through `younggeul ingest`, but the GitHub Actions workflow still accepted invalid inputs and only echoed a TODO. This change makes the scheduled pipeline actually ingest live data while keeping the CLI surface unchanged.

## Test plan
- `actionlint .github/workflows/data-pipeline.yml` (fallback not needed locally because `actionlint` is available)
- `.venv/bin/ruff check . && .venv/bin/ruff format --check .`
- `.venv/bin/mypy core/src apps/kr-seoul-apartment/src`
- `.venv/bin/python -m pytest -m "not slow and not integration and not live" -q --no-cov`

## Migration
- workflow_dispatch inputs now use `source`, `gus`, `months`, and `output_dir` to mirror the CLI instead of the old placeholder fields
- scheduled runs default to `--source live --gus 11680 --months <last completed UTC month>`
- the workflow now reads `KPUBDATA_DATAGO_API_KEY`, `KPUBDATA_BOK_API_KEY`, and `KPUBDATA_KOSIS_API_KEY`; the legacy `DATA_GO_KR_API_KEY` secret can remain in the repo but is no longer used here

## ADR
- [ADR-010: Run live ingest from the GitHub Actions data pipeline workflow](https://github.com/kpubdata-lab/younggeul/blob/fix/data-pipeline-live-workflow/docs/adr/010-data-pipeline-live-workflow.md)