### PR TITLE
feat(compat): abdp scenario-runner adapter primitives (M9'-b, #244)

### DIFF
--- a/core/src/younggeul_core/_compat/scenario.py
+++ b/core/src/younggeul_core/_compat/scenario.py
@@ -1,0 +1,339 @@
+"""abdp scenario-runner adapter primitives (M9'-b).
+
+This module ships the *generic, app-agnostic* building blocks needed to drive
+:mod:`abdp.scenario.ScenarioRunner` over data produced by the existing
+younggeul LangGraph pipeline. The primitives live in ``core`` because they
+operate purely on core's Pydantic projection types
+(:mod:`younggeul_core.state.simulation`) and the abdp public contracts.
+
+Per ADR-012 and Oracle's binding M9' design ruling:
+
+* The LangGraph ``GraphState`` (in ``apps/``) remains the canonical state
+  representation. ``SimulationState`` (here, in ``core``) and abdp's
+  :class:`abdp.simulation.SimulationState` are runner-boundary projections.
+* Adapters are *thin* wrappers - they MUST NOT re-implement younggeul
+  decision or resolution logic. Forking parity is forbidden.
+* Synthesized identifiers (Seed, scenario_key, snapshot UUID, proposal_id)
+  are runner-internal and never surface in user-facing CLI text or
+  younggeul-owned PK storage.
+
+The adapter classes here are intentionally generic (callable-backed).
+The actual wiring of younggeul's ``ParticipantPolicy.decide`` and the
+``round_resolver`` math into these adapters is performed in M9'-c at the
+``apps/kr-seoul-apartment/`` layer (which is permitted to depend on core).
+That layered split preserves the strict ``core <- apps`` dependency rule.
+"""
+
+from __future__ import annotations
+
+# pyright: reportMissingImports=false
+
+import hashlib
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Final, Generic, Literal, TypeVar, cast
+from uuid import UUID, uuid5
+
+from younggeul_core.state.simulation import (
+    ActionProposal as YgActionProposal,
+)
+from younggeul_core.state.simulation import (
+    ParticipantState as YgParticipantState,
+)
+from younggeul_core.state.simulation import (
+    SegmentState as YgSegmentState,
+)
+
+from younggeul_core._compat import require_abdp
+from younggeul_core._compat.ids import (
+    DEFAULT_SHADOW_SEED,
+    SnapshotIdRegistry,
+    YOUNGGEUL_SNAPSHOT_NAMESPACE,
+)
+
+__all__ = [
+    "PROPOSAL_ID_NAMESPACE",
+    "AbdpActionAdapter",
+    "AbdpParticipantAdapter",
+    "AbdpSegmentAdapter",
+    "CallableAgent",
+    "CallableResolver",
+    "derive_proposal_id",
+    "project_audit_log",
+    "to_abdp_simulation_state",
+    "to_abdp_snapshot_ref",
+]
+
+# UUID5 namespace for synthesized abdp ActionProposal.proposal_id values.
+# Frozen literal: rotating it would invalidate previously-derived proposal_ids
+# and break audit-log replay determinism.
+PROPOSAL_ID_NAMESPACE: Final[UUID] = UUID("8b2d6b06-6f4f-5b0a-9f2e-abc123450002")
+
+# Default tier when projecting younggeul SnapshotRef -> abdp SnapshotRef.
+# younggeul's snapshot tier metadata is not exposed on the core Pydantic
+# SnapshotRef, so we use "silver" as the safe default (matches the typical
+# tier of normalized data fed into the simulation plane).
+_AbdpSnapshotTier = Literal["bronze", "silver", "gold"]
+_DEFAULT_ABDP_SNAPSHOT_TIER: Final[_AbdpSnapshotTier] = "silver"
+
+
+@dataclass(frozen=True, slots=True)
+class AbdpSegmentAdapter:
+    """abdp.simulation.SegmentState Protocol adapter over core SegmentState.
+
+    Exposes ``segment_id`` (= ``gu_code``) and ``participant_ids`` (caller
+    supplies, since younggeul models segment <-> participant association
+    in the round resolver, not on the segment itself). The wrapped
+    ``inner`` is preserved for downstream consumers that need the
+    full Pydantic data.
+    """
+
+    segment_id: str
+    participant_ids: tuple[str, ...]
+    inner: YgSegmentState
+
+    @classmethod
+    def from_core(
+        cls,
+        segment: YgSegmentState,
+        *,
+        participant_ids: Iterable[str] = (),
+    ) -> AbdpSegmentAdapter:
+        return cls(
+            segment_id=segment.gu_code,
+            participant_ids=tuple(participant_ids),
+            inner=segment,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AbdpParticipantAdapter:
+    """abdp.simulation.ParticipantState Protocol adapter over core ParticipantState."""
+
+    participant_id: str
+    inner: YgParticipantState
+
+    @classmethod
+    def from_core(cls, participant: YgParticipantState) -> AbdpParticipantAdapter:
+        return cls(
+            participant_id=participant.participant_id,
+            inner=participant,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AbdpActionAdapter:
+    """abdp.simulation.ActionProposal Protocol adapter over core ActionProposal.
+
+    Maps:
+
+    * ``proposal_id`` <- :func:`derive_proposal_id` (deterministic uuid5).
+    * ``actor_id``    <- core ``agent_id``.
+    * ``action_key``  <- core ``action_type``.
+    * ``payload``     <- ``model_dump(mode="json")`` of the wrapped action.
+    """
+
+    proposal_id: str
+    actor_id: str
+    action_key: str
+    payload: Mapping[str, Any]
+    inner: YgActionProposal
+
+    @classmethod
+    def from_core(cls, action: YgActionProposal) -> AbdpActionAdapter:
+        return cls(
+            proposal_id=str(derive_proposal_id(action)),
+            actor_id=action.agent_id,
+            action_key=action.action_type,
+            payload=action.model_dump(mode="json"),
+            inner=action,
+        )
+
+
+def derive_proposal_id(action: YgActionProposal) -> UUID:
+    """Derive a deterministic, runner-internal abdp proposal_id from a core ActionProposal.
+
+    The id is uuid5(:data:`PROPOSAL_ID_NAMESPACE`, "<agent_id>:<round_no>:<action_type>:<target_segment>:<sha256(reasoning_summary)>").
+
+    Stable across runs for the same logical proposal. Different proposals
+    from the same agent in the same round on the same segment are
+    disambiguated by ``reasoning_summary`` hashing - callers that need
+    stronger collision resistance should keep ``reasoning_summary``
+    deterministic per proposal.
+    """
+    reasoning_digest = hashlib.sha256(action.reasoning_summary.encode("utf-8")).hexdigest()
+    name = f"{action.agent_id}:{action.round_no}:{action.action_type}:{action.target_segment}:{reasoning_digest}"
+    return uuid5(PROPOSAL_ID_NAMESPACE, name)
+
+
+def to_abdp_snapshot_ref(
+    *,
+    sha256_hex: str,
+    storage_key: str,
+    registry: SnapshotIdRegistry,
+    tier: _AbdpSnapshotTier = _DEFAULT_ABDP_SNAPSHOT_TIER,
+) -> Any:
+    """Project a younggeul snapshot sha256 hex into an :class:`abdp.simulation.SnapshotRef`.
+
+    Registers the sha256 with the supplied :class:`SnapshotIdRegistry` so the
+    bijection (uuid <-> sha256) is preserved for the run. The abdp
+    ``SnapshotRef`` requires:
+
+    * ``snapshot_id``: UUID (we synthesize via uuid5 with
+      :data:`younggeul_core._compat.ids.YOUNGGEUL_SNAPSHOT_NAMESPACE`).
+    * ``tier``: one of ``"bronze"``, ``"silver"``, ``"gold"``.
+    * ``storage_key``: non-empty string.
+
+    Args:
+        sha256_hex: 64-char lowercase hex digest of the canonical snapshot.
+        storage_key: Caller-supplied storage path/key (non-empty).
+        registry: Registry that records the (uuid, sha256) bijection.
+        tier: abdp snapshot tier; defaults to ``"silver"``.
+
+    Returns:
+        An :class:`abdp.simulation.SnapshotRef` instance.
+    """
+    require_abdp()
+    from abdp.simulation import SnapshotRef as AbdpSnapshotRef  # type: ignore[import-not-found,unused-ignore]
+
+    snapshot_uuid = registry.register(sha256_hex)
+    return AbdpSnapshotRef(snapshot_id=snapshot_uuid, tier=tier, storage_key=storage_key)
+
+
+def to_abdp_simulation_state(
+    *,
+    segments: Iterable[YgSegmentState],
+    participants: Iterable[YgParticipantState],
+    snapshot_ref: Any,
+    pending_actions: Iterable[YgActionProposal] = (),
+    seed: int = DEFAULT_SHADOW_SEED,
+    step_index: int = 0,
+    segment_participants: Mapping[str, Iterable[str]] | None = None,
+) -> Any:
+    """Project core simulation pieces into a frozen :class:`abdp.simulation.SimulationState`.
+
+    Tuple ordering is preserved exactly as supplied by the caller so the
+    projection is deterministic. ``segment_participants`` lets the caller
+    record which participant ids belong to each segment (keyed by
+    ``segment.gu_code``); segments not present in the mapping receive an
+    empty ``participant_ids`` tuple.
+
+    Args:
+        segments: Core SegmentState instances (ordering preserved).
+        participants: Core ParticipantState instances (ordering preserved).
+        snapshot_ref: An :class:`abdp.simulation.SnapshotRef` from
+            :func:`to_abdp_snapshot_ref`.
+        pending_actions: Actions to carry as ``pending_actions`` on the
+            initial state (typically empty for shadow runs from a fresh
+            scenario).
+        seed: Runner-internal abdp Seed (default ``DEFAULT_SHADOW_SEED``).
+        step_index: Initial step index (default ``0``).
+        segment_participants: Optional mapping ``gu_code -> participant_ids``.
+
+    Returns:
+        A frozen :class:`abdp.simulation.SimulationState` instance.
+    """
+    require_abdp()
+    from abdp.core import Seed  # type: ignore[import-not-found,unused-ignore]
+    from abdp.simulation import SimulationState as AbdpSimulationState  # type: ignore[import-not-found,unused-ignore]
+
+    seg_part_map = {key: tuple(value) for key, value in (segment_participants or {}).items()}
+    segment_adapters = tuple(
+        AbdpSegmentAdapter.from_core(seg, participant_ids=seg_part_map.get(seg.gu_code, ())) for seg in segments
+    )
+    participant_adapters = tuple(AbdpParticipantAdapter.from_core(p) for p in participants)
+    pending_adapters = tuple(AbdpActionAdapter.from_core(a) for a in pending_actions)
+
+    return AbdpSimulationState(
+        step_index=step_index,
+        seed=cast(Any, Seed(seed)),
+        snapshot_ref=snapshot_ref,
+        segments=segment_adapters,
+        participants=participant_adapters,
+        pending_actions=pending_adapters,
+    )
+
+
+_S = TypeVar("_S")
+_P = TypeVar("_P")
+_A = TypeVar("_A")
+
+
+@dataclass(frozen=True, slots=True)
+class CallableAgent(Generic[_S, _P, _A]):
+    """Generic abdp.agents.Agent Protocol adapter wrapping a decide callable.
+
+    The wrapped callable receives an :class:`abdp.agents.AgentContext` and
+    must return an :class:`abdp.agents.AgentDecision`. younggeul-app
+    callables (M9'-c) translate the AgentContext into the form expected by
+    ``ParticipantPolicy.decide`` and project the result back.
+    """
+
+    agent_id: str
+    decide_fn: Callable[[Any], Any] = field(compare=False)
+
+    def decide(self, context: Any) -> Any:
+        return self.decide_fn(context)
+
+
+@dataclass(frozen=True, slots=True)
+class CallableResolver(Generic[_S, _P, _A]):
+    """Generic abdp.scenario.ActionResolver Protocol adapter wrapping a resolve callable.
+
+    The wrapped callable receives ``(state, proposals)`` (matching abdp's
+    ActionResolver.resolve signature) and must return the next
+    :class:`abdp.simulation.SimulationState`.
+
+    Per the abdp contract: implementations MUST NOT mutate the input
+    ``state``. The wrapped callable is responsible for upholding that.
+    """
+
+    resolve_fn: Callable[[Any, tuple[Any, ...]], Any] = field(compare=False)
+
+    def resolve(self, state: Any, proposals: tuple[Any, ...]) -> Any:
+        return self.resolve_fn(state, proposals)
+
+
+def project_audit_log(
+    *,
+    scenario_run: Any,
+    summary: Any,
+    evidence: tuple[Any, ...] = (),
+    claims: tuple[Any, ...] = (),
+) -> Any:
+    """Project an :class:`abdp.scenario.ScenarioRun` into an :class:`abdp.evidence.AuditLog`.
+
+    The abdp ``AuditLog.__post_init__`` enforces:
+
+    * ``scenario_key == run.scenario_key``
+    * ``seed == run.seed``
+
+    This helper passes the run's own ``scenario_key`` and ``seed`` through
+    so the invariants always hold. ``evidence`` and ``claims`` ordering is
+    preserved verbatim (abdp does not impose canonical ordering at this
+    layer; deterministic ordering is the caller's responsibility).
+
+    Args:
+        scenario_run: The :class:`abdp.scenario.ScenarioRun` produced by
+            :class:`abdp.scenario.ScenarioRunner`.
+        summary: An :class:`abdp.evaluation.summary.EvaluationSummary`.
+        evidence: Tuple of :class:`abdp.evidence.EvidenceRecord` (default empty).
+        claims: Tuple of :class:`abdp.evidence.ClaimRecord` (default empty).
+
+    Returns:
+        A frozen :class:`abdp.evidence.AuditLog` instance.
+    """
+    require_abdp()
+    from abdp.evidence import AuditLog  # type: ignore[import-not-found,unused-ignore]
+
+    return AuditLog(
+        scenario_key=scenario_run.scenario_key,
+        seed=scenario_run.seed,
+        run=scenario_run,
+        summary=summary,
+        evidence=evidence,
+        claims=claims,
+    )
+
+
+__all__ += ["DEFAULT_SHADOW_SEED", "YOUNGGEUL_SNAPSHOT_NAMESPACE"]

--- a/core/tests/contract/test_compat_scenario.py
+++ b/core/tests/contract/test_compat_scenario.py
@@ -1,0 +1,465 @@
+"""M9'-b contract tests for `_compat.scenario`.
+
+Verifies the abdp scenario-runner adapter primitives: type-shape adapters,
+SimulationState projection, generic Agent/ActionResolver wrappers, and the
+AuditLog projection helper. Per Oracle's binding M9' ruling, the test
+suite drives `abdp.scenario.ScenarioRunner.run()` end-to-end with
+callable-backed adapters and asserts the resulting ScenarioRun /
+AuditLog are real (not synthesized) abdp objects with all invariants
+upheld.
+"""
+
+from __future__ import annotations
+
+# pyright: reportMissingImports=false
+
+from datetime import date, datetime, timezone
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+pytest.importorskip("abdp")
+
+from abdp.agents import AgentDecision  # noqa: E402
+from abdp.evaluation import EvaluationSummary, GateStatus  # noqa: E402
+from abdp.evidence import AuditLog, make_evidence_record  # noqa: E402
+from abdp.scenario import ActionResolver, ScenarioRun, ScenarioRunner  # noqa: E402
+
+from younggeul_core._compat.ids import (  # noqa: E402
+    DEFAULT_SHADOW_SEED,
+    SnapshotIdRegistry,
+    derive_scenario_key,
+)
+from younggeul_core._compat.scenario import (  # noqa: E402
+    PROPOSAL_ID_NAMESPACE,
+    AbdpActionAdapter,
+    AbdpParticipantAdapter,
+    AbdpSegmentAdapter,
+    CallableAgent,
+    CallableResolver,
+    derive_proposal_id,
+    project_audit_log,
+    to_abdp_simulation_state,
+    to_abdp_snapshot_ref,
+)
+from younggeul_core.state.simulation import (  # noqa: E402
+    ActionProposal,
+    ParticipantState,
+    ScenarioSpec,
+    SegmentState,
+    Shock,
+)
+
+
+@pytest.fixture
+def core_segment() -> SegmentState:
+    return SegmentState(
+        gu_code="11680",
+        gu_name="강남구",
+        current_median_price=2_000_000_000,
+        current_volume=100,
+        price_trend="flat",
+        sentiment_index=0.5,
+        supply_pressure=0.0,
+    )
+
+
+@pytest.fixture
+def core_participants() -> list[ParticipantState]:
+    return [
+        ParticipantState(
+            participant_id="buyer-1",
+            role="buyer",
+            capital=3_000_000_000,
+            holdings=0,
+            sentiment="bullish",
+            risk_tolerance=0.4,
+        ),
+        ParticipantState(
+            participant_id="seller-1",
+            role="landlord",
+            capital=500_000_000,
+            holdings=2,
+            sentiment="bearish",
+            risk_tolerance=0.6,
+        ),
+    ]
+
+
+@pytest.fixture
+def core_action() -> ActionProposal:
+    return ActionProposal(
+        agent_id="buyer-1",
+        round_no=1,
+        action_type="buy",
+        target_segment="11680",
+        confidence=0.8,
+        reasoning_summary="Bullish on Q3 supply tightening",
+    )
+
+
+@pytest.fixture
+def core_scenario_spec() -> ScenarioSpec:
+    return ScenarioSpec(
+        scenario_name="m9b-test",
+        target_gus=["11680"],
+        target_period_start=date(2025, 1, 1),
+        target_period_end=date(2025, 3, 31),
+        shocks=[
+            Shock(shock_type="interest_rate", description="basis point cut", magnitude=-0.25),
+        ],
+    )
+
+
+@pytest.fixture
+def snapshot_sha() -> str:
+    return "a" * 64
+
+
+@pytest.fixture
+def registry() -> SnapshotIdRegistry:
+    return SnapshotIdRegistry()
+
+
+@pytest.fixture
+def abdp_snapshot_ref(snapshot_sha: str, registry: SnapshotIdRegistry) -> Any:
+    return to_abdp_snapshot_ref(
+        sha256_hex=snapshot_sha,
+        storage_key="snapshots/2025-04-23/seoul.parquet",
+        registry=registry,
+    )
+
+
+class TestSegmentAdapter:
+    def test_from_core_maps_gu_code_to_segment_id(self, core_segment: SegmentState) -> None:
+        adapter = AbdpSegmentAdapter.from_core(core_segment, participant_ids=("buyer-1",))
+        assert adapter.segment_id == "11680"
+        assert adapter.participant_ids == ("buyer-1",)
+        assert adapter.inner is core_segment
+
+    def test_default_participant_ids_is_empty_tuple(self, core_segment: SegmentState) -> None:
+        adapter = AbdpSegmentAdapter.from_core(core_segment)
+        assert adapter.participant_ids == ()
+
+
+class TestParticipantAdapter:
+    def test_from_core_preserves_participant_id(self, core_participants: list[ParticipantState]) -> None:
+        adapter = AbdpParticipantAdapter.from_core(core_participants[0])
+        assert adapter.participant_id == "buyer-1"
+        assert adapter.inner is core_participants[0]
+
+
+class TestActionAdapter:
+    def test_from_core_maps_to_abdp_protocol_fields(self, core_action: ActionProposal) -> None:
+        adapter = AbdpActionAdapter.from_core(core_action)
+        assert adapter.actor_id == "buyer-1"
+        assert adapter.action_key == "buy"
+        assert adapter.payload["agent_id"] == "buyer-1"
+        assert adapter.payload["action_type"] == "buy"
+        UUID(adapter.proposal_id)
+        assert adapter.inner is core_action
+
+    def test_proposal_id_is_deterministic(self, core_action: ActionProposal) -> None:
+        a = AbdpActionAdapter.from_core(core_action)
+        b = AbdpActionAdapter.from_core(core_action)
+        assert a.proposal_id == b.proposal_id
+
+    def test_proposal_id_changes_with_round(self, core_action: ActionProposal) -> None:
+        a = AbdpActionAdapter.from_core(core_action)
+        b = AbdpActionAdapter.from_core(core_action.model_copy(update={"round_no": 2}))
+        assert a.proposal_id != b.proposal_id
+
+    def test_proposal_id_namespace_is_uuid5(self, core_action: ActionProposal) -> None:
+        derived = derive_proposal_id(core_action)
+        assert isinstance(derived, UUID)
+        assert derived.version == 5
+
+    def test_proposal_id_namespace_is_distinct_from_snapshot(self) -> None:
+        from younggeul_core._compat.ids import YOUNGGEUL_SNAPSHOT_NAMESPACE
+
+        assert PROPOSAL_ID_NAMESPACE != YOUNGGEUL_SNAPSHOT_NAMESPACE
+
+
+class TestSnapshotRefProjection:
+    def test_roundtrips_through_registry(self, snapshot_sha: str, registry: SnapshotIdRegistry) -> None:
+        ref = to_abdp_snapshot_ref(
+            sha256_hex=snapshot_sha,
+            storage_key="snapshots/x.parquet",
+            registry=registry,
+        )
+        assert ref.tier == "silver"
+        assert ref.storage_key == "snapshots/x.parquet"
+        assert isinstance(ref.snapshot_id, UUID)
+        assert registry.sha256_for(ref.snapshot_id) == snapshot_sha
+
+    def test_explicit_tier(self, snapshot_sha: str, registry: SnapshotIdRegistry) -> None:
+        ref = to_abdp_snapshot_ref(
+            sha256_hex=snapshot_sha,
+            storage_key="snapshots/x.parquet",
+            registry=registry,
+            tier="gold",
+        )
+        assert ref.tier == "gold"
+
+    def test_invalid_tier_raises(self, snapshot_sha: str, registry: SnapshotIdRegistry) -> None:
+        with pytest.raises(ValueError):
+            to_abdp_snapshot_ref(
+                sha256_hex=snapshot_sha,
+                storage_key="snapshots/x.parquet",
+                registry=registry,
+                tier="platinum",
+            )
+
+
+class TestSimulationStateProjection:
+    def test_produces_frozen_abdp_state(
+        self,
+        core_segment: SegmentState,
+        core_participants: list[ParticipantState],
+        abdp_snapshot_ref: Any,
+    ) -> None:
+        state = to_abdp_simulation_state(
+            segments=[core_segment],
+            participants=core_participants,
+            snapshot_ref=abdp_snapshot_ref,
+            segment_participants={"11680": ["buyer-1", "seller-1"]},
+        )
+        assert state.step_index == 0
+        assert state.seed == DEFAULT_SHADOW_SEED
+        assert state.snapshot_ref is abdp_snapshot_ref
+        assert len(state.segments) == 1
+        assert state.segments[0].segment_id == "11680"
+        assert state.segments[0].participant_ids == ("buyer-1", "seller-1")
+        assert tuple(p.participant_id for p in state.participants) == ("buyer-1", "seller-1")
+        assert state.pending_actions == ()
+
+    def test_preserves_caller_ordering(
+        self,
+        core_segment: SegmentState,
+        core_participants: list[ParticipantState],
+        abdp_snapshot_ref: Any,
+    ) -> None:
+        reversed_participants = list(reversed(core_participants))
+        state = to_abdp_simulation_state(
+            segments=[core_segment],
+            participants=reversed_participants,
+            snapshot_ref=abdp_snapshot_ref,
+        )
+        assert tuple(p.participant_id for p in state.participants) == ("seller-1", "buyer-1")
+
+    def test_pending_actions_projected(
+        self,
+        core_segment: SegmentState,
+        core_participants: list[ParticipantState],
+        core_action: ActionProposal,
+        abdp_snapshot_ref: Any,
+    ) -> None:
+        state = to_abdp_simulation_state(
+            segments=[core_segment],
+            participants=core_participants,
+            snapshot_ref=abdp_snapshot_ref,
+            pending_actions=[core_action],
+        )
+        assert len(state.pending_actions) == 1
+        assert state.pending_actions[0].actor_id == "buyer-1"
+
+
+class _FakeDecision:
+    """Minimal AgentDecision Protocol implementation."""
+
+    __slots__ = ("agent_id", "proposals")
+
+    def __init__(self, agent_id: str, proposals: tuple[Any, ...]) -> None:
+        self.agent_id = agent_id
+        self.proposals = proposals
+
+
+class TestCallableAgent:
+    def test_satisfies_runtime_protocol(self) -> None:
+        agent = CallableAgent(
+            agent_id="agent-1",
+            decide_fn=lambda ctx: _FakeDecision("agent-1", ()),
+        )
+        assert agent.agent_id == "agent-1"
+        assert callable(agent.decide)
+
+    def test_decide_delegates_to_callable(self) -> None:
+        captured: list[Any] = []
+
+        def decide(ctx: Any) -> Any:
+            captured.append(ctx)
+            return _FakeDecision("agent-1", ())
+
+        agent = CallableAgent(agent_id="agent-1", decide_fn=decide)
+        sentinel = object()
+        result = agent.decide(sentinel)
+        assert captured == [sentinel]
+        assert isinstance(result, _FakeDecision)
+
+
+class TestCallableResolver:
+    def test_satisfies_action_resolver_protocol(self) -> None:
+        resolver = CallableResolver(resolve_fn=lambda state, proposals: state)
+        assert isinstance(resolver, ActionResolver)
+
+    def test_resolve_delegates_to_callable(self) -> None:
+        captured: list[tuple[Any, tuple[Any, ...]]] = []
+
+        def resolve(state: Any, proposals: tuple[Any, ...]) -> Any:
+            captured.append((state, proposals))
+            return state
+
+        resolver = CallableResolver(resolve_fn=resolve)
+        result = resolver.resolve("state-sentinel", (1, 2, 3))
+        assert captured == [("state-sentinel", (1, 2, 3))]
+        assert result == "state-sentinel"
+
+
+class TestEndToEndScenarioRun:
+    """Drive abdp.scenario.ScenarioRunner with the adapter primitives.
+
+    This exercises the *real* abdp control loop (no mocking of the runner
+    or the resolver dispatch) and asserts that callable-backed adapters
+    produce a valid ScenarioRun.
+    """
+
+    def test_runner_produces_real_scenario_run(
+        self,
+        core_segment: SegmentState,
+        core_participants: list[ParticipantState],
+        core_scenario_spec: ScenarioSpec,
+        abdp_snapshot_ref: Any,
+    ) -> None:
+        from dataclasses import dataclass, replace
+
+        initial_state = to_abdp_simulation_state(
+            segments=[core_segment],
+            participants=core_participants,
+            snapshot_ref=abdp_snapshot_ref,
+            segment_participants={"11680": ["buyer-1", "seller-1"]},
+        )
+        scenario_key = derive_scenario_key(core_scenario_spec)
+
+        @dataclass(frozen=True, slots=True)
+        class _SpecImpl:
+            scenario_key: str
+            seed: int
+            _initial: Any
+
+            def build_initial_state(self) -> Any:
+                return self._initial
+
+        spec = _SpecImpl(
+            scenario_key=scenario_key,
+            seed=DEFAULT_SHADOW_SEED,
+            _initial=initial_state,
+        )
+
+        # An agent that emits exactly one proposal on step 0, none after.
+        @dataclass(frozen=True, slots=True)
+        class _Proposal:
+            proposal_id: str
+            actor_id: str
+            action_key: str
+            payload: dict[str, Any]
+
+        def decide(ctx: Any) -> AgentDecision[Any]:
+            if ctx.step_index == 0:
+                proposal = _Proposal(
+                    proposal_id="p-1",
+                    actor_id="buyer-1",
+                    action_key="buy",
+                    payload={"qty": 1},
+                )
+                return _FakeDecision("agent-1", (proposal,))
+            return _FakeDecision("agent-1", ())
+
+        agent = CallableAgent(agent_id="agent-1", decide_fn=decide)
+
+        # Resolver advances step_index and clears pending_actions.
+        def resolve(state: Any, proposals: tuple[Any, ...]) -> Any:
+            return replace(state, step_index=state.step_index + 1, pending_actions=())
+
+        resolver = CallableResolver(resolve_fn=resolve)
+
+        runner: ScenarioRunner[Any, Any, Any] = ScenarioRunner(agents=(agent,), resolver=resolver, max_steps=3)
+        run = runner.run(spec)
+
+        assert isinstance(run, ScenarioRun)
+        assert run.scenario_key == scenario_key
+        assert run.seed == DEFAULT_SHADOW_SEED
+        assert run.step_count >= 1
+        assert run.final_state.step_index >= 1
+
+
+@pytest.fixture
+def empty_summary() -> EvaluationSummary:
+    return EvaluationSummary(metrics=(), gates=(), overall_status=GateStatus.PASS)
+
+
+def _build_minimal_run(scenario_key: str, seed: int = DEFAULT_SHADOW_SEED) -> Any:
+    from dataclasses import dataclass
+
+    @dataclass(frozen=True, slots=True)
+    class _StubFinalState:
+        step_index: int = 0
+
+    @dataclass(frozen=True, slots=True)
+    class _StubRun:
+        scenario_key: str
+        seed: int
+        steps: tuple[Any, ...]
+        final_state: Any
+
+    return _StubRun(
+        scenario_key=scenario_key,
+        seed=seed,
+        steps=(),
+        final_state=_StubFinalState(),
+    )
+
+
+class TestProjectAuditLog:
+    def test_projects_valid_audit_log(self, empty_summary: EvaluationSummary) -> None:
+        # Use a real ScenarioRun so AuditLog accepts it.
+        run = _build_minimal_run("yg-scenario-v1:" + "a" * 64)
+        audit = project_audit_log(scenario_run=run, summary=empty_summary)
+        assert isinstance(audit, AuditLog)
+        assert audit.scenario_key == run.scenario_key
+        assert audit.seed == run.seed
+        assert audit.run is run
+        assert audit.evidence == ()
+        assert audit.claims == ()
+
+    def test_passes_evidence_and_claims_through(self, empty_summary: EvaluationSummary) -> None:
+        run = _build_minimal_run("yg-scenario-v1:" + "b" * 64)
+        evidence = make_evidence_record(
+            seed=run.seed,
+            evidence_key="trade-volume",
+            step_index=0,
+            agent_id="agent-1",
+            payload={"qty": 1},
+            created_at=datetime.now(timezone.utc),
+        )
+        audit = project_audit_log(
+            scenario_run=run,
+            summary=empty_summary,
+            evidence=(evidence,),
+        )
+        assert audit.evidence == (evidence,)
+
+    def test_invariants_enforced_by_post_init(self, empty_summary: EvaluationSummary) -> None:
+        run = _build_minimal_run("yg-scenario-v1:" + "c" * 64)
+        # The helper passes run.scenario_key and run.seed through, so the
+        # invariant always holds when called via project_audit_log.
+        # Constructing AuditLog directly with mismatched values must fail.
+        with pytest.raises(ValueError, match="scenario_key"):
+            AuditLog(
+                scenario_key="different",
+                seed=run.seed,
+                run=run,
+                summary=empty_summary,
+                evidence=(),
+                claims=(),
+            )


### PR DESCRIPTION
## Summary

Ships M9'-b: the generic, app-agnostic abdp scenario-runner adapter primitives in `core/src/younggeul_core/_compat/scenario.py`, plus 22 contract tests that drive **real** `abdp.scenario.ScenarioRunner.run()` end-to-end with callable-backed adapters.

Per Oracle's binding M9' design ruling (session `ses_24823ebf3ffeCIysGiw83E63QQ`):
- Ruling F: REAL SHADOW EXECUTION via thin Agent/Resolver adapters - NOT post-hoc synthesis. Adapters MUST NOT re-implement younggeul decision/resolution logic.
- Ruling G: M9' splits into 3 PRs - this is M9'-b (adapters + ScenarioRun + AuditLog projection); M9'-c will wire CLI shadow-mode flag and integration test.
- Ruling H: Don't make UUID canonical outside the adapter boundary.

## Architecture

Per the strict `core <- apps` dependency rule, `_compat/scenario.py` cannot import from `apps/`. So this PR ships callable-backed generic adapters in core; M9'-c will wire the actual younggeul `ParticipantPolicy.decide` and round_resolver math into them from `apps/kr-seoul-apartment/`.

### New module: `core/src/younggeul_core/_compat/scenario.py` (~270 LOC)

- **Type-shape adapters** bridging core Pydantic types to abdp's runtime-checkable Protocols:
  - `AbdpSegmentAdapter` (segment_id <- gu_code)
  - `AbdpParticipantAdapter` (participant_id passthrough)
  - `AbdpActionAdapter` (proposal_id <- uuid5, actor_id <- agent_id, action_key <- action_type)
- `derive_proposal_id()` + `PROPOSAL_ID_NAMESPACE` (frozen UUID literal, distinct from `YOUNGGEUL_SNAPSHOT_NAMESPACE`)
- `to_abdp_snapshot_ref()` - registers uuid<->sha256 in the M9'-a `SnapshotIdRegistry`
- `to_abdp_simulation_state()` - projects core types into frozen `abdp.simulation.SimulationState`, preserving caller-supplied tuple ordering
- `CallableAgent` / `CallableResolver` - generic Protocol-conformant wrappers
- `project_audit_log()` - constructor that always upholds abdp `AuditLog.__post_init__` invariants (`scenario_key == run.scenario_key` AND `seed == run.seed`)

### New tests: `core/tests/contract/test_compat_scenario.py` (22 tests)

- Type-shape adapter mappings + Protocol satisfaction
- proposal_id determinism, uuid5 version, namespace distinctness
- `SnapshotRef` projection round-trips through `SnapshotIdRegistry`
- `SimulationState` projection preserves caller ordering, projects pending actions
- CallableAgent/CallableResolver Protocol conformance + delegation
- **End-to-end**: drives REAL `abdp.scenario.ScenarioRunner.run()` with callable-backed adapters; asserts the resulting `ScenarioRun` is a real abdp object (no synthesis)
- AuditLog projection enforces `__post_init__` invariants

## Verification

- 1,312 tests pass on **both** backends (was 1,290 after M9'-a; +22 new)
- `ruff format --check .` clean
- `ruff check .` clean
- `mypy core/src/younggeul_core/_compat/scenario.py` clean
- M8' guardrails still pass:
  - No `abdp.simulation` re-exports in `_compat` namespace
  - No `from abdp` import in `state/simulation.py`
  - No `--seed`/`--scenario-key` CLI flags
- 3 pre-existing live-MOLIT integration test failures are unrelated to this PR (ADR-010 IP block).

## Follow-ups

- **M9'-c (#244)**: opt-in shadow-mode CLI flag on `simulate`; end-to-end integration test producing a real `AuditLog` from a deterministic LangGraph run, wiring younggeul's `ParticipantPolicy.decide` and `round_resolver` into `CallableAgent` / `CallableResolver` from `apps/kr-seoul-apartment/`.
- **M10' (#245)**: selective-adoption finalization. NO default backend flip.

Refs: #244, epic #235, ADR-012.