### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "younggeul"
-version = "0.1.0"
+version = "0.3.0"
 description = "YOLO Mortgage Simulator monorepo"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Version bump for v0.3.0 release. 29 commits since v0.2.1, including major features: kpubdata live ingest, multi-gu/multi-month support, KOSTAT activation, GitHub Models support, MOLIT CI block mitigation, and live snapshot wiring into simulate (ADR-011).

Tag will be pushed after this PR merges, triggering release.yml.