### PR TITLE
docs(adr-012): clarify path notation in final selective-adoption inventory

### DIFF
--- a/docs/adr/012-abdp-backed-core.md
+++ b/docs/adr/012-abdp-backed-core.md
@@ -127,6 +127,8 @@ Hands-on inspection during the data-aliases adoption (issue #239) and a follow-u
 
 The 2026-04-23 finalization ruling (Oracle, recorded in this amendment) closed out the selective-adoption epic without flipping the default backend and without deleting any local module. The inventory below freezes the per-surface adoption decision and the parity tests that gate it. Future changes to this inventory require a new ADR or amendment.
 
+> **Path notation in this section.** For brevity the tables below use the short forms `core/...` and `apps/kr-seoul-apartment/...` to refer to the package roots. The full on-disk paths are `core/src/younggeul_core/...` and `apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/...` respectively. Test paths (`core/tests/...`, `apps/kr-seoul-apartment/tests/...`) are already the actual on-disk paths.
+
 **Adopted surfaces (delegated to `abdp` and gated by parity tests)**
 
 | Surface | Local site | abdp target | Parity test |


### PR DESCRIPTION
## Summary

Resolves the single NIT surfaced by the post-#257 doc-code consistency audit: ADR-012's "Final selective-adoption inventory" tables use short-form paths (\`core/...\`, \`apps/kr-seoul-apartment/...\`) for readability, but the rest of the repo also uses full-form paths (\`core/src/younggeul_core/...\`, \`apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/...\`). New readers can find this confusing.

This PR adds an inline note above the tables documenting the convention. No table rewrites — both notations remain valid; we just say so out loud.

## Audit results recap

- CRITICAL: 0
- MISMATCH: 0 (one path-style NIT — fixed by this PR)
- STALE: 0
- VERIFIED: ADR-012 milestones, amendment, and final inventory all match code (\`_compat/__init__.py\` DEFAULT_BACKEND, \`_compat/scenario.py\` exports, \`connectors/hashing.py\` delegation, CLI \`--shadow-audit-log\` and \`--render abdp|legacy\`, all referenced parity test files, \`.github/workflows/test.yml\` matrix [local, abdp], pinned commit \`bf0ab1d\` in \`pyproject.toml\`)

## Verification

- 1,320 passed × 2 backends (\`local\`, \`abdp\`)
- Doc-only change; no code touched