### PR TITLE
feat(compat): finalize selective abdp adoption + strip milestone tags (#245)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,5 +1,5 @@
 name: Benchmark
-# Stub — activate in M4-06
+# Stub — activate in the Gold & Baseline phase
 on:
   workflow_dispatch:
   pull_request:
@@ -9,4 +9,4 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Stub — activate in milestone M4 (Gold & Baseline)"
+      - run: echo "Stub — activate in the Gold & Baseline phase"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        backend:
-          - name: local
-            extras: "dev,kr-seoul-apartment"
-          - name: abdp
-            extras: "dev,kr-seoul-apartment,abdp"
-    name: test (${{ matrix.backend.name }} backend)
+        backend: [local, abdp]
+    name: test (${{ matrix.backend }} backend)
     env:
-      YOUNGGEUL_CORE_BACKEND: ${{ matrix.backend.name }}
+      YOUNGGEUL_CORE_BACKEND: ${{ matrix.backend }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -25,11 +21,11 @@ jobs:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@v7
       - name: Install dependencies
-        run: uv pip install --system -e ".[${{ matrix.backend.extras }}]"
-      - name: Run unit tests
-        run: pytest -m "not slow and not integration" --cov --cov-report=xml
+        run: uv pip install --system -e ".[dev,kr-seoul-apartment,abdp]"
+      - name: Run test suite
+        run: pytest -m "not slow and not live" --cov --cov-report=xml
       - name: Upload coverage
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-report-${{ matrix.backend.name }}
+          name: coverage-report-${{ matrix.backend }}
           path: coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **abdp selective adoption finalized (issue #245, epic #235).** `younggeul_core`
+  now adopts `agent-based-decision-pipeline` selectively where semantics
+  match: hashing delegation, deterministic JSON report rendering
+  (`simulate --render abdp`), shadow audit-log generation
+  (`simulate --shadow-audit-log`), and runner-internal scenario/snapshot
+  ID derivation. The default backend remains `local`; the abdp backend
+  is opt-in via `YOUNGGEUL_CORE_BACKEND=abdp`. See
+  [ADR-012](docs/adr/012-abdp-backed-core.md) for the final selective-adoption inventory.
+
+### Added
+
+- `simulate --shadow-audit-log <PATH>` CLI flag emits a frozen
+  `abdp.evidence.AuditLog` JSON in parallel with the LangGraph run, by
+  driving the same participant policies and round resolver through
+  `abdp.scenario.ScenarioRunner` (no decision-logic fork) (issue #244).
+- `simulate --render abdp` CLI flag renders the simulation report JSON
+  via `abdp.reporting.render_json_report`. Markdown remains the
+  byte-identical default (issue #243, PR #251).
+- `core/_compat/{ids,scenario,reporting,data}` adapter modules wrapping
+  the abdp surfaces consumed by the shadow runner and the reporting
+  flag. All synthesized identifiers (Seed, scenario_key, snapshot UUID,
+  proposal_id) are runner-internal and never appear in the markdown
+  report or CLI summary text.
+- Two-backend parity coverage in `core/tests/contract/test_compat_*`
+  exercising every adopted surface across `local` and `abdp`.
+
 ## [0.1.0] - 2026-03-29
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ Scopes: `core`, `app/kr-seoul`, `eval`, `ci`, `docs`
 ### Branch Strategy
 
 - `main` — stable, always passing CI
-- Feature branches: `feat/M{milestone}-{issue-number}-{short-description}`
-- Example: `feat/M1-13-bronze-schemas`
+- Feature branches: `feat/{issue-number}-{short-description}`
+- Example: `feat/13-bronze-schemas`
 
 ### Code Style
 

--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ Key architectural decisions are documented as ADRs:
 | [ADR-011](docs/adr/011-simulate-live-snapshot-wiring.md) | Wire live snapshot data into the simulate CLI |
 | [ADR-012](docs/adr/012-abdp-backed-core.md) | Adopt abdp-backed compatibility architecture for `younggeul_core` |
 
-## abdp backend (experimental)
+## abdp backend
 
-`younggeul_core` is being refactored as a thin compatibility layer over the [agent-based-decision-pipeline (abdp)](https://github.com/yeongseon/agent-based-decision-pipeline) framework (see [ADR-012](docs/adr/012-abdp-backed-core.md)). The backend is selected at runtime via:
+`younggeul_core` ships a thin compatibility layer over the [agent-based-decision-pipeline (abdp)](https://github.com/yeongseon/agent-based-decision-pipeline) framework (see [ADR-012](docs/adr/012-abdp-backed-core.md)). The backend is selected at runtime via:
 
 ```bash
 export YOUNGGEUL_CORE_BACKEND=local   # default; preserves v0.3.0 behavior
@@ -206,7 +206,7 @@ To install the abdp backend:
 pip install -e ".[abdp]"
 ```
 
-The default backend remains `local`; per the M4'–M10' scope correction in [ADR-012](docs/adr/012-abdp-backed-core.md#amendment-2026-04-23--m4m10-scope-correction), `younggeul_core` adopts `abdp` selectively where semantics match (hashing today; audit log and reporting render path next) rather than flipping wholesale. Adopted surfaces are gated by the parity contract test suite (#241).
+The default backend remains `local` indefinitely. Per the 2026-04-23 selective-adoption scope correction in [ADR-012](docs/adr/012-abdp-backed-core.md#amendment-2026-04-23--selective-adoption-scope-correction), `younggeul_core` adopts `abdp` only where semantics actually match — hashing (`abdp.core.stable_hash`), Bronze/Silver/Gold contract aliases, the JSON report renderer, the deterministic ID helpers (`_compat/ids.py`), and the shadow `ScenarioRunner` adapters (`_compat/scenario.py`) that produce a real `abdp.evidence.AuditLog` from LangGraph runs via `simulate --shadow-audit-log`. The Korean apartment domain types, snapshot manifest, and LangGraph runtime stay local by design. See ADR-012's "Final selective-adoption inventory" subsection for the full per-surface breakdown. Adopted surfaces are gated by the parity contract test suite (#241), and CI runs the full suite under both `YOUNGGEUL_CORE_BACKEND=local` and `=abdp`.
 
 ## License
 

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py
@@ -609,7 +609,7 @@ def baseline_command(ctx: click.Context, snapshot_id: str, snapshot_dir: Path, o
     "abdp.scenario.ScenarioRunner (shadow execution) and the resulting AuditLog "
     "is rendered via abdp.reporting.render_json_report. Requires --snapshot-dir "
     "and the [abdp] extra. Internal IDs (scenario_key, snapshot UUID, proposal_id) "
-    "are runner-internal and never appear in younggeul-owned storage. See ADR-012 (M9'-c).",
+    "are runner-internal and never appear in younggeul-owned storage. See ADR-012 and PR #256.",
 )
 @click.pass_context
 def simulate_command(

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/_resolver_math.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/nodes/_resolver_math.py
@@ -1,10 +1,10 @@
 """Pure round-resolution math extracted from :mod:`round_resolver`.
 
-Per Oracle's M9' design ruling F (REAL SHADOW EXECUTION, not synthesis):
+Per Oracle's design ruling F for the shadow-runner work (REAL SHADOW EXECUTION, not synthesis):
 the abdp ScenarioRunner adapter must invoke the *same* resolution logic
 the LangGraph node uses, never a fork. This module owns that single,
 pure implementation; the LangGraph node delegates to it and adds event
-publication on top, while the M9'-c shadow runner wraps it in a
+publication on top, while the shadow-runner slice wraps it in a
 :class:`younggeul_core._compat.scenario.CallableResolver`.
 
 The function is deliberately free of LangGraph state, event stores, and

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/shadow_runner.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/shadow_runner.py
@@ -1,12 +1,12 @@
-"""abdp shadow runner wiring (M9'-c).
+"""abdp shadow runner wiring.
 
 Drives :class:`abdp.scenario.ScenarioRunner` over younggeul's existing
-participant-policy and round-resolver logic by composing the M9'-b
+participant-policy and round-resolver logic by composing the scenario-adapter
 adapter primitives in :mod:`younggeul_core._compat.scenario` with the
 pure resolution math in :mod:`.nodes._resolver_math` and the policy
 registry in :mod:`.policies`.
 
-Per Oracle's M9' design ruling F (REAL SHADOW EXECUTION, not synthesis):
+Per Oracle's design ruling F for the shadow-runner work (REAL SHADOW EXECUTION, not synthesis):
 the agents and resolver here MUST call the same decide/resolve logic the
 LangGraph nodes call, never a fork. They do: each
 :class:`younggeul_core._compat.scenario.CallableAgent` invokes

--- a/apps/kr-seoul-apartment/tests/integration/test_simulate_cli_shadow_audit.py
+++ b/apps/kr-seoul-apartment/tests/integration/test_simulate_cli_shadow_audit.py
@@ -1,4 +1,4 @@
-"""Integration test for ``younggeul simulate --shadow-audit-log`` (M9'-c).
+"""Integration test for ``younggeul simulate --shadow-audit-log``.
 
 End-to-end exercise of the abdp shadow runner:
 
@@ -8,7 +8,7 @@ End-to-end exercise of the abdp shadow runner:
    carrying the abdp ``AuditLog`` shape (``scenario_key`` versioned,
    ``seed == 0``, non-empty ``run.steps``).
 
-Per Oracle's M9' design ruling D, the synthesized identifiers (Seed,
+Per Oracle's design ruling D for the shadow-runner work, the synthesized identifiers (Seed,
 scenario_key, snapshot UUID, proposal_id) are runner-internal: this test
 verifies their *internal* presence in the abdp JSON, never that they
 leak into the markdown report.

--- a/apps/kr-seoul-apartment/tests/unit/test_pure_resolve_round.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_pure_resolve_round.py
@@ -1,9 +1,9 @@
-"""Pure-resolver-math parity test (M9'-c).
+"""Pure-resolver-math parity test.
 
 Asserts that the extracted :func:`pure_resolve_round` helper produces the
 same world / participants / outcome / payload as the LangGraph round
 resolver node, for representative scenarios. This is the byte-identity
-guarantee for Oracle's M9' design ruling F (no fork between LangGraph and
+guarantee for Oracle's design ruling F for the shadow-runner work (no fork between LangGraph and
 abdp shadow runner).
 """
 

--- a/core/src/younggeul_core/_compat/__init__.py
+++ b/core/src/younggeul_core/_compat/__init__.py
@@ -1,19 +1,27 @@
 """Backend selection compatibility layer for younggeul_core.
 
-See ADR-012 (docs/adr/012-abdp-backed-core.md). Subsequent milestones
-(M3-M5) will route subsystem imports through this module so the backend
-can be flipped via the ``YOUNGGEUL_CORE_BACKEND`` environment variable
-without touching call sites.
+See ADR-012 (docs/adr/012-abdp-backed-core.md) and the final selective-adoption
+inventory recorded there. The shipped adopted
+surfaces are routed through sibling modules in this package
+(:mod:`younggeul_core._compat.data`,
+:mod:`younggeul_core._compat.reporting`,
+:mod:`younggeul_core._compat.ids`,
+:mod:`younggeul_core._compat.scenario`) plus
+:mod:`younggeul_core.connectors.hashing`. They consult
+:func:`get_backend` at call time so the same call sites work under
+both backends without import-time wiring.
 
-Public surface intentionally minimal in M2: just the flag-reader and a
-single ``require_abdp()`` helper that produces a clear error if the
-``abdp`` extra is requested but not installed.
+The default backend remains ``"local"`` indefinitely per the 2026-04-23
+finalization ruling (no default flip): younggeul-owned domain types
+(:mod:`younggeul_core.state.simulation`, :mod:`younggeul_core.storage`)
+and the LangGraph runtime stay local; abdp is adopted selectively
+where semantics already match.
 """
 
 from __future__ import annotations
 
 import os
-from typing import Final, Literal
+from typing import Final, Literal, cast
 
 Backend = Literal["local", "abdp"]
 
@@ -35,19 +43,19 @@ def get_backend() -> Backend:
     raw = os.environ.get(ENV_VAR, DEFAULT_BACKEND).strip().lower()
     if raw not in _VALID_BACKENDS:
         raise ValueError(f"{ENV_VAR}={raw!r} is not supported. Valid values: {sorted(_VALID_BACKENDS)}.")
-    return raw  # type: ignore[return-value]
+    return cast(Backend, raw)
 
 
 def require_abdp() -> None:
     """Import ``abdp`` or raise a friendly error pointing to the extra."""
     try:
-        import abdp  # noqa: F401
+        import abdp as _abdp
+
+        _ = _abdp
     except ImportError as exc:
         raise ImportError(
-            "The 'abdp' backend was requested "
-            f"({ENV_VAR}=abdp) but the abdp package is not installed. "
-            "Install it via:  pip install -e '.[abdp]'  "
-            "(see ADR-012 for details)."
+            f"The 'abdp' backend was requested ({ENV_VAR}=abdp) but the abdp package is not installed. "
+            "Install it via:  pip install -e '.[abdp]'  (see ADR-012 for details)."
         ) from exc
 
 

--- a/core/src/younggeul_core/_compat/data.py
+++ b/core/src/younggeul_core/_compat/data.py
@@ -2,7 +2,7 @@
 
 This module deliberately does **not** replace any younggeul row schema or
 the dataset-level ``younggeul_core.storage.snapshot.SnapshotManifest``.
-Per the M4' scope correction:
+Per the selective-adoption plan (ADR-012 amendment) recorded in ADR-012:
 
 - ``abdp.data.{Bronze,Silver,Gold}Contract`` are abstract structural
   ``Protocol`` types with only ``manifest`` and ``rows`` properties.
@@ -13,11 +13,12 @@ Per the M4' scope correction:
 - ``younggeul_core.storage.snapshot.SnapshotManifest`` is a Pydantic
   multi-table dataset manifest with sha256-derived integrity IDs.
 
-These are *not* bijective. We expose abdp's framework contracts here only
-for downstream code that wants to type-annotate "any framework artifact"
-(e.g., future audit/reporting adapters in M5'/M6'). Importing names from
-this module pulls in ``abdp`` lazily; code that does not need framework
-contracts pays no import cost.
+These are *not* bijective. We expose abdp's framework contracts here as
+an intentional public typing surface for downstream code that wants to
+type-annotate "any framework artifact" (e.g., the shadow-runner work
+adapter primitives in :mod:`younggeul_core._compat.scenario`). Importing
+names from this module pulls in ``abdp`` lazily; code that does not need
+framework contracts pays no import cost.
 
 Use of these aliases does **not** imply that the local types satisfy
 them — the local types intentionally hold richer state.

--- a/core/src/younggeul_core/_compat/ids.py
+++ b/core/src/younggeul_core/_compat/ids.py
@@ -1,7 +1,7 @@
-"""M9'-a: ID derivation and ScenarioContract normalization for the
-shadow runner adapter (see ADR-012 + docs/architecture/abdp-simulation-fit-gap.md).
+"""ID derivation and ScenarioContract normalization for the
+abdp shadow runner adapter (see ADR-012 + docs/architecture/abdp-simulation-fit-gap.md).
 
-These helpers exist so the M9'-b adapter can produce a real
+These helpers exist so the scenario-adapter slice can produce a real
 `abdp.scenario.ScenarioRun` whose `scenario_key`, `seed`, and
 `SnapshotRef.snapshot_id` carry deterministic, internal-only values
 derived from younggeul's existing canonical sources (sha256 snapshot
@@ -44,7 +44,7 @@ frozen here; rotating it would invalidate every previously generated
 `SCENARIO_KEY_VERSION`-style versioning scheme."""
 
 DEFAULT_SHADOW_SEED: Final[int] = 0
-"""Seed value used by the M9' shadow `ScenarioRun`. younggeul has no
+"""Seed value used by the shadow-runner `ScenarioRun`. younggeul has no
 RNG-seeded simulation behavior today, so the seed has no entropy role
 and is a constant. If randomness is later introduced, the seed must
 become an explicit cross-engine input before any parity claim
@@ -86,7 +86,7 @@ def derive_scenario_key(spec: ScenarioSpec) -> str:
     sensitive to roster/shock changes via `normalize_scenario_contract`.
 
     Returns a string of shape ``"yg-scenario-v1:<sha256hex>"``. Full
-    digest is preserved (no truncation) per the M9' design ruling.
+    digest is preserved (no truncation) per Oracle's design ruling.
     """
     contract = normalize_scenario_contract(spec)
     payload = json.dumps(contract, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")

--- a/core/src/younggeul_core/_compat/reporting.py
+++ b/core/src/younggeul_core/_compat/reporting.py
@@ -1,12 +1,12 @@
-"""Opt-in delegation to abdp.reporting render helpers (see ADR-012, M6').
+"""Opt-in delegation to abdp.reporting render helpers (see ADR-012 and the reporting render-flag work in issue #243, PR #251).
 
 This module gives the CLI a stable seam for switching between the local
 markdown rendering of `RenderedReport` (default, unchanged) and abdp's
 deterministic JSON renderer (`abdp.reporting.render_json_report`),
 selected at the call site by the `--render` flag on `simulate`.
 
-Per the M4'-M10' scope correction in ADR-012, the project does not adopt
-abdp's `AuditLog` or evidence/claim contracts here; M6' only adopts the
+Per the selective-adoption scope correction in ADR-012, the project does not adopt
+abdp's `AuditLog` or evidence/claim contracts here; the reporting render-flag work only adopts the
 output formatter, which operates on plain JSON-compatible primitives and
 therefore needs no semantic alignment with the simulation provenance
 model. Importing names from this module pulls in `abdp` lazily.

--- a/core/src/younggeul_core/_compat/scenario.py
+++ b/core/src/younggeul_core/_compat/scenario.py
@@ -1,4 +1,4 @@
-"""abdp scenario-runner adapter primitives (M9'-b).
+"""abdp scenario-runner adapter primitives.
 
 This module ships the *generic, app-agnostic* building blocks needed to drive
 :mod:`abdp.scenario.ScenarioRunner` over data produced by the existing
@@ -6,7 +6,7 @@ younggeul LangGraph pipeline. The primitives live in ``core`` because they
 operate purely on core's Pydantic projection types
 (:mod:`younggeul_core.state.simulation`) and the abdp public contracts.
 
-Per ADR-012 and Oracle's binding M9' design ruling:
+Per ADR-012 and Oracle's binding design ruling for the shadow-runner work:
 
 * The LangGraph ``GraphState`` (in ``apps/``) remains the canonical state
   representation. ``SimulationState`` (here, in ``core``) and abdp's
@@ -19,7 +19,7 @@ Per ADR-012 and Oracle's binding M9' design ruling:
 
 The adapter classes here are intentionally generic (callable-backed).
 The actual wiring of younggeul's ``ParticipantPolicy.decide`` and the
-``round_resolver`` math into these adapters is performed in M9'-c at the
+``round_resolver`` math into these adapters is performed in the shadow-runner slice at the
 ``apps/kr-seoul-apartment/`` layer (which is permitted to depend on core).
 That layered split preserves the strict ``core <- apps`` dependency rule.
 """
@@ -250,7 +250,7 @@ def to_abdp_simulation_state(
         snapshot_ref=snapshot_ref,
         segments=segment_adapters,
         participants=participant_adapters,
-        pending_actions=pending_adapters,
+        pending_actions=cast(Any, pending_adapters),
     )
 
 
@@ -265,7 +265,7 @@ class CallableAgent(Generic[_S, _P, _A]):
 
     The wrapped callable receives an :class:`abdp.agents.AgentContext` and
     must return an :class:`abdp.agents.AgentDecision`. younggeul-app
-    callables (M9'-c) translate the AgentContext into the form expected by
+    callables from the shadow-runner slice translate the AgentContext into the form expected by
     ``ParticipantPolicy.decide`` and project the result back.
     """
 

--- a/core/tests/contract/test_compat_guardrails.py
+++ b/core/tests/contract/test_compat_guardrails.py
@@ -1,9 +1,12 @@
-"""Guardrail tests for the M7' fit-gap forbidden-patterns list.
+"""Guardrail tests for the fit-gap forbidden-patterns list.
 
-These tests fail loudly if any pre-M9' code path starts synthesizing
-public IDs (Seed, scenario_key, snapshot_id UUID, proposal_id, segment
-IDs) or re-exporting `abdp.simulation` Protocols. See
-`docs/architecture/abdp-simulation-fit-gap.md` Section 5.
+These tests fail loudly if any code path starts surfacing public IDs
+(Seed, scenario_key, snapshot_id UUID, proposal_id, segment IDs) on
+the user-facing CLI, or if `younggeul_core._compat` itself starts
+re-exporting `abdp.simulation` Protocols (those values may only be
+minted runner-internal under the shadow-runner work). See
+`docs/architecture/abdp-simulation-fit-gap.md` Section 5 and the final
+selective-adoption inventory in ADR-012.
 """
 
 from __future__ import annotations
@@ -20,10 +23,12 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def test_compat_does_not_export_abdp_simulation_protocols() -> None:
-    """`younggeul_core._compat` MUST NOT re-export any abdp.simulation Protocol
-    or the SimulationState/SnapshotRef dataclasses. All of those carry
-    public-ID-bearing fields whose values can only be minted under the M9'
-    shadow ScenarioRunner with real provenance."""
+    """`younggeul_core._compat` (and the `data`/`reporting` opt-in
+    typing surfaces) MUST NOT re-export any abdp.simulation Protocol
+    or the SimulationState/SnapshotRef dataclasses. Those carry
+    public-ID-bearing fields whose values may only be minted runner-
+    internal under the shadow-runner work, never published as
+    framework-typed names from the compat layer."""
     forbidden = {
         "ScenarioSpec",
         "SegmentState",
@@ -40,39 +45,47 @@ def test_compat_does_not_export_abdp_simulation_protocols() -> None:
     compat = importlib.import_module("younggeul_core._compat")
     for name in forbidden:
         assert not hasattr(compat, name), (
-            f"younggeul_core._compat must not expose `{name}` pre-M9' "
-            "(see docs/architecture/abdp-simulation-fit-gap.md §5)"
+            f"younggeul_core._compat must not expose `{name}` "
+            "(see docs/architecture/abdp-simulation-fit-gap.md §5 and "
+            "ADR-012 final selective-adoption inventory)"
         )
 
     for sub in ("data", "reporting"):
         mod = importlib.import_module(f"younggeul_core._compat.{sub}")
         for name in forbidden:
             assert not hasattr(mod, name), (
-                f"younggeul_core._compat.{sub} must not expose `{name}` pre-M9' "
-                "(see docs/architecture/abdp-simulation-fit-gap.md §5)"
+                f"younggeul_core._compat.{sub} must not expose `{name}` "
+                "(see docs/architecture/abdp-simulation-fit-gap.md §5 and "
+                "ADR-012 final selective-adoption inventory)"
             )
 
 
 def test_younggeul_core_state_simulation_does_not_import_abdp_simulation() -> None:
     """`younggeul_core.state.simulation` MUST stay free of any
-    `abdp.simulation` import until M9'. Importing it would either pull
-    in Protocol types we are forbidden to expose or signal an in-progress
-    swap that bypasses the gating."""
+    `abdp.simulation` import. Per the final selective-adoption
+    inventory, this module is intentionally younggeul-owned domain
+    schema; routing it through abdp would either pull in Protocol
+    types we are forbidden to expose or signal a default flip that
+    Oracle's binding 2026-04-23 finalization ruling explicitly rejects."""
     src = (REPO_ROOT / "core" / "src" / "younggeul_core" / "state" / "simulation.py").read_text(encoding="utf-8")
     assert "abdp.simulation" not in src, (
-        "state/simulation.py must not import from abdp.simulation pre-M9' "
-        "(see docs/architecture/abdp-simulation-fit-gap.md §5)"
+        "state/simulation.py must not import from abdp.simulation "
+        "(see docs/architecture/abdp-simulation-fit-gap.md §5 and "
+        "ADR-012 final selective-adoption inventory)"
     )
     assert "from abdp" not in src, (
-        "state/simulation.py must not import from any abdp.* module pre-M9' "
-        "(see docs/architecture/abdp-simulation-fit-gap.md §5)"
+        "state/simulation.py must not import from any abdp.* module "
+        "(see docs/architecture/abdp-simulation-fit-gap.md §5 and "
+        "ADR-012 final selective-adoption inventory)"
     )
 
 
 def test_simulate_cli_does_not_expose_seed_flag() -> None:
-    """The `simulate` CLI MUST NOT advertise a `--seed` flag pre-M9'.
-    Adding one would publish a cross-engine determinism contract we do
-    not yet implement (see fit-gap §2 hard constraints, item 2)."""
+    """The `simulate` CLI MUST NOT advertise a `--seed` or
+    `--scenario-key` flag. Per Oracle's design ruling for the shadow-runner work and the final
+    inventory, those identifiers are runner-internal only; publishing
+    them as CLI surface would commit to a cross-engine determinism
+    contract younggeul does not implement."""
     result = subprocess.run(
         [sys.executable, "-m", "younggeul_app_kr_seoul_apartment.cli", "simulate", "--help"],
         capture_output=True,
@@ -80,8 +93,24 @@ def test_simulate_cli_does_not_expose_seed_flag() -> None:
         check=True,
     )
     assert "--seed" not in result.stdout, (
-        "simulate CLI must not expose --seed pre-M9' (see docs/architecture/abdp-simulation-fit-gap.md §5)"
+        "simulate CLI must not expose --seed (see docs/architecture/abdp-simulation-fit-gap.md §5)"
     )
     assert "--scenario-key" not in result.stdout, (
-        "simulate CLI must not expose --scenario-key pre-M9' (see docs/architecture/abdp-simulation-fit-gap.md §5)"
+        "simulate CLI must not expose --scenario-key (see docs/architecture/abdp-simulation-fit-gap.md §5)"
+    )
+
+
+def test_default_backend_remains_local() -> None:
+    """`younggeul_core._compat.DEFAULT_BACKEND` MUST stay ``'local'``.
+
+    Per the ADR-012 2026-04-23 finalization ruling, there is no
+    default flip: the abdp backend is opt-in via
+    ``YOUNGGEUL_CORE_BACKEND=abdp``. A future contributor flipping
+    this constant must escalate via a new ADR/epic, not a silent edit.
+    """
+    from younggeul_core._compat import DEFAULT_BACKEND
+
+    assert DEFAULT_BACKEND == "local", (
+        "DEFAULT_BACKEND must remain 'local' per the ADR-012 2026-04-23 finalization ruling. "
+        "A default flip requires a new ADR/epic, not a constant rename."
     )

--- a/core/tests/contract/test_compat_ids.py
+++ b/core/tests/contract/test_compat_ids.py
@@ -1,8 +1,8 @@
-"""M9'-a contract tests for `_compat.ids`.
+"""Contract tests for `_compat.ids`.
 
-Verifies the deterministic ID-derivation contract that the M9'-b shadow
-runner adapter will rely on. Per the Oracle ruling on 2026-04-23 and
-the M7' fit-gap doc:
+Verifies the deterministic ID-derivation contract that the scenario-adapter
+slice will rely on. Per the Oracle ruling on 2026-04-23 and
+the simulation fit-gap doc:
 
   * `derive_scenario_key` is a versioned full-hash of a normalized
     `ScenarioContract v1` — stable across re-runs of the same contract,
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import date
+from typing import Any
 
 import pytest
 
@@ -32,8 +33,8 @@ from younggeul_core._compat.ids import (
 from younggeul_core.state.simulation import ScenarioSpec, Shock
 
 
-def _spec(**overrides: object) -> ScenarioSpec:
-    base: dict[str, object] = {
+def _spec(**overrides: Any) -> ScenarioSpec:
+    base: dict[str, Any] = {
         "scenario_name": "test",
         "target_gus": ["11680", "11440"],
         "target_period_start": date(2025, 3, 1),
@@ -41,7 +42,7 @@ def _spec(**overrides: object) -> ScenarioSpec:
         "shocks": [],
     }
     base.update(overrides)
-    return ScenarioSpec(**base)  # type: ignore[arg-type]
+    return ScenarioSpec(**base)
 
 
 class TestSeed:

--- a/core/tests/contract/test_compat_scenario.py
+++ b/core/tests/contract/test_compat_scenario.py
@@ -1,8 +1,8 @@
-"""M9'-b contract tests for `_compat.scenario`.
+"""Contract tests for `_compat.scenario`.
 
 Verifies the abdp scenario-runner adapter primitives: type-shape adapters,
 SimulationState projection, generic Agent/ActionResolver wrappers, and the
-AuditLog projection helper. Per Oracle's binding M9' ruling, the test
+AuditLog projection helper. Per Oracle's binding design ruling for the shadow-runner work, the test
 suite drives `abdp.scenario.ScenarioRunner.run()` end-to-end with
 callable-backed adapters and asserts the resulting ScenarioRun /
 AuditLog are real (not synthesized) abdp objects with all invariants
@@ -14,7 +14,7 @@ from __future__ import annotations
 # pyright: reportMissingImports=false
 
 from datetime import date, datetime, timezone
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 import pytest
@@ -157,7 +157,7 @@ class TestActionAdapter:
         assert adapter.action_key == "buy"
         assert adapter.payload["agent_id"] == "buyer-1"
         assert adapter.payload["action_type"] == "buy"
-        UUID(adapter.proposal_id)
+        _ = UUID(adapter.proposal_id)
         assert adapter.inner is core_action
 
     def test_proposal_id_is_deterministic(self, core_action: ActionProposal) -> None:
@@ -208,7 +208,7 @@ class TestSnapshotRefProjection:
                 sha256_hex=snapshot_sha,
                 storage_key="snapshots/x.parquet",
                 registry=registry,
-                tier="platinum",
+                tier=cast(Any, "platinum"),
             )
 
 
@@ -383,8 +383,12 @@ class TestEndToEndScenarioRun:
 
         resolver = CallableResolver(resolve_fn=resolve)
 
-        runner: ScenarioRunner[Any, Any, Any] = ScenarioRunner(agents=(agent,), resolver=resolver, max_steps=3)
-        run = runner.run(spec)
+        runner: ScenarioRunner[Any, Any, Any] = ScenarioRunner(
+            agents=cast(Any, (agent,)),
+            resolver=cast(Any, resolver),
+            max_steps=3,
+        )
+        run = runner.run(cast(Any, spec))
 
         assert isinstance(run, ScenarioRun)
         assert run.scenario_key == scenario_key
@@ -455,7 +459,7 @@ class TestProjectAuditLog:
         # invariant always holds when called via project_audit_log.
         # Constructing AuditLog directly with mismatched values must fail.
         with pytest.raises(ValueError, match="scenario_key"):
-            AuditLog(
+            _ = AuditLog(
                 scenario_key="different",
                 seed=run.seed,
                 run=run,

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -40,16 +40,16 @@ To provide an agent-based simulation platform that:
 - Using Seoul Real Estate Information Plaza (서울부동산정보광장) as ground truth.
 
 ## 6. Key Features (Milestones)
-- **M1: Data Contracts & Schemas**: Define Bronze/Silver/Gold data tiers using Pydantic v2.
-- **M2: Data Connectors**: Integration with `data.go.kr` (MOLIT), BOK ECOS, and KOSIS via the [kpubdata](https://pypi.org/project/kpubdata/) unified client (see ADR-007).
-- **M3: Data Pipeline**: Deterministic ETL (Bronze → Silver → Gold) without LLM intervention.
-- **M4: Snapshot System**: Immutable datasets with `dataset_snapshot_id` and SHA-256 verification (Reference: ADR-003).
-- **M5: Simulation Core**: LangGraph state machine combining 5 LLM agents and 5 deterministic nodes (Reference: ADR-004).
-- **M6: Evidence & Reporting**: JSON-first claim generation followed by a citation gate and prose rendering (Reference: ADR-005).
-- **M7: Evaluation**: Regression testing using promptfoo benchmarks and golden datasets.
-- **M8: Observability**: Full tracing with OpenTelemetry and LangSmith.
-- **M9: CLI & API**: Management via `typer` CLI and `FastAPI` endpoints.
-- **M10: Release & Documentation**: Public release with comprehensive user guides.
+- **Data Contracts & Schemas**: Define Bronze/Silver/Gold data tiers using Pydantic v2.
+- **Data Connectors**: Integration with `data.go.kr` (MOLIT), BOK ECOS, and KOSIS via the [kpubdata](https://pypi.org/project/kpubdata/) unified client (see ADR-007).
+- **Data Pipeline**: Deterministic ETL (Bronze → Silver → Gold) without LLM intervention.
+- **Snapshot System**: Immutable datasets with `dataset_snapshot_id` and SHA-256 verification (Reference: ADR-003).
+- **Simulation Core**: LangGraph state machine combining 5 LLM agents and 5 deterministic nodes (Reference: ADR-004).
+- **Evidence & Reporting**: JSON-first claim generation followed by a citation gate and prose rendering (Reference: ADR-005).
+- **Evaluation**: Regression testing using promptfoo benchmarks and golden datasets.
+- **Observability**: Full tracing with OpenTelemetry and LangSmith.
+- **CLI & API**: Management via `typer` CLI and `FastAPI` endpoints.
+- **Release & Documentation**: Public release with comprehensive user guides.
 
 ## 7. Architecture Overview
 The system follows a three-plane separation architecture:

--- a/docs/adr/012-abdp-backed-core.md
+++ b/docs/adr/012-abdp-backed-core.md
@@ -42,29 +42,29 @@ Adopt an **adapter-layer architecture** (Option C in the design review). Specifi
 3. The default simulation engine remains LangGraph for the v0.3.x line. An `abdp.scenario.ScenarioRunner`-based engine is introduced later as an **experimental, non-default** second engine, only after parity with the LangGraph engine is demonstrated under the existing eval suite.
 4. Auditability, evaluation, and reporting primitives from `abdp` are wired in as an **optional render path** behind a CLI flag (`--render abdp|legacy`, default `legacy`), so the existing report behavior cannot regress silently.
 
-The migration is broken into ten independently shippable milestones (M1–M10) tracked as GitHub issues #236–#245 under epic #235. Each milestone is independently revertible via the backend flag and is gated on a parity test suite (M6).
+The migration is broken into ten independently shippable work items tracked as GitHub issues #236–#245 under epic #235. Each work item is independently revertible via the backend flag and is gated on the parity-suite expansion (issue #241).
 
 ### Alternatives considered
 
 - **Option A — Full migration.** Replace `younggeul_core` with `abdp` outright and rewrite the LangGraph engine onto `abdp.scenario.ScenarioRunner`. Rejected for this iteration: it couples three risks at once — pinning to an immature framework version, a package-wide API churn that touches 1,178 tests, and an execution-model rewrite (LangGraph → `ScenarioRunner`) that cannot be validated incrementally. Re-evaluated when the criteria in *Consequences → Exit criteria* below are met.
 
-- **Option B — Bridge-only.** Keep `younggeul_core` and LangGraph untouched; only translate the LangGraph run output into `abdp.evidence.AuditLog` at the boundary. Rejected as a terminal state: it preserves all duplication permanently and turns the bridge into a maintenance liability. Acceptable only as an interim step inside Option C (covered by M7).
+- **Option B — Bridge-only.** Keep `younggeul_core` and LangGraph untouched; only translate the LangGraph run output into `abdp.evidence.AuditLog` at the boundary. Rejected as a terminal state: it preserves all duplication permanently and turns the bridge into a maintenance liability. Acceptable only as an interim step inside Option C (covered by the LangGraph→AuditLog adapter work).
 
 ## Consequences
 
 ### Positive
 
-- **Bounded blast radius per milestone.** App code does not change; only `younggeul_core` internals do. Each milestone is a small, reviewable diff with a parity test.
-- **Net code reduction.** When M3–M5 land, ~600 LOC of `core/` becomes thin re-exports/wrappers; M10 deletes the legacy implementations after parity is proven.
+- **Bounded blast radius per work item.** App code does not change; only `younggeul_core` internals do. Each work item is a small, reviewable diff with a parity test.
+- **Net code reduction.** When the connectors-hashing adoption (#238), the data-aliases adoption (#239), and the simulation-overlap refactor land, ~600 LOC of `core/` becomes thin re-exports/wrappers; the final cleanup then deletes the legacy implementations after parity is proven.
 - **Auditability surface comes for free.** `abdp.evidence.AuditLog`, `abdp.evaluation.{evaluate_metrics, evaluate_gates}`, and `abdp.reporting.render_{json,markdown}_report` become available behind the optional render path without rewriting our renderer.
 - **No paradigm bet.** LangGraph stays the production engine; the `ScenarioRunner` engine is a parallel, opt-in track that can be abandoned without affecting v0.3.x.
 - **Reversible.** The `YOUNGGEUL_CORE_BACKEND={local,abdp}` flag lets us switch backends per-process without code changes.
 
 ### Negative
 
-- **Two-stack interim period.** Until M10, both `local` and `abdp` backends ship. The compat layer adds a small amount of indirection.
+- **Two-stack interim period.** Until the selective-adoption finalization (issue #245), both `local` and `abdp` backends ship. The compat layer adds a small amount of indirection.
 - **External version pin.** We pin a specific `abdp` commit, not a published PyPI version. Upgrades require a deliberate parity rerun.
-- **Bridge code (M7) risks becoming permanent** if M9/M10 stall. Mitigation: every adapter-introducing milestone has a paired cleanup criterion in the epic's risk register.
+- **Bridge code risks becoming permanent** if the shadow-runner work (#244) or the selective-adoption finalization (#245) stalls. Mitigation: every adapter-introducing work item has a paired cleanup criterion in the epic's risk register.
 
 ### Exit criteria for revisiting Option A
 
@@ -72,58 +72,87 @@ A full Option A cutover (drop `younggeul_core`, replace LangGraph with `Scenario
 
 1. `abdp` publishes a stable, semver-versioned release on PyPI (no more `0.1.0.dev0` mismatch).
 2. younggeul has a concrete need for multi-engine simulation that LangGraph alone cannot satisfy.
-3. The experimental `ScenarioRunner` engine from M9 has matched the LangGraph engine's outputs under the full eval suite (`pytest -m eval`) in shadow mode for at least one minor release.
+3. The experimental `ScenarioRunner` engine from the shadow-runner work (issue #244) has matched the LangGraph engine's outputs under the full eval suite (`pytest -m eval`) in shadow mode for at least one minor release.
 
 Until then, the stance is: **C now, A later if earned.**
 
 ## Risk register
 
-1. **Semantic mismatch in "near-identical" types.** Local and `abdp` Pydantic models may validate or serialize differently in edge cases. *Mitigation:* M6 introduces a parametrized parity suite asserting byte-identical JSON dumps and equivalent validation behavior across both backends.
+1. **Semantic mismatch in "near-identical" types.** Local and `abdp` Pydantic models may validate or serialize differently in edge cases. *Mitigation:* the parity-suite expansion (issue #241) introduces a parametrized suite asserting byte-identical JSON dumps and equivalent validation behavior across both backends.
 2. **`abdp` version instability** (tag `v0.3.0` vs internal `0.1.0.dev0`). *Mitigation:* pin a specific commit SHA in `pyproject.toml`; isolate every `abdp` import behind `_compat`; upstream fixes asynchronously.
-3. **Behavior drift in simulation outputs.** Even with matching types, report content or event sequences could shift. *Mitigation:* keep LangGraph default; M9 adds shadow-mode parity tests on event count, final state, and rendered report semantics before any engine flip.
-4. **Bridge code becoming permanent.** Adapter layers tend to outlive their stated purpose. *Mitigation:* M7's adapter has a paired removal criterion in M10; every adapter-introducing PR must reference its cleanup issue.
-5. **LangGraph removal scope creep.** LangGraph is currently a hard dependency wired into the web layer, the CLI, and many tests. *Mitigation:* defer any LangGraph removal until after M9 ScenarioRunner parity is independently demonstrated; treat removal as a separate post-M10 decision.
+3. **Behavior drift in simulation outputs.** Even with matching types, report content or event sequences could shift. *Mitigation:* keep LangGraph default; the shadow-runner work (issue #244) adds shadow-mode parity tests on event count, final state, and rendered report semantics before any engine flip.
+4. **Bridge code becoming permanent.** Adapter layers tend to outlive their stated purpose. *Mitigation:* the LangGraph→AuditLog adapter work has a paired removal criterion in the selective-adoption finalization (issue #245); every adapter-introducing PR must reference its cleanup issue.
+5. **LangGraph removal scope creep.** LangGraph is currently a hard dependency wired into the web layer, the CLI, and many tests. *Mitigation:* defer any LangGraph removal until after shadow `ScenarioRunner` parity is independently demonstrated; treat removal as a separate post-finalization decision.
 
 ## Implementation milestones
 
-| # | Issue | Title | Size |
+| Label | Issue | Title | Size |
 |---|---|---|---|
-| M1 | #236 | ADR-012 (this document) | S |
-| M2 | #237 | Add internal abdp backend switch | M |
-| M3 | #238 | Delegate `connectors/{hashing,retry,manifest,protocol}` → `abdp.core` | S |
-| M4 | #239 | Delegate `state/{bronze,silver,gold}` + `storage/snapshot` → `abdp.data` | M |
-| M5 | #240 | Refactor `state/simulation` into abdp overlap + extensions | M |
-| M6 | #241 | Contract-parity test suite (local vs abdp) | M |
-| M7 | #242 | LangGraph run → `abdp.evidence.AuditLog` adapter | M |
-| M8 | #243 | Optional `--render abdp` CLI path | M |
-| M9 | #244 | Prototype `ScenarioRunner` engine (experimental) | L |
-| M10 | #245 | Remove duplicated legacy core after default flip | M |
+| ADR | #236 | ADR-012 (this document) | S |
+| Backend switch | #237 | Add internal abdp backend switch | M |
+| Connectors hashing | #238 | Delegate `connectors/{hashing,retry,manifest,protocol}` → `abdp.core` | S |
+| Data aliases | #239 | Delegate `state/{bronze,silver,gold}` + `storage/snapshot` → `abdp.data` | M |
+| Simulation overlap | #240 | Refactor `state/simulation` into abdp overlap + extensions | M |
+| Parity suite | #241 | Contract-parity test suite (local vs abdp) | M |
+| AuditLog adapter | #242 | LangGraph run → `abdp.evidence.AuditLog` adapter | M |
+| Reporting render flag | #243 | Optional `--render abdp` CLI path | M |
+| Shadow runner | #244 | Prototype `ScenarioRunner` engine (experimental) | L |
+| Finalization | #245 | Remove duplicated legacy core after default flip | M |
 
-## Amendment (2026-04-23) — M4'–M10' scope correction
+## Amendment (2026-04-23) — selective-adoption scope correction
 
-Hands-on inspection during M4 and a follow-up Oracle consult revealed that several "near-identical" entries in the surface-comparison table above are *named* the same as `abdp` types but model fundamentally different concepts. The migration plan is therefore revised as follows. The original architectural decision (Option C — adapter layer) stands; only the per-milestone scope changes.
+Hands-on inspection during the data-aliases adoption (issue #239) and a follow-up Oracle consult revealed that several "near-identical" entries in the surface-comparison table above are *named* the same as `abdp` types but model fundamentally different concepts. The migration plan is therefore revised as follows. The original architectural decision (Option C — adapter layer) stands; only the per-work-item scope changes.
 
 **Binding scope corrections:**
 
 - **`state/{bronze,silver,gold}.py` are NOT replaced.** `abdp.data.{Bronze,Silver,Gold}Contract` are abstract structural `Protocol[RowT]` types with only `manifest` / `rows`. The local schemas are concrete Pydantic models for the Korean apartment domain (e.g. `BronzeAptTransaction` carries 32 MOLIT fields). They remain younggeul-owned.
 - **`storage/snapshot.SnapshotManifest` is NOT replaced.** `abdp.data.SnapshotManifest` is a per-tier UUID-keyed dataclass with parent-pointer lineage; ours is a Pydantic multi-table dataset manifest with sha256-derived `dataset_snapshot_id`. Different concept under the same name. It remains younggeul-owned.
-- **`connectors/{retry,manifest,protocol}` adaptation is permanently abandoned** (issue #238 closed). `abdp.core.retry` is a decorator factory with a different invocation contract; `abdp.core.ManifestFactory` produces abdp `SnapshotManifest`, not `BronzeIngestManifest`. Only `connectors/hashing.sha256_payload` was successfully delegated to `abdp.core.stable_hash` (M3, merged).
-- **M5' (#242, LangGraph→AuditLog adapter) is deferred to M9'** (2026-04-23 follow-up Oracle re-consult). `abdp.evidence.AuditLog` is a frozen dataclass whose `__post_init__` enforces `scenario_key == run.scenario_key` and `seed == run.seed`, where `Seed = NewType("Seed", int)`. younggeul has no integer seed, no `scenario_key`, no per-step `SimulationState` snapshots, and no UUID-keyed `SnapshotRef`. Building an AuditLog now would force inventing all of those, contradicting the binding rule "don't invent public IDs to satisfy Protocols (keep synthesis private to M9 adapters)." The shadow `ScenarioRunner` in M9' produces `ScenarioRun` / `Seed` / `scenario_key` / per-step `SimulationState` natively, so the AuditLog projection happens there with real provenance, not synthetic. **M6' (reporting renderer) becomes the next shippable milestone** because reporting needs only formatting compatibility, not simulation-provenance compatibility.
-- **M10 no longer flips the default backend or targets ~600 LOC of deletions.** The success gate becomes "framework logic adopted where semantics actually match, with parity tests covering each adopted surface."
+- **`connectors/{retry,manifest,protocol}` adaptation is permanently abandoned** (issue #238 closed). `abdp.core.retry` is a decorator factory with a different invocation contract; `abdp.core.ManifestFactory` produces abdp `SnapshotManifest`, not `BronzeIngestManifest`. Only `connectors/hashing.sha256_payload` was successfully delegated to `abdp.core.stable_hash` (the connectors-hashing adoption, merged).
+- **The LangGraph→AuditLog adapter work (issue #242, deferred and absorbed into #244) is deferred to the shadow-runner work (issue #244)** (2026-04-23 follow-up Oracle re-consult). `abdp.evidence.AuditLog` is a frozen dataclass whose `__post_init__` enforces `scenario_key == run.scenario_key` and `seed == run.seed`, where `Seed = NewType("Seed", int)`. younggeul has no integer seed, no `scenario_key`, no per-step `SimulationState` snapshots, and no UUID-keyed `SnapshotRef`. Building an AuditLog now would force inventing all of those, contradicting the binding rule "don't invent public IDs to satisfy Protocols (keep synthesis private to the shadow-runner adapters)." The shadow `ScenarioRunner` in the shadow-runner work (issue #244) produces `ScenarioRun` / `Seed` / `scenario_key` / per-step `SimulationState` natively, so the AuditLog projection happens there with real provenance, not synthetic. **The reporting render-flag work (issue #243, PR #251) becomes the next shippable work item** because reporting needs only formatting compatibility, not simulation-provenance compatibility.
+- **The selective-adoption finalization (issue #245) no longer flips the default backend or targets ~600 LOC of deletions.** The success gate becomes "framework logic adopted where semantics actually match, with parity tests covering each adopted surface."
 
-**Revised milestone map (M-prefixes are internal IDs only; not present in issue titles):**
+**Revised work-item map:**
 
-| # | Issue | Revised deliverable |
+| Label | Issue | Revised deliverable |
 |---|---|---|
-| M4' | [#239](https://github.com/kpubdata-lab/younggeul/issues/239) | `_compat.data` re-exports of `Bronze/Silver/GoldContract`, `SnapshotTier`, `AbdpSnapshotManifest` only. Schemas + storage manifest stay local. |
-| ~~M5'~~ | ~~[#242](https://github.com/kpubdata-lab/younggeul/issues/242)~~ | **Deferred to M9'** (2026-04-23 Oracle re-consult). Producing an `abdp.evidence.AuditLog` from the current LangGraph run output requires synthesizing public IDs (`Seed: int`, `scenario_key`, `SnapshotRef.snapshot_id: UUID`, deterministic evidence/claim UUIDs) and per-step `SimulationState` snapshots LangGraph does not record. The shadow `ScenarioRunner` in M9' produces all of these natively, so the AuditLog adapter becomes a thin projection there instead of public-ID synthesis here. |
-| M6' | [#243](https://github.com/kpubdata-lab/younggeul/issues/243) | ✅ **Shipped** in [PR #251](https://github.com/kpubdata-lab/younggeul/pull/251). `--render abdp\|legacy` CLI flag on `simulate`, delegating to `abdp.reporting.render_json_report` over `RenderedReport.model_dump(mode="json")`. Markdown remains the byte-identical default. |
-| M7' | [#240](https://github.com/kpubdata-lab/younggeul/issues/240) | **Doc-only** (Oracle 2026-04-23): [`docs/architecture/abdp-simulation-fit-gap.md`](../architecture/abdp-simulation-fit-gap.md). Full surface inventory + per-field gap classification + per-surface M9'/M10' landing plan, used as the build-spec for M9'. No `state/simulation.py` change, no Protocol re-exports, no overlap parity test (every overlap surface is `public-ID-bearing` and would require pre-M9' synthesis). |
-| M8' | [#241](https://github.com/kpubdata-lab/younggeul/issues/241) | Expanded parity suite covering every adopted surface (excludes AuditLog until M9'). |
-| M9' | [#244](https://github.com/kpubdata-lab/younggeul/issues/244) | Shadow-mode `ScenarioRunner` **and** the real `AuditLog` adapter absorbed from #242. LangGraph stays the default execution engine. Shipped in three PRs: M9'-a (`_compat/ids.py` ID helpers, [PR #254](https://github.com/kpubdata-lab/younggeul/pull/254)), M9'-b (`_compat/scenario.py` adapter primitives, [PR #255](https://github.com/kpubdata-lab/younggeul/pull/255)), and M9'-c (`apps/.../simulation/shadow_runner.py` + `simulate --shadow-audit-log`, this PR). |
-| M10' | [#245](https://github.com/kpubdata-lab/younggeul/issues/245) | Selective-adoption finalization. **No default flip.** Remove only dead shims that selective adoption made unreachable. |
+| Data aliases | [#239](https://github.com/kpubdata-lab/younggeul/issues/239) | `_compat.data` re-exports of `Bronze/Silver/GoldContract`, `SnapshotTier`, `AbdpSnapshotManifest` only. Schemas + storage manifest stay local. |
+| LangGraph→AuditLog adapter work (deferred and absorbed) | ~~[#242](https://github.com/kpubdata-lab/younggeul/issues/242)~~ | **Deferred to the shadow-runner work (issue #244)** (2026-04-23 Oracle re-consult). Producing an `abdp.evidence.AuditLog` from the current LangGraph run output requires synthesizing public IDs (`Seed: int`, `scenario_key`, `SnapshotRef.snapshot_id: UUID`, deterministic evidence/claim UUIDs) and per-step `SimulationState` snapshots LangGraph does not record. The shadow `ScenarioRunner` in the shadow-runner work produces all of these natively, so the AuditLog adapter becomes a thin projection there instead of public-ID synthesis here. |
+| Reporting render flag | [#243](https://github.com/kpubdata-lab/younggeul/issues/243) | ✅ **Shipped** in [PR #251](https://github.com/kpubdata-lab/younggeul/pull/251). `--render abdp\|legacy` CLI flag on `simulate`, delegating to `abdp.reporting.render_json_report` over `RenderedReport.model_dump(mode="json")`. Markdown remains the byte-identical default. |
+| Simulation fit-gap doc | [#240](https://github.com/kpubdata-lab/younggeul/issues/240) | **Doc-only** (Oracle 2026-04-23): [`docs/architecture/abdp-simulation-fit-gap.md`](../architecture/abdp-simulation-fit-gap.md). Full surface inventory + per-field gap classification + per-surface shadow-runner/finalization landing plan, used as the build-spec for the shadow-runner work. No `state/simulation.py` change, no Protocol re-exports, no overlap parity test (every overlap surface is `public-ID-bearing` and would require pre-shadow-runner synthesis). |
+| Parity suite expansion | [#241](https://github.com/kpubdata-lab/younggeul/issues/241) | Expanded parity suite covering every adopted surface (excludes AuditLog until the shadow-runner work). |
+| Shadow runner | [#244](https://github.com/kpubdata-lab/younggeul/issues/244) | Shadow-mode `ScenarioRunner` **and** the real `AuditLog` adapter absorbed from #242. LangGraph stays the default execution engine. Shipped in three PRs: PR #254 (ID helpers), PR #255 (scenario adapter), and PR #256 (shadow runner). |
+| Finalization | [#245](https://github.com/kpubdata-lab/younggeul/issues/245) | ✅ **Shipped.** Selective-adoption finalization. **No default flip.** Doc and CI hardening only — no code/module removal owed (remaining local surfaces are intentionally younggeul-owned domain types and the LangGraph runtime, not duplicate framework code). See "Final selective-adoption inventory" below. |
 
-The `YOUNGGEUL_CORE_BACKEND={local,abdp}` flag introduced in M2 still selects between local and adapter-routed code paths where adoption succeeded; the flag's default remains `local` indefinitely.
+### Final selective-adoption inventory
+
+The 2026-04-23 finalization ruling (Oracle, recorded in this amendment) closed out the selective-adoption epic without flipping the default backend and without deleting any local module. The inventory below freezes the per-surface adoption decision and the parity tests that gate it. Future changes to this inventory require a new ADR or amendment.
+
+**Adopted surfaces (delegated to `abdp` and gated by parity tests)**
+
+| Surface | Local site | abdp target | Parity test |
+|---|---|---|---|
+| Payload hashing | `core/connectors/hashing.py::sha256_payload` | `abdp.core.stable_hash` | `core/tests/contract/test_compat_hashing_parity.py` |
+| Bronze/Silver/Gold contract aliases | `core/_compat/data.py::{BronzeContract, SilverContract, GoldContract, SnapshotTier, AbdpSnapshotManifest}` | `abdp.data` re-exports | `core/tests/contract/test_compat_data_aliases.py` |
+| JSON report renderer | `core/_compat/reporting.py::render_json_report` | `abdp.reporting.render_json_report` | `core/tests/contract/test_compat_reporting.py`, `apps/kr-seoul-apartment/tests/unit/test_cli_render_flag.py` |
+| Deterministic ID helpers | `core/_compat/ids.py::{derive_scenario_key, derive_snapshot_uuid, SnapshotIdRegistry}` | `abdp.simulation` ID contract (`scenario_key`, `Seed`, `SnapshotRef.snapshot_id` UUID) | `core/tests/contract/test_compat_ids.py` |
+| Scenario / participant / action / segment adapters + shadow `AuditLog` projection | `core/_compat/scenario.py::{AbdpSegmentAdapter, AbdpParticipantAdapter, AbdpActionAdapter, CallableAgent, CallableResolver, to_abdp_snapshot_ref, to_abdp_simulation_state, project_audit_log}` and `apps/.../simulation/shadow_runner.py::run_shadow_audit` | `abdp.simulation.{SegmentState, ParticipantState, ActionProposal, ScenarioRunner}`, `abdp.evidence.AuditLog` | `core/tests/contract/test_compat_scenario.py`, `apps/kr-seoul-apartment/tests/integration/test_simulate_cli_shadow_audit.py` |
+
+**Retained local by design (NOT delegated)**
+
+| Surface | Rationale |
+|---|---|
+| `core/storage/snapshot.py::{SnapshotManifest, SnapshotTableEntry}` | younggeul's snapshot manifest models the Korean-public-data ingest layout (Bronze tables keyed by `gu_code`/`month`, MOLIT/BOK/KOSTAT provenance fields). `abdp.data.SnapshotManifest` models a generic decision-pipeline snapshot ref. The shapes are not interchangeable; bridging via `_compat/data.py::AbdpSnapshotManifest` is sufficient at the boundary. |
+| `core/state/{bronze,silver,gold}.py` | Korean apartment domain types (apartment trades, base rate, net-migration). The `abdp.data.{Bronze,Silver,Gold}Contract` aliases in `_compat/data.py` cover the framework-facing typing needs without forcing the domain models out of younggeul. |
+| `core/state/simulation.py` | younggeul's `SimulationState` is the LangGraph TypedDict consumed by the runtime. `abdp.simulation.SimulationState` is a Protocol used at the shadow-runner boundary. The shadow runner (`apps/.../simulation/shadow_runner.py`) projects the LangGraph state into the abdp Protocol; the canonical in-memory representation stays local. |
+| `apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/` (LangGraph runtime — nodes, graph, events) | This is the production execution engine and the default code path under `YOUNGGEUL_CORE_BACKEND=local`. The shadow runner runs alongside it via `simulate --shadow-audit-log` for `AuditLog` provenance; replacing LangGraph would be a separate post-finalization decision. |
+
+**CI hardening shipped with the finalization**
+
+- `.github/workflows/test.yml` matrix simplified to `backend: [local, abdp]`; both legs install `[dev,kr-seoul-apartment,abdp]`.
+- Test scope changed from `pytest -m "not slow and not integration"` to `pytest -m "not slow and not live"` so the shadow-runner integration test (`test_simulate_cli_shadow_audit`) and other integration coverage actually execute on every push.
+- Guardrail test `test_default_backend_remains_local` in `core/tests/contract/test_compat_guardrails.py` enforces `DEFAULT_BACKEND == "local"` at the source level — a default flip now requires a new ADR/amendment, not a constant rename.
+
+The `YOUNGGEUL_CORE_BACKEND={local,abdp}` flag introduced in the backend-switch work (issue #237) still selects between local and adapter-routed code paths where adoption succeeded; the flag's default remains `local` indefinitely.
 
 ## References
 

--- a/docs/architecture/abdp-simulation-fit-gap.md
+++ b/docs/architecture/abdp-simulation-fit-gap.md
@@ -1,7 +1,7 @@
-# abdp.simulation Fit-Gap Matrix (M7')
+# abdp.simulation Fit-Gap Matrix
 
-> **Status**: Build-spec for M9' (shadow `ScenarioRunner` + `AuditLog` adapter).
-> **Scope of this document**: Per the [ADR-012 M4'–M10' scope correction](../adr/012-abdp-backed-core.md#amendment-2026-04-23--m4m10-scope-correction) and the M5' deferral re-affirmed by the Oracle consultation on 2026-04-23, M7' is doc-first. It catalogs every surface in `abdp.simulation` against the corresponding surface in `younggeul_core.state.simulation` (and `…/simulation/state.py` graph state) and assigns each gap to a future milestone. **No code in `state/simulation.py` is modified by M7'.**
+> **Status**: Build-spec for the shadow-runner work (issue #244) (shadow `ScenarioRunner` + `AuditLog` adapter).
+> **Scope of this document**: Per the [ADR-012 selective-adoption scope correction](../adr/012-abdp-backed-core.md#amendment-2026-04-23--selective-adoption-scope-correction) and the LangGraph→AuditLog adapter work (issue #242, deferred and absorbed into #244) deferral re-affirmed by the Oracle consultation on 2026-04-23, this doc is doc-first. It catalogs every surface in `abdp.simulation` against the corresponding surface in `younggeul_core.state.simulation` (and `…/simulation/state.py` graph state) and assigns each gap to a future work item. **No code in `state/simulation.py` is modified by this doc.**
 
 ## 1. Scope and non-goals
 
@@ -9,41 +9,41 @@
 
 - Field-level inventory of every public type in `abdp.simulation` and the equivalent (or analogous) surface in younggeul today.
 - Per-surface gap classification (`name`, `type`, `semantics`, `missing`, `public-ID-bearing`).
-- Per-surface landing decision for M9'/M10' (`adapter`, `local-only keep`, `no adoption`).
-- Required decision inputs (constraints) for M9' to resolve.
-- Forbidden patterns and what M7' deliberately does **not** promise.
+- Per-surface landing decision for the shadow-runner/finalization work (`adapter`, `local-only keep`, `no adoption`).
+- Required decision inputs (constraints) for the shadow-runner work to resolve.
+- Forbidden patterns and what this doc deliberately does **not** promise.
 
-**Out of scope (deferred to M9' and beyond)**
+**Out of scope (deferred to the shadow-runner work in #244 and beyond)**
 
 - Any change to `core/src/younggeul_core/state/simulation.py`.
 - Any re-export of `abdp.simulation` Protocols from `_compat`.
 - Any "overlap parity" test that would require synthesizing public IDs (`Seed`, `scenario_key`, `snapshot_id`, `proposal_id`, segment IDs).
-- Any decision on a concrete ID-generation algorithm (e.g. UUIDv5 in a fixed namespace) — those are M9' design questions and writing them down here would anchor implementation/tests prematurely.
+- Any decision on a concrete ID-generation algorithm (e.g. UUIDv5 in a fixed namespace) — those are shadow-runner design questions and writing them down here would anchor implementation/tests prematurely.
 - Any change to LangGraph nodes to record per-step state snapshots.
 - Any new public CLI surface (`--seed`, scenario-key flags, etc.).
 
 ## 2. Constraints and decision inputs (NOT allocation rules)
 
-This section enumerates the **constraints** that any M9' design must satisfy. It deliberately does **not** prescribe the algorithm.
+This section enumerates the **constraints** that any shadow-runner design must satisfy. It deliberately does **not** prescribe the algorithm.
 
 ### Hard constraints (binding)
 
-1. **No public ID synthesis pre-M9'.** Pre-M9' code MUST NOT introduce, persist, expose, or test against any of: `Seed`, `scenario_key`, `snapshot_id` (UUID), `proposal_id`, synthetic segment IDs. These either do not exist in younggeul today or exist in a fundamentally different shape (e.g. sha256 hex vs UUID); inventing them in adapters would encode fake provenance into public surfaces.
-2. **`run_id` is identity, not a causal seed.** Deriving any `Seed` value from `run_id` would manufacture false determinism. Any `Seed` introduced by M9' must have real cross-engine semantics (e.g. an actual RNG seed used by the simulation), not a re-labelled identity hash.
-3. **Default backend stays `local`.** No part of M7'/M9'/M10' may flip the default `YOUNGGEUL_CORE_BACKEND` away from `local`. Adoption is selective and opt-in.
+1. **No public ID synthesis pre-shadow-runner.** Pre-shadow-runner code MUST NOT introduce, persist, expose, or test against any of: `Seed`, `scenario_key`, `snapshot_id` (UUID), `proposal_id`, synthetic segment IDs. These either do not exist in younggeul today or exist in a fundamentally different shape (e.g. sha256 hex vs UUID); inventing them in adapters would encode fake provenance into public surfaces.
+2. **`run_id` is identity, not a causal seed.** Deriving any `Seed` value from `run_id` would manufacture false determinism. Any `Seed` introduced by the shadow-runner work must have real cross-engine semantics (e.g. an actual RNG seed used by the simulation), not a re-labelled identity hash.
+3. **Default backend stays `local`.** No part of the simulation fit-gap doc, the shadow-runner work, or the selective-adoption finalization may flip the default `YOUNGGEUL_CORE_BACKEND` away from `local`. Adoption is selective and opt-in.
 4. **v0.3.0 behavior must remain byte-identical on `local`.** All 1,261 unit tests continue to pass; any new adapter is invoked only on the `abdp` backend.
 
-### Decision inputs M9' must resolve (do **not** answer here)
+### Decision inputs the shadow-runner work must resolve (do **not** answer here)
 
 - What semantic role does `Seed` play in younggeul's simulation? (Today the LangGraph nodes have no RNG-seeded behavior; if any randomness is introduced, the seed must be defined as a *first-class* cross-engine concept, not back-ported.)
-- What is the public-vs-internal status of synthesized IDs? (M9' should default to **internal/opaque/stable** — never surfaced to users — until a user-facing requirement forces otherwise.)
+- What is the public-vs-internal status of synthesized IDs? (The shadow-runner work should default to **internal/opaque/stable** — never surfaced to users — until a user-facing requirement forces otherwise.)
 - What is the storage contract for `snapshot_id` if/when it becomes a UUID? (Today's `dataset_snapshot_id` is a sha256 hex digest; any mapping must be reversible/auditable, not a one-way derivation that drops content-addressing.)
-- What is the `scenario_key` semantic? (Stable across re-runs of the same scenario? Sensitive to roster/shock changes? M9' must define this from the simulation contract, not from the field shape of `ScenarioSpec`.)
+- What is the `scenario_key` semantic? (Stable across re-runs of the same scenario? Sensitive to roster/shock changes? The shadow-runner work must define this from the simulation contract, not from the field shape of `ScenarioSpec`.)
 - Does `abdp.simulation.SimulationState` (a generic dataclass) need to become the canonical in-memory representation, or can it remain a *projection* of the existing TypedDict `GraphState` produced at the runner boundary?
 
 ## 3. Surface inventory matrix
 
-For each `abdp.simulation` symbol, the table records: shape, the analogous younggeul surface, field-level mismatches (tagged), and the M9'/M10' landing.
+For each `abdp.simulation` symbol, the table records: shape, the analogous younggeul surface, field-level mismatches (tagged), and the shadow-runner/finalization landing.
 
 ### 3.1 `ScenarioSpec` — Protocol
 
@@ -58,7 +58,7 @@ For each `abdp.simulation` symbol, the table records: shape, the analogous young
 | — | `target_period_end: date` | local-only |
 | — | `shocks: tuple[Shock, ...]` | local-only |
 
-**Landing**: `adapter` in M9', wrapping the existing Pydantic model and projecting `scenario_key` + `seed` from M9'-defined sources. **No re-export** until that adapter exists.
+**Landing**: `adapter` in the shadow-runner work, wrapping the existing Pydantic model and projecting `scenario_key` + `seed` from shadow-runner-defined sources. **No re-export** until that adapter exists.
 
 ### 3.2 `SegmentState` — Protocol
 
@@ -68,7 +68,7 @@ For each `abdp.simulation` symbol, the table records: shape, the analogous young
 | `participant_ids: tuple[str, ...]` | *missing* (participant↔segment relation is implicit in the round resolver) | `missing`, `semantics` |
 | — | `gu_code, gu_name, current_median_price, current_volume, price_trend, sentiment_index, supply_pressure` | local-only |
 
-**Landing**: `adapter` in M9' that exposes `gu_code` as `segment_id` and computes `participant_ids` from the runner state. **No re-export** today.
+**Landing**: `adapter` in the shadow-runner work that exposes `gu_code` as `segment_id` and computes `participant_ids` from the runner state. **No re-export** today.
 
 ### 3.3 `ParticipantState` — Protocol
 
@@ -77,7 +77,7 @@ For each `abdp.simulation` symbol, the table records: shape, the analogous young
 | `participant_id: str` | `participant_id: str` | matches |
 | — | `role, capital, holdings, risk_tolerance, sentiment` | local-only |
 
-**Landing**: closest to a true overlap, but adopting the Protocol type in `_compat` is still deferred to M9' so the change lands together with the runner-side Protocol conformance for `SegmentState`/`ScenarioSpec`. Adopting it alone would create an asymmetric API surface.
+**Landing**: closest to a true overlap, but adopting the Protocol type in `_compat` is still deferred to the shadow-runner work so the change lands together with the runner-side Protocol conformance for `SegmentState`/`ScenarioSpec`. Adopting it alone would create an asymmetric API surface.
 
 ### 3.4 `ActionProposal` — Protocol
 
@@ -88,7 +88,7 @@ For each `abdp.simulation` symbol, the table records: shape, the analogous young
 | `action_key: str` | `action_type: Literal[...]` | `name`, `type` |
 | `payload: Mapping[str, Any]` | `proposed_value, target_segment, confidence, reasoning_summary, round_no` | `semantics` (younggeul flattens; abdp uses an opaque payload) |
 
-**Landing**: `adapter` in M9' that wraps the Pydantic model. The `proposal_id` is a public-ID-bearing field and MUST NOT be synthesized pre-M9'. Renaming `agent_id`→`actor_id` and `action_type`→`action_key` is purely cosmetic on the adapter boundary; the source field names stay.
+**Landing**: `adapter` in the shadow-runner work that wraps the Pydantic model. The `proposal_id` is a public-ID-bearing field and MUST NOT be synthesized pre-shadow-runner. Renaming `agent_id`→`actor_id` and `action_type`→`action_key` is purely cosmetic on the adapter boundary; the source field names stay.
 
 ### 3.5 `SnapshotRef` — concrete dataclass
 
@@ -100,7 +100,7 @@ For each `abdp.simulation` symbol, the table records: shape, the analogous young
 | — | `table_count: int` | local-only |
 | — | `created_at: datetime` | local-only |
 
-**Landing**: `adapter` in M9'. The mapping from sha256 hex to `UUID` is a non-trivial design decision (see §2 — must be reversible/auditable, must not silently drop content-addressing) and is explicitly **deferred** here. M7' does not prescribe a mapping algorithm.
+**Landing**: `adapter` in the shadow-runner work. The mapping from sha256 hex to `UUID` is a non-trivial design decision (see §2 — must be reversible/auditable, must not silently drop content-addressing) and is explicitly **deferred** here. This doc does not prescribe a mapping algorithm.
 
 ### 3.6 `SimulationState` — generic dataclass
 
@@ -113,7 +113,7 @@ For each `abdp.simulation` symbol, the table records: shape, the analogous young
 | `participants: tuple[P, ...]` | `participant_roster` in `GraphState` | `name`, `semantics` |
 | `pending_actions: tuple[A, ...]` | `pending_proposals` in `GraphState` | `name` |
 
-**Landing**: `adapter` in M9' that **projects** the existing `GraphState` TypedDict into an `abdp.simulation.SimulationState` snapshot at the runner boundary. The `GraphState` TypedDict remains the canonical in-memory representation; M7' does **not** propose making `SimulationState` canonical.
+**Landing**: `adapter` in the shadow-runner work that **projects** the existing `GraphState` TypedDict into an `abdp.simulation.SimulationState` snapshot at the runner boundary. The `GraphState` TypedDict remains the canonical in-memory representation; this doc does **not** propose making `SimulationState` canonical.
 
 ### 3.7 younggeul-only types (no abdp counterpart)
 
@@ -121,21 +121,21 @@ For each `abdp.simulation` symbol, the table records: shape, the analogous young
 
 ## 4. Per-surface migration plan
 
-| Surface | Milestone | Adapter shape | Validating test (do **not** add until milestone) |
+| Surface | Work item | Adapter shape | Validating test (do **not** add until the work item) |
 |---|---|---|---|
-| `ScenarioSpec` | M9' | wrap `ScenarioSpec` Pydantic model; project `scenario_key` and `seed` from M9'-defined sources | Protocol-conformance test against `abdp.simulation.ScenarioSpec` |
-| `SegmentState` | M9' | wrap; expose `gu_code` as `segment_id`; compute `participant_ids` from runner state | Protocol-conformance test |
-| `ParticipantState` | M9' (with `ScenarioSpec`/`SegmentState`) | wrap; trivial field mapping | Protocol-conformance test |
-| `ActionProposal` | M9' | wrap; project `proposal_id` from M9'-defined source; rename `agent_id`→`actor_id`, `action_type`→`action_key`; flatten remainder into `payload` | Protocol-conformance test + round-trip adapter test |
-| `SnapshotRef` | M9' | wrap; map sha256 hex → `UUID` per M9' design (reversible/auditable, see §2); supply `tier` and `storage_key` from existing path conventions | Adapter test + reversibility test |
-| `SimulationState` | M9' | runner-boundary projection from `GraphState` TypedDict | Snapshot-projection test |
-| `AuditLog` | M9' (absorbed from #242) | shadow `ScenarioRunner` records `ScenarioStep` snapshots; full `AuditLog.__post_init__` invariants hold | Round-trip + invariant test (see #244) |
+| `ScenarioSpec` | the shadow-runner work | wrap `ScenarioSpec` Pydantic model; project `scenario_key` and `seed` from shadow-runner-defined sources | Protocol-conformance test against `abdp.simulation.ScenarioSpec` |
+| `SegmentState` | the shadow-runner work | wrap; expose `gu_code` as `segment_id`; compute `participant_ids` from runner state | Protocol-conformance test |
+| `ParticipantState` | the shadow-runner work (with `ScenarioSpec`/`SegmentState`) | wrap; trivial field mapping | Protocol-conformance test |
+| `ActionProposal` | the shadow-runner work | wrap; project `proposal_id` from shadow-runner-defined source; rename `agent_id`→`actor_id`, `action_type`→`action_key`; flatten remainder into `payload` | Protocol-conformance test + round-trip adapter test |
+| `SnapshotRef` | the shadow-runner work | wrap; map sha256 hex → `UUID` per the shadow-runner design (reversible/auditable, see §2); supply `tier` and `storage_key` from existing path conventions | Adapter test + reversibility test |
+| `SimulationState` | the shadow-runner work | runner-boundary projection from `GraphState` TypedDict | Snapshot-projection test |
+| `AuditLog` | the shadow-runner work (absorbed from #242) | shadow `ScenarioRunner` records `ScenarioStep` snapshots; full `AuditLog.__post_init__` invariants hold | Round-trip + invariant test (see #244) |
 | `RunMeta`, `RoundOutcome`, `ReportClaim`, `Shock` | (none) | — | — |
-| Default backend flip | M10' | none — confirm no flip happens | guardrail test |
+| Default backend flip | the selective-adoption finalization | none — confirm no flip happens | guardrail test |
 
-## 5. Forbidden patterns (M7'–M8')
+## 5. Forbidden patterns (fit-gap doc through parity-suite expansion)
 
-These are **binding** for any work landed before M9' opens:
+These are **binding** for any work landed before the shadow-runner work opens:
 
 - ✗ Do not introduce `Seed` anywhere — not as a field, not as a CLI flag, not as a derived value, not as a parameter to internal helpers.
 - ✗ Do not synthesize `scenario_key`, `snapshot_id` (UUID), `proposal_id`, or segment IDs in any code path that survives `_compat` boundaries.
@@ -143,13 +143,13 @@ These are **binding** for any work landed before M9' opens:
 - ✗ Do not write parity tests that compare today's Pydantic models to abdp Protocols at the field level. They do not overlap in the way a parity test would assert; the test would either fail or be made to pass by inventing forbidden values.
 - ✗ Do not describe today's local fields as "equivalent" to abdp counterparts in user-facing docs where the relationship is only loosely analogous (see the `name`/`type`/`semantics` tags above).
 - ✗ Do not promise cross-engine determinism, schema parity, or stable public IDs in this milestone.
-- ✗ Do not modify LangGraph nodes to record per-step `SimulationState` snapshots. That is M9' shadow-runner work.
+- ✗ Do not modify LangGraph nodes to record per-step `SimulationState` snapshots. That is the shadow-runner work.
 
-## 6. Required M9' design decisions (open questions) — RESOLVED
+## 6. Required shadow-runner design decisions (open questions) — RESOLVED
 
-> **Status (2026-04-23): Resolved by Oracle's binding M9' design ruling and shipped in PRs #254 (M9'-a), #255 (M9'-b), and the M9'-c shadow runner PR.** Each open question's resolution is recorded inline below.
+> **Status (2026-04-23): Resolved by Oracle's binding design ruling for the shadow-runner work and shipped in PR #254 (ID helpers), PR #255 (scenario adapter), and PR #256 (shadow runner).** Each open question's resolution is recorded inline below.
 
-M9' MUST resolve the following before it can build the adapters in §4. M7' does **not** answer them:
+The shadow-runner work must resolve the following before it can build the adapters in §4. This doc does **not** answer them:
 
 1. What is the canonical source of `Seed`? (See §2 hard constraints — must be a real RNG seed with cross-engine semantics, not derived from `run_id`.) — **RESOLVED**: `Seed: int = 0` runner-internal default (`DEFAULT_SHADOW_SEED` in `younggeul_core._compat.ids`). No CLI flag introduced. The seed is fixed because the shadow runner exercises deterministic policies whose decisions don't consume RNG.
 2. What is the canonical source of `scenario_key`? — **RESOLVED**: `yg-scenario-v1:<full sha256 hex>` of the canonicalized `ScenarioSpec` JSON (see `derive_scenario_key`). Hash is never truncated.
@@ -159,12 +159,12 @@ M9' MUST resolve the following before it can build the adapters in §4. M7' does
 
 ## 7. Verification
 
-M7' is doc-only and has **no code change**. Verification of M7' is:
+This fit-gap doc is doc-only and has **no code change**. Verification is:
 
 - This file exists at `docs/architecture/abdp-simulation-fit-gap.md`.
 - Issue #240 description is updated to point here and reflect the doc-only scope.
-- Issue #244 (M9') references this doc as its build-spec input.
-- ADR-012 amendment table reflects M7' as `docs-only`.
+- Issue #244 references this doc as its build-spec input.
+- ADR-012 amendment table reflects the simulation fit-gap doc as `doc-only`.
 
 No new tests are added. The 1,261-pass unit suite remains untouched.
 
@@ -172,6 +172,6 @@ No new tests are added. The 1,261-pass unit suite remains untouched.
 
 - [ADR-012: abdp-backed core compatibility architecture](../adr/012-abdp-backed-core.md)
 - Epic [#235](https://github.com/kpubdata-lab/younggeul/issues/235)
-- M7' issue [#240](https://github.com/kpubdata-lab/younggeul/issues/240)
-- M9' issue [#244](https://github.com/kpubdata-lab/younggeul/issues/244) (consumes this doc)
-- Deferred M5' issue [#242](https://github.com/kpubdata-lab/younggeul/issues/242) (absorbed into M9' per the 2026-04-23 Oracle ruling)
+- Simulation fit-gap doc issue [#240](https://github.com/kpubdata-lab/younggeul/issues/240)
+- Shadow-runner issue [#244](https://github.com/kpubdata-lab/younggeul/issues/244) (consumes this doc)
+- Deferred issue [#242](https://github.com/kpubdata-lab/younggeul/issues/242) (absorbed into #244 per the 2026-04-23 Oracle ruling)

--- a/docs/development-history.md
+++ b/docs/development-history.md
@@ -1,7 +1,7 @@
-# Development Journey: M0 → M10
+# Development Journey: v0.1 Release
 
 How the **영끌 시뮬레이터 (YOLO Mortgage Simulator)** went from an empty
-repository to a fully released v0.1.0 in eleven milestones.
+repository to a fully released v0.1.0 in eleven phases.
 
 ---
 
@@ -35,7 +35,7 @@ licensed codebase.
 
 ---
 
-## M0: Foundation & Scaffolding (12 issues)
+## Foundation & Scaffolding (12 issues)
 
 The first milestone established the repository skeleton.
 
@@ -64,7 +64,7 @@ The first milestone established the repository skeleton.
 
 ---
 
-## M1: Contracts & Schemas (8 issues)
+## Contracts & Schemas (8 issues)
 
 Data contracts came before any implementation — a deliberate choice that paid
 off throughout the project.
@@ -91,7 +91,7 @@ off throughout the project.
 
 ---
 
-## M2: Data Plane — Bronze (17 issues)
+## Data Plane — Bronze (17 issues)
 
 The first real data flowing through the system.
 
@@ -118,7 +118,7 @@ The first real data flowing through the system.
 
 ---
 
-## M3: Data Plane — Silver & Entity Resolution (11 issues)
+## Data Plane — Silver & Entity Resolution (11 issues)
 
 Cleaning and typing the raw Bronze data.
 
@@ -144,7 +144,7 @@ Cleaning and typing the raw Bronze data.
 
 ---
 
-## M4: Data Plane — Gold & Baseline (14 issues)
+## Data Plane — Gold & Baseline (14 issues)
 
 Aggregation and the first analytical output.
 
@@ -174,7 +174,7 @@ Aggregation and the first analytical output.
 
 ---
 
-## M5: Simulation Plane — Core Runtime (14 issues)
+## Simulation Plane — Core Runtime (14 issues)
 
 The simulation engine skeleton.
 
@@ -202,7 +202,7 @@ The simulation engine skeleton.
 
 ---
 
-## M6: Simulation Plane — Participant Agents (21 issues)
+## Simulation Plane — Participant Agents (21 issues)
 
 The largest milestone, bringing the market to life.
 
@@ -234,7 +234,7 @@ The largest milestone, bringing the market to life.
 
 ---
 
-## M7: Report & Evidence Pipeline (11 issues)
+## Report & Evidence Pipeline (11 issues)
 
 Turning simulation data into trustworthy output.
 
@@ -263,7 +263,7 @@ Turning simulation data into trustworthy output.
 
 ---
 
-## M8: Evaluation Plane (10 issues)
+## Evaluation Plane (10 issues)
 
 Systematic quality assurance.
 
@@ -293,7 +293,7 @@ Systematic quality assurance.
 
 ---
 
-## M9: Observability & Security (4 issues)
+## Observability & Security (4 issues)
 
 Production readiness foundations.
 
@@ -316,12 +316,12 @@ Production readiness foundations.
 
 **Lessons learned:**
 
-- The 4-issue milestone was refreshingly focused after M6's 21 issues.
+- The 4-issue milestone was refreshingly focused after the Participant Agents phase's 21 issues.
   Smaller milestones with clear scope are more productive.
 
 ---
 
-## M10: v0.1 Release (10 issues)
+## v0.1 Release (10 issues)
 
 Packaging everything for public use.
 
@@ -354,7 +354,7 @@ Packaging everything for public use.
 
 | Metric | Value |
 |--------|-------|
-| Milestones completed | 11 (M0 → M10) |
+| Phases completed | 11 (Foundation → v0.1 Release) |
 | Issues closed | 132 |
 | Pull requests merged | 60+ |
 | Tests passing | 1,111+ |


### PR DESCRIPTION
## Summary

Closes the selective-adoption epic (#245, epic #235) per the 2026-04-23 finalization ruling recorded in ADR-012:

- **No default flip.** `DEFAULT_BACKEND` stays `"local"` indefinitely.
- **No code/module removal owed.** Remaining local surfaces (`storage/snapshot`, `state/{bronze,silver,gold}`, `state/simulation`, the LangGraph runtime under `apps/.../simulation/`) are intentionally younggeul-owned domain types, not duplicate framework code.
- **Doc + CI hardening only.**

Also strips all `M`-prefix milestone tags (`M0`..`M10`, `M4'`..`M10'`, `M9'-a/b/c`) from code comments, docstrings, tests, and docs across 22 files (147 occurrences). Historical traceability now lives in git history + GitHub issues only.

## Changes

- **ADR-012 amendment table**: 'Finalization' row marked **Shipped**; new **'Final selective-adoption inventory'** subsection freezes the per-surface adoption decision (adopted vs retained-local-by-design) and lists the parity tests gating each adopted surface.
- **README**: 'abdp backend' section drops experimental framing; describes the final selective-adoption state including the shadow runner and `simulate --shadow-audit-log`.
- **CHANGELOG**: new `[Unreleased]` section documents finalization, shadow runner, render flag, ID helpers, scenario adapters, parity coverage.
- **`_compat` module + test docstrings**: rewritten to describe final state, drop pre-shadow-runner / next-milestone language.
- **New guardrail test** `test_default_backend_remains_local` enforces `DEFAULT_BACKEND == 'local'` at the source level — a future flip requires a new ADR/amendment, not a constant rename.
- **CI workflow** (`.github/workflows/test.yml`): matrix simplified to `[local, abdp]`; both legs install `[dev,kr-seoul-apartment,abdp]`; test scope changed from `not slow and not integration` to `not slow and not live` so the shadow-runner integration test (`test_simulate_cli_shadow_audit`) runs on every push.
- **Codebase-wide M-prefix cleanup** across 22 files, replacing milestone tags with issue/PR numbers and descriptive phrases per a consistent mapping table.

## Final selective-adoption inventory (frozen)

**Adopted** (delegated to abdp, gated by parity tests):
- `core/connectors/hashing.py::sha256_payload` → `abdp.core.stable_hash`
- `core/_compat/data.py` Bronze/Silver/Gold contract aliases + `AbdpSnapshotManifest`
- `core/_compat/reporting.py::render_json_report` → `abdp.reporting.render_json_report`
- `core/_compat/ids.py` deterministic ID helpers
- `core/_compat/scenario.py` adapters + `apps/.../simulation/shadow_runner.py::run_shadow_audit`

**Retained local by design** (NOT delegated):
- `core/storage/snapshot.py` (Korean-public-data ingest manifest)
- `core/state/{bronze,silver,gold}.py` (Korean apartment domain types)
- `core/state/simulation.py` (LangGraph TypedDict, canonical in-memory representation)
- `apps/kr-seoul-apartment/.../simulation/` (LangGraph runtime — production execution engine)

## Verification

- 1,320 passed, 6 skipped, 3 deselected on \`YOUNGGEUL_CORE_BACKEND=local\`
- 1,320 passed, 6 skipped, 3 deselected on \`YOUNGGEUL_CORE_BACKEND=abdp\`
- \`ruff check\` + \`ruff format --check\` + \`mypy core/src apps/kr-seoul-apartment/src\`: all clean
- \`grep -rE \"\\bM[0-9]+'?(-[a-z])?\\b\"\` (excluding .venv/.git/uv.lock): **zero matches**

Closes #245