### PR TITLE
chore: bump abdp pin to post-#163 commit so __version__ reports 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,10 @@ docs = [
 ]
 # abdp backend (Adapter Layer; see ADR-012). Optional extra so the default
 # install keeps working with the local backend. Pinned to a specific commit
-# because abdp tags v0.3.0 still ship internal __version__ "0.1.0.dev0".
+# on abdp main (post-yeongseon/agent-based-decision-pipeline#163) where
+# `abdp.__version__` correctly reports "0.3.0".
 abdp = [
-  "abdp @ git+https://github.com/yeongseon/agent-based-decision-pipeline.git@bf0ab1d027602ff5cbbc9e6cba1ffa98e37404b7",
+  "abdp @ git+https://github.com/yeongseon/agent-based-decision-pipeline.git@e695ea664926680fe456e5b409f46b39080aa40b",
 ]
 
 [tool.hatch.metadata]


### PR DESCRIPTION
## Summary

Repoints the `[abdp]` extra in `pyproject.toml` from `bf0ab1d` (the `v0.3.0` tag commit, where `abdp.__version__` misreported `"0.1.0.dev0"` — the very motivation we documented in the prior pin comment) to `e695ea6` on abdp `main`, the squash-merge of [yeongseon/agent-based-decision-pipeline#163](https://github.com/yeongseon/agent-based-decision-pipeline/pull/163) which fixes the version drift and adds a regression test pinning runtime ↔ packaging-metadata sync.

After this bump, downstream consumers of younggeul who install the `[abdp]` extra observe `abdp.__version__ == "0.3.0"` instead of the misleading dev string.

## Changes

- `pyproject.toml`: `abdp` extra git ref `bf0ab1d…` → `e695ea6…`
- `pyproject.toml`: pin-rationale comment updated to reference the upstream fix PR (#163) instead of the old `0.1.0.dev0` workaround note

No code, ADR, test, or doc changes — this is purely a version-pin refresh that completes the end-to-end fix arc.

## Verification

Ran locally from repo root after `uv sync --extra dev --extra kr-seoul-apartment --extra abdp --reinstall-package abdp`:

\`\`\`
\$ python -c "import abdp; print(abdp.__version__)"
0.3.0

\$ ruff format --check .
190 files already formatted

\$ ruff check .
All checks passed!

\$ mypy core/src/ apps/kr-seoul-apartment/src/
Success: no issues found in 103 source files

\$ YOUNGGEUL_CORE_BACKEND=local pytest -m "not slow and not live"
1320 passed, 6 skipped, 3 deselected, 1 warning in 20.42s

\$ YOUNGGEUL_CORE_BACKEND=abdp  pytest -m "not slow and not live"
1320 passed, 6 skipped, 3 deselected, 1 warning in 15.58s
\`\`\`

CI's [local, abdp] matrix will repeat both legs.

## Out of scope

- Pinning a published abdp version range — abdp is not on PyPI; commit-pin is still required.
- Committing uv.lock — younggeul does not currently track uv.lock in git.
- Cutting a younggeul release.

## Acceptance

- [x] abdp.__version__ returns 0.3.0 after install
- [x] All 1,320 tests pass under both backends
- [x] ruff/mypy clean
- [x] Pin-rationale comment refreshed