### PR TITLE
fix: docs strict build by adding new ADRs to nav

### DIFF
--- a/docs/adr/009-github-models-llm.md
+++ b/docs/adr/009-github-models-llm.md
@@ -79,4 +79,4 @@ GitHub Models' free API usage is rate limited by request volume, daily quotas, t
 
 - `apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/llm/litellm_adapter.py` — provider routing and token bridge.
 - `.github/workflows/simulation.yml` — workflow token wiring and `younggeul simulate` invocation.
-- [README](../../README.md) — top-level setup note.
+- Repository `README.md` — top-level setup note (lives outside the docs site root).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,9 @@ nav:
     - ADR-005 Evidence-Gated Reporting: adr/005-evidence-gated-reporting.md
     - ADR-006 Public Data Policy: adr/006-public-data-policy.md
     - ADR-007 kpubdata Live Ingest: adr/007-kpubdata-live-ingest.md
+    - ADR-008 KOSTAT Live Activation: adr/008-kostat-live-activation.md
+    - ADR-009 GitHub Models LLM: adr/009-github-models-llm.md
+    - ADR-010 Data Pipeline Live Workflow: adr/010-data-pipeline-live-workflow.md
   - API Reference:
     - Overview: api/index.md
     - Core:


### PR DESCRIPTION
## Summary
- Add ADR-008/009/010 to mkdocs nav
- Replace broken `../../README.md` link in ADR-009 with prose reference

## Why
`deploy-docs.yml` workflow has been failing on every push since ADR-009 introduced a link to README.md outside the docs root. mkdocs --strict mode aborts with: `Aborted with 1 warnings in strict mode!`

## Test plan
- `mkdocs build --strict` passes locally