### PR TITLE
feat(core): add abdp framework data Protocol re-exports (#239)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ To install the abdp backend:
 pip install -e ".[abdp]"
 ```
 
-The default backend remains `local` until the M10 milestone (#245) flips it. Both backends MUST produce byte-identical JSON dumps and equivalent validation; this is enforced by the parity contract test suite (#241).
+The default backend remains `local`; per the M4'–M10' scope correction in [ADR-012](docs/adr/012-abdp-backed-core.md#amendment-2026-04-23--m4m10-scope-correction), `younggeul_core` adopts `abdp` selectively where semantics match (hashing today; audit log and reporting render path next) rather than flipping wholesale. Adopted surfaces are gated by the parity contract test suite (#241).
 
 ## License
 

--- a/core/src/younggeul_core/_compat/data.py
+++ b/core/src/younggeul_core/_compat/data.py
@@ -1,0 +1,81 @@
+"""Opt-in re-exports of abdp framework data Protocols (see ADR-012).
+
+This module deliberately does **not** replace any younggeul row schema or
+the dataset-level ``younggeul_core.storage.snapshot.SnapshotManifest``.
+Per the M4' scope correction:
+
+- ``abdp.data.{Bronze,Silver,Gold}Contract`` are abstract structural
+  ``Protocol`` types with only ``manifest`` and ``rows`` properties.
+- ``younggeul_core.state.{bronze,silver,gold}`` are concrete Pydantic
+  schemas for the Korean apartment domain (kpubdata/MOLIT/BOK/KOSTAT).
+- ``abdp.data.SnapshotManifest`` is a per-tier UUID-keyed dataclass with
+  parent-pointer lineage.
+- ``younggeul_core.storage.snapshot.SnapshotManifest`` is a Pydantic
+  multi-table dataset manifest with sha256-derived integrity IDs.
+
+These are *not* bijective. We expose abdp's framework contracts here only
+for downstream code that wants to type-annotate "any framework artifact"
+(e.g., future audit/reporting adapters in M5'/M6'). Importing names from
+this module pulls in ``abdp`` lazily; code that does not need framework
+contracts pays no import cost.
+
+Use of these aliases does **not** imply that the local types satisfy
+them — the local types intentionally hold richer state.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from younggeul_core._compat import require_abdp
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from abdp.data import (
+        BronzeContract,
+        GoldContract,
+        SilverContract,
+        SnapshotManifest as AbdpSnapshotManifest,
+        SnapshotTier,
+    )
+
+
+def _resolve() -> tuple[object, object, object, object, object]:
+    require_abdp()
+    from abdp.data import (
+        BronzeContract,
+        GoldContract,
+        SilverContract,
+        SnapshotManifest as AbdpSnapshotManifest,
+        SnapshotTier,
+    )
+
+    return BronzeContract, SilverContract, GoldContract, SnapshotTier, AbdpSnapshotManifest
+
+
+def __getattr__(name: str) -> object:
+    if name in {
+        "BronzeContract",
+        "SilverContract",
+        "GoldContract",
+        "SnapshotTier",
+        "AbdpSnapshotManifest",
+    }:
+        bronze, silver, gold, tier, manifest = _resolve()
+        mapping = {
+            "BronzeContract": bronze,
+            "SilverContract": silver,
+            "GoldContract": gold,
+            "SnapshotTier": tier,
+            "AbdpSnapshotManifest": manifest,
+        }
+        return mapping[name]
+    raise AttributeError(f"module 'younggeul_core._compat.data' has no attribute {name!r}")
+
+
+__all__ = [
+    "AbdpSnapshotManifest",
+    "BronzeContract",
+    "GoldContract",
+    "SilverContract",
+    "SnapshotTier",
+]

--- a/core/tests/contract/test_compat_data_aliases.py
+++ b/core/tests/contract/test_compat_data_aliases.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+pytest.importorskip("abdp")
+
+
+def test_compat_data_reexports_abdp_protocols() -> None:
+    mod = importlib.import_module("younggeul_core._compat.data")
+
+    from abdp.data import (
+        BronzeContract,
+        GoldContract,
+        SilverContract,
+        SnapshotManifest as AbdpSnapshotManifest,
+        SnapshotTier,
+    )
+
+    assert mod.BronzeContract is BronzeContract
+    assert mod.SilverContract is SilverContract
+    assert mod.GoldContract is GoldContract
+    assert mod.SnapshotTier is SnapshotTier
+    assert mod.AbdpSnapshotManifest is AbdpSnapshotManifest
+
+
+def test_compat_data_aliases_are_not_local_snapshot_manifest() -> None:
+    """Guardrail: the abdp re-export must NOT be conflated with the local
+    dataset-level SnapshotManifest in storage.snapshot. Different concept."""
+    mod = importlib.import_module("younggeul_core._compat.data")
+    from younggeul_core.storage.snapshot import SnapshotManifest as LocalSnapshotManifest
+
+    assert mod.AbdpSnapshotManifest is not LocalSnapshotManifest
+
+
+def test_compat_data_unknown_attribute_raises() -> None:
+    mod = importlib.import_module("younggeul_core._compat.data")
+    with pytest.raises(AttributeError, match="has no attribute"):
+        _ = mod.DoesNotExist  # type: ignore[attr-defined]

--- a/docs/adr/012-abdp-backed-core.md
+++ b/docs/adr/012-abdp-backed-core.md
@@ -99,6 +99,31 @@ Until then, the stance is: **C now, A later if earned.**
 | M9 | #244 | Prototype `ScenarioRunner` engine (experimental) | L |
 | M10 | #245 | Remove duplicated legacy core after default flip | M |
 
+## Amendment (2026-04-23) — M4'–M10' scope correction
+
+Hands-on inspection during M4 and a follow-up Oracle consult revealed that several "near-identical" entries in the surface-comparison table above are *named* the same as `abdp` types but model fundamentally different concepts. The migration plan is therefore revised as follows. The original architectural decision (Option C — adapter layer) stands; only the per-milestone scope changes.
+
+**Binding scope corrections:**
+
+- **`state/{bronze,silver,gold}.py` are NOT replaced.** `abdp.data.{Bronze,Silver,Gold}Contract` are abstract structural `Protocol[RowT]` types with only `manifest` / `rows`. The local schemas are concrete Pydantic models for the Korean apartment domain (e.g. `BronzeAptTransaction` carries 32 MOLIT fields). They remain younggeul-owned.
+- **`storage/snapshot.SnapshotManifest` is NOT replaced.** `abdp.data.SnapshotManifest` is a per-tier UUID-keyed dataclass with parent-pointer lineage; ours is a Pydantic multi-table dataset manifest with sha256-derived `dataset_snapshot_id`. Different concept under the same name. It remains younggeul-owned.
+- **`connectors/{retry,manifest,protocol}` adaptation is permanently abandoned** (issue #238 closed). `abdp.core.retry` is a decorator factory with a different invocation contract; `abdp.core.ManifestFactory` produces abdp `SnapshotManifest`, not `BronzeIngestManifest`. Only `connectors/hashing.sha256_payload` was successfully delegated to `abdp.core.stable_hash` (M3, merged).
+- **M10 no longer flips the default backend or targets ~600 LOC of deletions.** The success gate becomes "framework logic adopted where semantics actually match, with parity tests covering each adopted surface."
+
+**Revised milestone map (M-prefixes are internal IDs only; not present in issue titles):**
+
+| # | Issue | Revised deliverable |
+|---|---|---|
+| M4' | [#239](https://github.com/kpubdata-lab/younggeul/issues/239) | `_compat.data` re-exports of `Bronze/Silver/GoldContract`, `SnapshotTier`, `AbdpSnapshotManifest` only. Schemas + storage manifest stay local. |
+| M5' | [#242](https://github.com/kpubdata-lab/younggeul/issues/242) | LangGraph run → `abdp.evidence.AuditLog` adapter. |
+| M6' | [#243](https://github.com/kpubdata-lab/younggeul/issues/243) | `--render abdp\|legacy` CLI flag using `abdp.reporting.render_{json,markdown}_report`. |
+| M7' | [#240](https://github.com/kpubdata-lab/younggeul/issues/240) | Simulation fit-gap matrix + runner-only adapters (no schema replacement). |
+| M8' | [#241](https://github.com/kpubdata-lab/younggeul/issues/241) | Expanded parity suite covering every adopted surface. |
+| M9' | [#244](https://github.com/kpubdata-lab/younggeul/issues/244) | Shadow-mode `ScenarioRunner` only. LangGraph stays the default execution engine. |
+| M10' | [#245](https://github.com/kpubdata-lab/younggeul/issues/245) | Selective-adoption finalization. **No default flip.** Remove only dead shims that selective adoption made unreachable. |
+
+The `YOUNGGEUL_CORE_BACKEND={local,abdp}` flag introduced in M2 still selects between local and adapter-routed code paths where adoption succeeded; the flag's default remains `local` indefinitely.
+
 ## References
 
 - Epic: [#235 — Adopt abdp framework for younggeul_core](https://github.com/kpubdata-lab/younggeul/issues/235)


### PR DESCRIPTION
Closes #239. Refs epic #235, ADR-012.

## What this PR does
Introduces `younggeul_core._compat.data` — a tiny module with lazy `__getattr__` re-exports of:

- `abdp.data.BronzeContract`
- `abdp.data.SilverContract`
- `abdp.data.GoldContract`
- `abdp.data.SnapshotTier`
- `abdp.data.SnapshotManifest as AbdpSnapshotManifest`

These give M5' (LangGraph → `AuditLog` adapter) and M6' (`--render abdp\|legacy` CLI) a single typing handle for "any framework artifact" without forcing every importer to depend on `abdp`.

## Why this is a re-export, NOT a delegation

Hands-on inspection during early M4 work and a follow-up Oracle consult revealed that abdp's data surface is **named** like ours but models a fundamentally different concept:

| Surface | abdp | younggeul |
|---|---|---|
| `Bronze/Silver/GoldContract` | abstract `Protocol[RowT]` (`manifest` + `rows` only) | concrete Pydantic schemas; e.g. `BronzeAptTransaction` carries 32 MOLIT fields |
| `SnapshotManifest` | per-tier UUID dataclass with parent-pointer lineage | Pydantic multi-table dataset manifest with sha256-derived `dataset_snapshot_id` |

Replacing the local types with abdp's would drop all domain validation and rewrite the integrity model. So per the **ADR-012 amendment** added in this PR (M4'–M10' scope correction):

- `state/{bronze,silver,gold}` and `storage/snapshot.SnapshotManifest` stay younggeul-owned.
- M10 no longer flips the default backend or targets ~600 LOC of deletions.
- The success gate becomes "framework logic adopted where semantics actually match, with parity tests covering each adopted surface."

A guardrail test (`test_compat_data_aliases_are_not_local_snapshot_manifest`) asserts `AbdpSnapshotManifest is not LocalSnapshotManifest` to make the non-equivalence mechanically enforced.

## Files

- `core/src/younggeul_core/_compat/data.py` — new (70 lines, lazy re-exports + scope docstring).
- `core/tests/contract/test_compat_data_aliases.py` — new (3 tests: identity, guardrail, AttributeError).
- `docs/adr/012-abdp-backed-core.md` — appended "Amendment (2026-04-23) — M4'–M10' scope correction" section.
- `README.md` — updated abdp-backend section to remove the planned default flip.

## Verification
```
pytest core/tests/contract/        →  165 passed
pytest -m "not slow and not integration"  →  1,254 passed (3 pre-existing live-MOLIT failures unrelated; ADR-010 IP block)
mypy core/src/ apps/kr-seoul-apartment/src/  →  Success: no issues found in 98 source files
ruff check core/                   →  All checks passed!
ruff format --check core/          →  clean
```

## Out of scope (intentionally not here)
- Schema or storage-manifest replacement (per scope correction above).
- `connectors/{retry,manifest,protocol}` adaptation (will be closed as `wontfix` on #238 after this PR merges, per Oracle).
- Audit log adapter (M5' / #242), CLI render flag (M6' / #243).