### PR TITLE
feat(core): add M9'-a internal ID derivation helpers for shadow runner adapter (#244)

### DIFF
--- a/core/src/younggeul_core/_compat/ids.py
+++ b/core/src/younggeul_core/_compat/ids.py
@@ -1,0 +1,172 @@
+"""M9'-a: ID derivation and ScenarioContract normalization for the
+shadow runner adapter (see ADR-012 + docs/architecture/abdp-simulation-fit-gap.md).
+
+These helpers exist so the M9'-b adapter can produce a real
+`abdp.scenario.ScenarioRun` whose `scenario_key`, `seed`, and
+`SnapshotRef.snapshot_id` carry deterministic, internal-only values
+derived from younggeul's existing canonical sources (sha256 snapshot
+digests; ScenarioSpec contract). Per the Oracle ruling on 2026-04-23:
+
+  * `Seed` is reserved for future RNG-bearing simulation work; today it
+    is a constant `0`. It is NOT derived from any user-facing identity,
+    and there is no `--seed` CLI flag.
+  * `scenario_key` is a versioned full-hash of a normalized
+    `ScenarioContract v1`, NOT the field shape of `ScenarioSpec`. It is
+    not truncated; the full sha256 hex is preserved.
+  * `snapshot_uuid` is generated via `uuid5(YOUNGGEUL_SNAPSHOT_NAMESPACE,
+    sha256_hex)` and paired with an explicit per-run lookup map so the
+    sha256 content-address (younggeul's source of truth) is recoverable
+    at any adapter boundary. UUID is never canonical outside this layer.
+
+All three values are runner-internal: never logged in markdown reports,
+never surfaced in CLI text, never persisted as primary keys in
+younggeul-owned storage. They appear only inside abdp `ScenarioRun` /
+`AuditLog` / abdp JSON artifacts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+    from younggeul_core.state.simulation import ScenarioSpec
+
+SCENARIO_KEY_VERSION: Final[str] = "yg-scenario-v1"
+
+YOUNGGEUL_SNAPSHOT_NAMESPACE: Final[uuid.UUID] = uuid.UUID("8b2d6b06-6f4f-5b0a-9f2e-abc123450001")
+"""Stable UUID5 namespace for projecting younggeul sha256 snapshot
+digests to abdp `SnapshotRef.snapshot_id` UUIDs. Generated once and
+frozen here; rotating it would invalidate every previously generated
+`snapshot_uuid` and is therefore forbidden without a new
+`SCENARIO_KEY_VERSION`-style versioning scheme."""
+
+DEFAULT_SHADOW_SEED: Final[int] = 0
+"""Seed value used by the M9' shadow `ScenarioRun`. younggeul has no
+RNG-seeded simulation behavior today, so the seed has no entropy role
+and is a constant. If randomness is later introduced, the seed must
+become an explicit cross-engine input before any parity claim
+continues; do not silently lift a non-zero default here."""
+
+
+def normalize_scenario_contract(spec: ScenarioSpec) -> dict[str, Any]:
+    """Project a younggeul `ScenarioSpec` into the canonical, sortable
+    `ScenarioContract v1` mapping the `scenario_key` is hashed from.
+
+    The mapping is deliberately a small, versioned shape distinct from
+    `ScenarioSpec` itself so future field additions to `ScenarioSpec`
+    do not silently change `scenario_key` for unrelated reasons.
+    """
+    return {
+        "version": 1,
+        "scenario_name": spec.scenario_name,
+        "target_gus": sorted(spec.target_gus),
+        "target_period_start": spec.target_period_start.isoformat(),
+        "target_period_end": spec.target_period_end.isoformat(),
+        "shocks": sorted(
+            (
+                {
+                    "shock_type": s.shock_type,
+                    "description": s.description,
+                    "magnitude": s.magnitude,
+                    "target_segments": sorted(s.target_segments),
+                }
+                for s in spec.shocks
+            ),
+            key=lambda d: (d["shock_type"], d["description"], d["magnitude"]),
+        ),
+    }
+
+
+def derive_scenario_key(spec: ScenarioSpec) -> str:
+    """Derive a deterministic, versioned `scenario_key` for the shadow
+    `ScenarioRun`. Stable across re-runs of the same scenario contract;
+    sensitive to roster/shock changes via `normalize_scenario_contract`.
+
+    Returns a string of shape ``"yg-scenario-v1:<sha256hex>"``. Full
+    digest is preserved (no truncation) per the M9' design ruling.
+    """
+    contract = normalize_scenario_contract(spec)
+    payload = json.dumps(contract, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    digest = hashlib.sha256(payload).hexdigest()
+    return f"{SCENARIO_KEY_VERSION}:{digest}"
+
+
+def derive_snapshot_uuid(sha256_hex: str) -> uuid.UUID:
+    """Project a younggeul sha256 snapshot digest to an abdp
+    `SnapshotRef.snapshot_id` UUID via `uuid5` over a frozen namespace.
+
+    `uuid5` is deterministic and one-way; pair it with a
+    `SnapshotIdRegistry` (below) to recover the original sha256 hex
+    when projecting back at the adapter boundary.
+    """
+    if not isinstance(sha256_hex, str) or len(sha256_hex) != 64:
+        raise ValueError(
+            f"sha256_hex must be a 64-char hex digest; got {len(sha256_hex) if isinstance(sha256_hex, str) else type(sha256_hex).__name__}"
+        )
+    try:
+        int(sha256_hex, 16)
+    except ValueError as exc:
+        raise ValueError(f"sha256_hex must be hex-only; got non-hex characters in {sha256_hex!r}") from exc
+    return uuid.uuid5(YOUNGGEUL_SNAPSHOT_NAMESPACE, sha256_hex.lower())
+
+
+class SnapshotIdRegistry:
+    """Per-run bijection between younggeul sha256 snapshot digests and
+    the abdp `SnapshotRef.snapshot_id` UUIDs derived from them.
+
+    Populated at adapter creation time; consulted whenever the adapter
+    projects an abdp `SnapshotRef` back to a younggeul sha256
+    content-address. Without this map, the `uuid5` projection alone is
+    not invertible.
+    """
+
+    __slots__ = ("_uuid_to_sha", "_sha_to_uuid")
+
+    def __init__(self) -> None:
+        self._uuid_to_sha: dict[uuid.UUID, str] = {}
+        self._sha_to_uuid: dict[str, uuid.UUID] = {}
+
+    def register(self, sha256_hex: str) -> uuid.UUID:
+        """Idempotently register a sha256 digest and return its UUID."""
+        normalized = sha256_hex.lower()
+        existing = self._sha_to_uuid.get(normalized)
+        if existing is not None:
+            return existing
+        snapshot_uuid = derive_snapshot_uuid(normalized)
+        self._sha_to_uuid[normalized] = snapshot_uuid
+        self._uuid_to_sha[snapshot_uuid] = normalized
+        return snapshot_uuid
+
+    def sha256_for(self, snapshot_uuid: uuid.UUID) -> str:
+        """Recover the sha256 digest for a previously registered UUID."""
+        try:
+            return self._uuid_to_sha[snapshot_uuid]
+        except KeyError as exc:
+            raise KeyError(
+                f"snapshot_uuid {snapshot_uuid} is not registered; the abdp "
+                "adapter must register every sha256 digest it projects"
+            ) from exc
+
+    def __contains__(self, key: object) -> bool:
+        if isinstance(key, uuid.UUID):
+            return key in self._uuid_to_sha
+        if isinstance(key, str):
+            return key.lower() in self._sha_to_uuid
+        return False
+
+    def __len__(self) -> int:
+        return len(self._uuid_to_sha)
+
+
+__all__ = [
+    "DEFAULT_SHADOW_SEED",
+    "SCENARIO_KEY_VERSION",
+    "SnapshotIdRegistry",
+    "YOUNGGEUL_SNAPSHOT_NAMESPACE",
+    "derive_scenario_key",
+    "derive_snapshot_uuid",
+    "normalize_scenario_contract",
+]

--- a/core/tests/contract/test_compat_ids.py
+++ b/core/tests/contract/test_compat_ids.py
@@ -1,0 +1,204 @@
+"""M9'-a contract tests for `_compat.ids`.
+
+Verifies the deterministic ID-derivation contract that the M9'-b shadow
+runner adapter will rely on. Per the Oracle ruling on 2026-04-23 and
+the M7' fit-gap doc:
+
+  * `derive_scenario_key` is a versioned full-hash of a normalized
+    `ScenarioContract v1` — stable across re-runs of the same contract,
+    sensitive to roster/shock changes, never truncated.
+  * `derive_snapshot_uuid` is `uuid5(NAMESPACE, sha256_hex)` — one-way,
+    deterministic, paired with `SnapshotIdRegistry` for recovery.
+  * `DEFAULT_SHADOW_SEED == 0` — reserved for future RNG work; today a
+    constant with no entropy role.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+import pytest
+
+from younggeul_core._compat.ids import (
+    DEFAULT_SHADOW_SEED,
+    SCENARIO_KEY_VERSION,
+    SnapshotIdRegistry,
+    YOUNGGEUL_SNAPSHOT_NAMESPACE,
+    derive_scenario_key,
+    derive_snapshot_uuid,
+    normalize_scenario_contract,
+)
+from younggeul_core.state.simulation import ScenarioSpec, Shock
+
+
+def _spec(**overrides: object) -> ScenarioSpec:
+    base: dict[str, object] = {
+        "scenario_name": "test",
+        "target_gus": ["11680", "11440"],
+        "target_period_start": date(2025, 3, 1),
+        "target_period_end": date(2025, 6, 1),
+        "shocks": [],
+    }
+    base.update(overrides)
+    return ScenarioSpec(**base)  # type: ignore[arg-type]
+
+
+class TestSeed:
+    def test_default_shadow_seed_is_zero(self) -> None:
+        """Today's seed has no entropy role; constant 0 prevents any
+        accidental claim of cross-engine RNG determinism."""
+        assert DEFAULT_SHADOW_SEED == 0
+        assert isinstance(DEFAULT_SHADOW_SEED, int)
+
+
+class TestNormalizeScenarioContract:
+    def test_target_gus_are_sorted(self) -> None:
+        """Re-ordering input gus must not change the contract — the
+        contract shape, not the ScenarioSpec field order, is what the
+        scenario_key hashes."""
+        a = normalize_scenario_contract(_spec(target_gus=["11680", "11440"]))
+        b = normalize_scenario_contract(_spec(target_gus=["11440", "11680"]))
+        assert a == b
+        assert a["target_gus"] == ["11440", "11680"]
+
+    def test_versioned(self) -> None:
+        contract = normalize_scenario_contract(_spec())
+        assert contract["version"] == 1
+
+    def test_dates_are_isoformat(self) -> None:
+        contract = normalize_scenario_contract(_spec())
+        assert contract["target_period_start"] == "2025-03-01"
+        assert contract["target_period_end"] == "2025-06-01"
+
+    def test_shocks_are_sorted_and_normalized(self) -> None:
+        s1 = Shock(
+            shock_type="interest_rate",
+            description="rate hike",
+            magnitude=0.5,
+            target_segments=["a", "b"],
+        )
+        s2 = Shock(
+            shock_type="demand",
+            description="supply cut",
+            magnitude=-0.3,
+            target_segments=["c"],
+        )
+        a = normalize_scenario_contract(_spec(shocks=[s1, s2]))
+        b = normalize_scenario_contract(_spec(shocks=[s2, s1]))
+        assert a == b
+        assert [s["shock_type"] for s in a["shocks"]] == ["demand", "interest_rate"]
+
+
+class TestDeriveScenarioKey:
+    def test_format_is_versioned_full_hash(self) -> None:
+        """Per Oracle: scenario_key MUST NOT be truncated. Format is
+        ``yg-scenario-v1:<sha256hex>`` with a 64-char hex digest."""
+        key = derive_scenario_key(_spec())
+        prefix, _, digest = key.partition(":")
+        assert prefix == SCENARIO_KEY_VERSION == "yg-scenario-v1"
+        assert len(digest) == 64
+        assert int(digest, 16) >= 0
+
+    def test_deterministic_across_field_order(self) -> None:
+        a = derive_scenario_key(_spec(target_gus=["11680", "11440"]))
+        b = derive_scenario_key(_spec(target_gus=["11440", "11680"]))
+        assert a == b
+
+    def test_sensitive_to_scenario_name(self) -> None:
+        a = derive_scenario_key(_spec(scenario_name="alpha"))
+        b = derive_scenario_key(_spec(scenario_name="beta"))
+        assert a != b
+
+    def test_sensitive_to_period(self) -> None:
+        a = derive_scenario_key(_spec(target_period_end=date(2025, 6, 1)))
+        b = derive_scenario_key(_spec(target_period_end=date(2025, 7, 1)))
+        assert a != b
+
+    def test_sensitive_to_shocks(self) -> None:
+        no_shock = derive_scenario_key(_spec())
+        with_shock = derive_scenario_key(
+            _spec(
+                shocks=[
+                    Shock(
+                        shock_type="interest_rate",
+                        description="d",
+                        magnitude=0.1,
+                        target_segments=[],
+                    )
+                ]
+            )
+        )
+        assert no_shock != with_shock
+
+
+class TestDeriveSnapshotUuid:
+    def test_namespace_is_frozen(self) -> None:
+        """Rotating the namespace would invalidate every previously
+        derived snapshot_uuid; freeze the literal here."""
+        assert YOUNGGEUL_SNAPSHOT_NAMESPACE == uuid.UUID("8b2d6b06-6f4f-5b0a-9f2e-abc123450001")
+
+    def test_is_uuid5(self) -> None:
+        sha = "a" * 64
+        u = derive_snapshot_uuid(sha)
+        assert u == uuid.uuid5(YOUNGGEUL_SNAPSHOT_NAMESPACE, sha)
+        assert u.version == 5
+
+    def test_deterministic(self) -> None:
+        sha = "0123456789abcdef" * 4
+        assert derive_snapshot_uuid(sha) == derive_snapshot_uuid(sha)
+
+    def test_case_insensitive(self) -> None:
+        assert derive_snapshot_uuid("ABCDEF" + "0" * 58) == derive_snapshot_uuid("abcdef" + "0" * 58)
+
+    def test_distinct_inputs_distinct_uuids(self) -> None:
+        assert derive_snapshot_uuid("a" * 64) != derive_snapshot_uuid("b" * 64)
+
+    @pytest.mark.parametrize("bad", ["", "abc", "z" * 64, "a" * 63, "a" * 65])
+    def test_rejects_non_sha256_input(self, bad: str) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            derive_snapshot_uuid(bad)
+
+
+class TestSnapshotIdRegistry:
+    def test_register_returns_derived_uuid(self) -> None:
+        reg = SnapshotIdRegistry()
+        sha = "a" * 64
+        u = reg.register(sha)
+        assert u == derive_snapshot_uuid(sha)
+
+    def test_register_is_idempotent(self) -> None:
+        reg = SnapshotIdRegistry()
+        sha = "a" * 64
+        assert reg.register(sha) == reg.register(sha)
+        assert len(reg) == 1
+
+    def test_round_trip_uuid_to_sha(self) -> None:
+        reg = SnapshotIdRegistry()
+        sha = "abcdef0123456789" * 4
+        u = reg.register(sha)
+        assert reg.sha256_for(u) == sha
+
+    def test_unregistered_uuid_raises(self) -> None:
+        reg = SnapshotIdRegistry()
+        with pytest.raises(KeyError, match="not registered"):
+            reg.sha256_for(uuid.uuid4())
+
+    def test_contains(self) -> None:
+        reg = SnapshotIdRegistry()
+        sha = "a" * 64
+        u = reg.register(sha)
+        assert sha in reg
+        assert sha.upper() in reg
+        assert u in reg
+        assert "missing" not in reg
+        assert uuid.uuid4() not in reg
+        assert 42 not in reg
+
+    def test_two_distinct_snapshots(self) -> None:
+        reg = SnapshotIdRegistry()
+        u1 = reg.register("a" * 64)
+        u2 = reg.register("b" * 64)
+        assert u1 != u2
+        assert reg.sha256_for(u1) != reg.sha256_for(u2)
+        assert len(reg) == 2


### PR DESCRIPTION
## Summary

First of three M9' PRs (M9'-a / M9'-b / M9'-c). Per the [Oracle design ruling on 2026-04-23](https://github.com/kpubdata-lab/younggeul/issues/244), M9' adopts a real shadow `ScenarioRunner` producing a real `abdp.scenario.ScenarioRun` (and projected `abdp.evidence.AuditLog`, absorbed from the deferred [#242](https://github.com/kpubdata-lab/younggeul/issues/242)). M9'-a lands the deterministic ID-derivation primitives the M9'-b adapter will consume.

Tracks #244.

## What ships

`core/src/younggeul_core/_compat/ids.py`:

| Helper | Decision |
|---|---|
| `DEFAULT_SHADOW_SEED = 0` | younggeul has no RNG-seeded simulation behavior today; seed has no entropy role. Reserved for future RNG work. **No `--seed` CLI flag.** |
| `normalize_scenario_contract()` | Projects `ScenarioSpec` → versioned `ScenarioContract v1` mapping (sorted gus + shocks, ISO dates). Stable across re-runs, insensitive to `ScenarioSpec` field-order churn. |
| `derive_scenario_key()` | Returns `yg-scenario-v1:<sha256hex>`. Full 64-char digest preserved per Oracle (no truncation). |
| `derive_snapshot_uuid()` | `uuid5(YOUNGGEUL_SNAPSHOT_NAMESPACE, sha256_hex)`. Deterministic, one-way. sha256 hex remains canonical. |
| `SnapshotIdRegistry` | Explicit per-run bijection (uuid ↔ sha256_hex) so the adapter can recover content-address at any boundary. |

26 contract tests cover: seed constancy, contract-shape order-insensitivity, `scenario_key` versioning + sensitivity to name/period/shocks, uuid5 namespace freeze, registry idempotence, round-trip recovery, hex validation rejection.

## Internal-only IDs

Per Oracle (D), `Seed` / `scenario_key` / `snapshot_uuid` are runner-internal — never logged in markdown reports, never surfaced in CLI text, never persisted as primary keys in younggeul-owned storage. The M8' guardrails ([`test_compat_guardrails.py`](core/tests/contract/test_compat_guardrails.py)) remain green: nothing in this PR exposes them through `_compat` public surfaces, `state/simulation.py`, or CLI flags.

## Verification

- `ruff check` / `format`: ✅
- `mypy`: ✅ (100 source files)
- `YOUNGGEUL_CORE_BACKEND=local pytest`: **1290 passed**
- `YOUNGGEUL_CORE_BACKEND=abdp pytest`: **1290 passed**
- 3 pre-existing live-MOLIT failures unrelated.

## Up next

- **M9'-b**: thin Agent / ActionResolver adapters over real younggeul decision logic; produce a real `ScenarioRun` and project `AuditLog` from it (absorbs the AuditLog work deferred from #242).
- **M9'-c**: opt-in shadow-mode CLI flag + canned end-to-end integration test producing a real `AuditLog` from a deterministic simulation.