### PR TITLE
fix: install kr-seoul-apartment extras in data-pipeline and simulation workflows

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv pip install --system -e ".[dev]"
+        run: uv pip install --system -e ".[dev,kr-seoul-apartment]"
 
       - name: Resolve ingest parameters
         id: params

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@v7
       - name: Install dependencies
-        run: uv pip install --system -e ".[dev]"
+        run: uv pip install --system -e ".[dev,kr-seoul-apartment]"
       - name: Check GitHub Models token
         run: |
           if [ -z "$GH_MODELS_TOKEN" ]; then


### PR DESCRIPTION
## Summary
`data-pipeline.yml` and `simulation.yml` only installed `[dev]` extras, missing `kr-seoul-apartment` which provides `kpubdata`. Live ingest and simulate fail at runtime with `No module named 'kpubdata'`.

## Test plan
- Live data-pipeline run failed: https://github.com/kpubdata-lab/younggeul/actions/runs/24697546580
- After fix, will trigger live run again to verify