### PR TITLE
test(ci): expand parity coverage to local+abdp matrix and add M7' forbidden-pattern guardrails (#241)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        backend:
+          - name: local
+            extras: "dev,kr-seoul-apartment"
+          - name: abdp
+            extras: "dev,kr-seoul-apartment,abdp"
+    name: test (${{ matrix.backend.name }} backend)
+    env:
+      YOUNGGEUL_CORE_BACKEND: ${{ matrix.backend.name }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -14,11 +25,11 @@ jobs:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@v7
       - name: Install dependencies
-        run: uv pip install --system -e ".[dev,kr-seoul-apartment]"
+        run: uv pip install --system -e ".[${{ matrix.backend.extras }}]"
       - name: Run unit tests
         run: pytest -m "not slow and not integration" --cov --cov-report=xml
       - name: Upload coverage
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-report
+          name: coverage-report-${{ matrix.backend.name }}
           path: coverage.xml

--- a/core/tests/contract/test_compat_guardrails.py
+++ b/core/tests/contract/test_compat_guardrails.py
@@ -1,0 +1,87 @@
+"""Guardrail tests for the M7' fit-gap forbidden-patterns list.
+
+These tests fail loudly if any pre-M9' code path starts synthesizing
+public IDs (Seed, scenario_key, snapshot_id UUID, proposal_id, segment
+IDs) or re-exporting `abdp.simulation` Protocols. See
+`docs/architecture/abdp-simulation-fit-gap.md` Section 5.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_compat_does_not_export_abdp_simulation_protocols() -> None:
+    """`younggeul_core._compat` MUST NOT re-export any abdp.simulation Protocol
+    or the SimulationState/SnapshotRef dataclasses. All of those carry
+    public-ID-bearing fields whose values can only be minted under the M9'
+    shadow ScenarioRunner with real provenance."""
+    forbidden = {
+        "ScenarioSpec",
+        "SegmentState",
+        "ParticipantState",
+        "ActionProposal",
+        "SnapshotRef",
+        "SimulationState",
+        "Seed",
+    }
+
+    if importlib.util.find_spec("abdp") is None:
+        pytest.skip("abdp not installed")
+
+    compat = importlib.import_module("younggeul_core._compat")
+    for name in forbidden:
+        assert not hasattr(compat, name), (
+            f"younggeul_core._compat must not expose `{name}` pre-M9' "
+            "(see docs/architecture/abdp-simulation-fit-gap.md §5)"
+        )
+
+    for sub in ("data", "reporting"):
+        mod = importlib.import_module(f"younggeul_core._compat.{sub}")
+        for name in forbidden:
+            assert not hasattr(mod, name), (
+                f"younggeul_core._compat.{sub} must not expose `{name}` pre-M9' "
+                "(see docs/architecture/abdp-simulation-fit-gap.md §5)"
+            )
+
+
+def test_younggeul_core_state_simulation_does_not_import_abdp_simulation() -> None:
+    """`younggeul_core.state.simulation` MUST stay free of any
+    `abdp.simulation` import until M9'. Importing it would either pull
+    in Protocol types we are forbidden to expose or signal an in-progress
+    swap that bypasses the gating."""
+    src = (REPO_ROOT / "core" / "src" / "younggeul_core" / "state" / "simulation.py").read_text(encoding="utf-8")
+    assert "abdp.simulation" not in src, (
+        "state/simulation.py must not import from abdp.simulation pre-M9' "
+        "(see docs/architecture/abdp-simulation-fit-gap.md §5)"
+    )
+    assert "from abdp" not in src, (
+        "state/simulation.py must not import from any abdp.* module pre-M9' "
+        "(see docs/architecture/abdp-simulation-fit-gap.md §5)"
+    )
+
+
+def test_simulate_cli_does_not_expose_seed_flag() -> None:
+    """The `simulate` CLI MUST NOT advertise a `--seed` flag pre-M9'.
+    Adding one would publish a cross-engine determinism contract we do
+    not yet implement (see fit-gap §2 hard constraints, item 2)."""
+    result = subprocess.run(
+        [sys.executable, "-m", "younggeul_app_kr_seoul_apartment.cli", "simulate", "--help"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "--seed" not in result.stdout, (
+        "simulate CLI must not expose --seed pre-M9' (see docs/architecture/abdp-simulation-fit-gap.md §5)"
+    )
+    assert "--scenario-key" not in result.stdout, (
+        "simulate CLI must not expose --scenario-key pre-M9' (see docs/architecture/abdp-simulation-fit-gap.md §5)"
+    )


### PR DESCRIPTION
## Summary

Per the [M7' fit-gap](docs/architecture/abdp-simulation-fit-gap.md#5-forbidden-patterns-m7m8) and the Oracle-revised M8' scope, the parity suite ships in two parts.

Closes #241.

### 1. CI matrix (`.github/workflows/test.yml`)

The unit job now fans out over `backend={local, abdp}`, installs the appropriate extras, and runs `pytest` with `YOUNGGEUL_CORE_BACKEND` set. This is what makes the existing `pytest.importorskip('abdp')`-gated parity tests (`test_compat_data_aliases`, `test_compat_hashing_parity`, `test_compat_reporting`, `test_cli_render_flag`) actually execute in CI instead of being silently skipped, and verifies the local backend remains byte-identical to v0.3.0.

### 2. Forbidden-pattern guardrails (`core/tests/contract/test_compat_guardrails.py`)

Three assertions that fail loudly if any pre-M9' code path drifts from the M7' rules:

- `_compat` must not re-export `ScenarioSpec` / `SegmentState` / `ParticipantState` / `ActionProposal` / `SnapshotRef` / `SimulationState` / `Seed`
- `state/simulation.py` must not import from `abdp`
- `simulate` CLI must not advertise `--seed` or `--scenario-key`

## Deliberately not in scope (per M7' fit-gap)

- No parity tests for sim-overlap models — they don't field-level overlap and any such test would either fail or force forbidden ID synthesis to pass.
- No `AuditLog` parity test — deferred to M9' ([#244](https://github.com/kpubdata-lab/younggeul/issues/244)).

## Verification

- `ruff check` / `format`: ✅
- `mypy`: ✅
- `YOUNGGEUL_CORE_BACKEND=local pytest`: **1264 passed**
- `YOUNGGEUL_CORE_BACKEND=abdp pytest`: **1264 passed**
- 3 pre-existing live-MOLIT failures unrelated (ADR-010 IP block).