### PR TITLE
feat(core): delegate sha256_payload to abdp on abdp backend

### DIFF
--- a/core/src/younggeul_core/connectors/hashing.py
+++ b/core/src/younggeul_core/connectors/hashing.py
@@ -30,6 +30,6 @@ def sha256_payload(records: list[dict[str, Any]]) -> str:
     if get_backend() == "abdp":
         from abdp.core import JsonValue, stable_hash
 
-        return stable_hash(cast("JsonValue", records))
+        return str(stable_hash(cast("JsonValue", records)))
     canonical = json.dumps(records, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/core/src/younggeul_core/connectors/hashing.py
+++ b/core/src/younggeul_core/connectors/hashing.py
@@ -1,10 +1,18 @@
-"""Deterministic SHA-256 hashing for data payloads."""
+"""Deterministic SHA-256 hashing for data payloads.
+
+When ``YOUNGGEUL_CORE_BACKEND=abdp`` (see ADR-012), the hashing is
+delegated to ``abdp.core.stable_hash``, which produces byte-identical
+output to the local implementation (verified by the parity contract
+test ``core/tests/contract/test_compat_hashing_parity.py``).
+"""
 
 from __future__ import annotations
 
 import hashlib
 import json
-from typing import Any
+from typing import Any, cast
+
+from younggeul_core._compat import get_backend
 
 
 def sha256_payload(records: list[dict[str, Any]]) -> str:
@@ -19,5 +27,9 @@ def sha256_payload(records: list[dict[str, Any]]) -> str:
     Returns:
         64-character lowercase hex SHA-256 string.
     """
+    if get_backend() == "abdp":
+        from abdp.core import JsonValue, stable_hash
+
+        return stable_hash(cast("JsonValue", records))
     canonical = json.dumps(records, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/core/tests/contract/test_compat_hashing_parity.py
+++ b/core/tests/contract/test_compat_hashing_parity.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+from younggeul_core._compat import ENV_VAR
+from younggeul_core.connectors.hashing import sha256_payload
+
+pytest.importorskip("abdp")
+
+
+PAYLOADS: list[list[dict[str, object]]] = [
+    [],
+    [{"a": 1}],
+    [{"b": 2, "a": 1}, {"c": 3.5, "d": "한글"}],
+    [{"nested": {"x": [1, 2, 3], "y": None}}],
+    [{f"key_{i}": i for i in range(50)} for _ in range(10)],
+]
+
+
+@pytest.mark.parametrize("payload", PAYLOADS, ids=range(len(PAYLOADS)))
+def test_sha256_payload_local_and_abdp_are_byte_identical(
+    monkeypatch: pytest.MonkeyPatch, payload: list[dict[str, object]]
+) -> None:
+    monkeypatch.setenv(ENV_VAR, "local")
+    local_hash = sha256_payload(payload)
+
+    monkeypatch.setenv(ENV_VAR, "abdp")
+    abdp_hash = sha256_payload(payload)
+
+    assert local_hash == abdp_hash, f"backend mismatch for payload {payload!r}"
+    assert len(local_hash) == 64


### PR DESCRIPTION
## Summary
- First M3 slice for [ADR-012](../blob/main/docs/adr/012-abdp-backed-core.md) connector delegation.
- When `YOUNGGEUL_CORE_BACKEND=abdp`, `sha256_payload()` now calls `abdp.core.stable_hash`. Verified byte-identical to the local `hashlib+json` implementation across 5 parametrized parity scenarios (empty / single / multi-record / nested / large payloads).
- Default backend is unchanged. 1,251 unit tests still pass; ruff and mypy both green.

## Why a partial M3?
The other three connector primitives have non-trivial API mismatches:
- `abdp.core.retry` is a decorator factory with a different exception model (no built-in `NonRetryableError`); needs an adapter shim.
- `abdp.ManifestFactory` produces an abdp-specific `SnapshotManifest`, not `BronzeIngestManifest` — blocked on M4 (data-contract delegation).
- `Connector` Protocol — pure typing; trivial swap once the model layer in M4 lands.

These will land as follow-up commits under #238 after M4. Shipping `sha256_payload` independently de-risks the parity-test infrastructure that M6 will scale up.

## Test plan
- `pytest core/tests/contract/test_compat_hashing_parity.py -v` → 5 passed
- `pytest -m "not slow and not integration"` → 1,251 passed
- `mypy core/src/ apps/kr-seoul-apartment/src/` → clean
- `ruff check && ruff format --check` → clean

The parity test uses `pytest.importorskip(\"abdp\")` so CI without the `[abdp]` extra simply skips it — no breakage.

Refs #238.
Refs #235.