### PR TITLE
feat(core): add YOUNGGEUL_CORE_BACKEND env switch and abdp extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,23 @@ Key architectural decisions are documented as ADRs:
 | [ADR-011](docs/adr/011-simulate-live-snapshot-wiring.md) | Wire live snapshot data into the simulate CLI |
 | [ADR-012](docs/adr/012-abdp-backed-core.md) | Adopt abdp-backed compatibility architecture for `younggeul_core` |
 
+## abdp backend (experimental)
+
+`younggeul_core` is being refactored as a thin compatibility layer over the [agent-based-decision-pipeline (abdp)](https://github.com/yeongseon/agent-based-decision-pipeline) framework (see [ADR-012](docs/adr/012-abdp-backed-core.md)). The backend is selected at runtime via:
+
+```bash
+export YOUNGGEUL_CORE_BACKEND=local   # default; preserves v0.3.0 behavior
+export YOUNGGEUL_CORE_BACKEND=abdp    # delegate to abdp (requires the [abdp] extra)
+```
+
+To install the abdp backend:
+
+```bash
+pip install -e ".[abdp]"
+```
+
+The default backend remains `local` until the M10 milestone (#245) flips it. Both backends MUST produce byte-identical JSON dumps and equivalent validation; this is enforced by the parity contract test suite (#241).
+
 ## License
 
 [Apache-2.0](LICENSE)

--- a/core/src/younggeul_core/_compat/__init__.py
+++ b/core/src/younggeul_core/_compat/__init__.py
@@ -1,0 +1,54 @@
+"""Backend selection compatibility layer for younggeul_core.
+
+See ADR-012 (docs/adr/012-abdp-backed-core.md). Subsequent milestones
+(M3-M5) will route subsystem imports through this module so the backend
+can be flipped via the ``YOUNGGEUL_CORE_BACKEND`` environment variable
+without touching call sites.
+
+Public surface intentionally minimal in M2: just the flag-reader and a
+single ``require_abdp()`` helper that produces a clear error if the
+``abdp`` extra is requested but not installed.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Final, Literal
+
+Backend = Literal["local", "abdp"]
+
+ENV_VAR: Final[str] = "YOUNGGEUL_CORE_BACKEND"
+DEFAULT_BACKEND: Final[Backend] = "local"
+_VALID_BACKENDS: Final[frozenset[str]] = frozenset({"local", "abdp"})
+
+
+def get_backend() -> Backend:
+    """Return the currently configured younggeul_core backend.
+
+    Reads ``YOUNGGEUL_CORE_BACKEND`` at call time (not import time) so tests
+    can switch backends via ``monkeypatch.setenv``. Defaults to ``"local"``
+    so existing installs keep their v0.3.0 behavior.
+
+    Raises:
+        ValueError: if the env var is set to an unsupported value.
+    """
+    raw = os.environ.get(ENV_VAR, DEFAULT_BACKEND).strip().lower()
+    if raw not in _VALID_BACKENDS:
+        raise ValueError(f"{ENV_VAR}={raw!r} is not supported. " f"Valid values: {sorted(_VALID_BACKENDS)}.")
+    return raw  # type: ignore[return-value]
+
+
+def require_abdp() -> None:
+    """Import ``abdp`` or raise a friendly error pointing to the extra."""
+    try:
+        import abdp  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "The 'abdp' backend was requested "
+            f"({ENV_VAR}=abdp) but the abdp package is not installed. "
+            "Install it via:  pip install -e '.[abdp]'  "
+            "(see ADR-012 for details)."
+        ) from exc
+
+
+__all__ = ["Backend", "DEFAULT_BACKEND", "ENV_VAR", "get_backend", "require_abdp"]

--- a/core/src/younggeul_core/_compat/__init__.py
+++ b/core/src/younggeul_core/_compat/__init__.py
@@ -34,7 +34,7 @@ def get_backend() -> Backend:
     """
     raw = os.environ.get(ENV_VAR, DEFAULT_BACKEND).strip().lower()
     if raw not in _VALID_BACKENDS:
-        raise ValueError(f"{ENV_VAR}={raw!r} is not supported. " f"Valid values: {sorted(_VALID_BACKENDS)}.")
+        raise ValueError(f"{ENV_VAR}={raw!r} is not supported. Valid values: {sorted(_VALID_BACKENDS)}.")
     return raw  # type: ignore[return-value]
 
 

--- a/core/tests/contract/test_compat_backend.py
+++ b/core/tests/contract/test_compat_backend.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from younggeul_core._compat import (
+    DEFAULT_BACKEND,
+    ENV_VAR,
+    get_backend,
+    require_abdp,
+)
+
+
+def test_default_backend_is_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    assert get_backend() == "local"
+    assert DEFAULT_BACKEND == "local"
+
+
+@pytest.mark.parametrize("value", ["local", "abdp", "LOCAL", "  ABDP  "])
+def test_get_backend_accepts_valid_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv(ENV_VAR, value)
+    assert get_backend() == value.strip().lower()
+
+
+def test_get_backend_rejects_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_VAR, "remote")
+    with pytest.raises(ValueError, match="not supported"):
+        get_backend()
+
+
+def test_require_abdp_raises_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "abdp" or name.startswith("abdp."):
+            raise ImportError("simulated missing abdp")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match="abdp"):
+        require_abdp()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,10 @@ strict = true
 module = ["kpubdata", "kpubdata.*"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["abdp", "abdp.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 addopts = "--import-mode=importlib"
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,12 @@ docs = [
   "mkdocs>=1.5",
   "mkdocstrings[python]>=0.25",
 ]
+# abdp backend (Adapter Layer; see ADR-012). Optional extra so the default
+# install keeps working with the local backend. Pinned to a specific commit
+# because abdp tags v0.3.0 still ship internal __version__ "0.1.0.dev0".
+abdp = [
+  "abdp @ git+https://github.com/yeongseon/agent-based-decision-pipeline.git@bf0ab1d027602ff5cbbc9e6cba1ffa98e37404b7",
+]
 
 [tool.hatch.metadata]
 allow-direct-references = true


### PR DESCRIPTION
## Summary
- Adds the M2 backend-switch plumbing for [ADR-012](../blob/main/docs/adr/012-abdp-backed-core.md): a `YOUNGGEUL_CORE_BACKEND={local,abdp}` environment variable plus a `[abdp]` optional extra pinned to a specific [abdp](https://github.com/yeongseon/agent-based-decision-pipeline) commit.
- Introduces `younggeul_core._compat` with `get_backend()` (read at call time so tests can monkeypatch) and `require_abdp()` (friendly error pointing at the extra).
- Default backend stays `local`, so v0.3.0 behavior is fully preserved. No call sites use the new module yet — M3 (#238) will be the first consumer.
- 7 new contract tests; full unit suite (1,247 tests) + ruff still green.

## Why pin to a commit, not a tag?
`abdp` v0.3.0 is tagged but its package still reports `__version__ = \"0.1.0.dev0\"`, so semver-based pins are unsafe. The pinned commit (`bf0ab1d`) corresponds to the v0.3.0 \"Auditable Simulation Milestone\" surface that ADR-012 is built against.

## Test plan
- `pytest core/tests/contract/test_compat_backend.py -v` → 7 passed
- `pytest -m "not slow and not integration"` → 1,247 passed (matches CI scope)
- `ruff check core/ apps/` → clean

The 3 pre-existing failures in `test_live_ingest.py` are MOLIT live-API failures (IP block, see ADR-010) that CI excludes via `-m "not integration"`.

Closes #237.
Refs #235.