### PR TITLE
chore: ignore local pipeline artifacts (output/, .coverage, uv.lock)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,15 @@ data/snapshots/**
 !data/.gitkeep
 eval_results/
 demo_output/
+output/
+
+# Test/coverage artifacts
+.coverage
+.coverage.*
+htmlcov/
+
+# uv lockfile (project uses `uv pip install` against pyproject; lockfile not pinned)
+uv.lock
 
 # Docs build
 site/


### PR DESCRIPTION
## Summary
- Add `output/` to .gitignore (live ingest CLI default output dir; mirrors existing `demo_output/` entry)
- Add `.coverage`, `.coverage.*`, `htmlcov/` (pytest-cov artifacts)
- Add `uv.lock` — project installs via `uv pip install` against `pyproject.toml`; lockfile is not pinned today

Untracked-file noise from local pipeline runs is now silenced; no behavior change.