### PR TITLE
chore: bump abdp pin to v0.5 ReviewLoopRunner / two-plane execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **abdp pin bumped to v0.5 ReviewLoopRunner / two-plane execution model.**
+  The `[abdp]` extra now points at the squash-merge commit of
+  `agent-based-decision-pipeline#175`, which lands the v0.5 cyclic
+  `ReviewLoopRunner` (two-plane execution model, ADR-0001) on top of #174's
+  `abdp.inspector` tracing subsystem (v0.4). `abdp.__version__` continues to
+  report `0.3.0` on this commit; the new `abdp.inspector` and `abdp.review`
+  packages are additive and not yet adopted by `younggeul_core`'s selective
+  compat layer (ADR-012). Default backend remains `local`; the abdp backend
+  stays opt-in via `YOUNGGEUL_CORE_BACKEND=abdp`.
+
 - **abdp selective adoption finalized (issue #245, epic #235).** `younggeul_core`
   now adopts `agent-based-decision-pipeline` selectively where semantics
   match: hashing delegation, deterministic JSON report rendering

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,14 @@ docs = [
 ]
 # abdp backend (Adapter Layer; see ADR-012). Optional extra so the default
 # install keeps working with the local backend. Pinned to a specific commit
-# on abdp main (post-yeongseon/agent-based-decision-pipeline#163) where
-# `abdp.__version__` correctly reports "0.3.0".
+# on abdp main (post-yeongseon/agent-based-decision-pipeline#175) which
+# squash-merges the v0.5 ReviewLoopRunner / two-plane execution model on
+# top of #174's Inspector tracing subsystem (v0.4). `abdp.__version__`
+# continues to report "0.3.0" on this commit; the new `abdp.inspector`
+# and `abdp.review` packages are additive and not yet adopted by the
+# selective compat layer (ADR-012).
 abdp = [
-  "abdp @ git+https://github.com/yeongseon/agent-based-decision-pipeline.git@e695ea664926680fe456e5b409f46b39080aa40b",
+  "abdp @ git+https://github.com/yeongseon/agent-based-decision-pipeline.git@9520cfed7e150f644fb5d01bb1a9b32eb0082f8d",
 ]
 
 [tool.hatch.metadata]


### PR DESCRIPTION
## Summary

Repoints the `[abdp]` extra from `e695ea6` (post-#163, abdp v0.3.0 version
fix) to `9520cfe` on abdp `main`, the squash-merge of
[`agent-based-decision-pipeline#175`](https://github.com/yeongseon/agent-based-decision-pipeline/pull/175)
which lands the **v0.5 cyclic `ReviewLoopRunner` / two-plane execution
model** on top of [#174](https://github.com/yeongseon/agent-based-decision-pipeline/pull/174)'s
**v0.4 `abdp.inspector` tracing subsystem**.

## What's new upstream

- `abdp.inspector` — in-process tracing plane: `TraceEvent`, `TraceRecorder`,
  `TraceStore` protocol with `MemoryTraceStore` + `SQLiteTraceStore`, plus
  the `abdp inspect` CLI subcommand for JSON Lines export.
- `abdp.review` — cyclic self-correction: `CorrectionPolicy`, `Critic` /
  `Reviser` Protocols, `ReviewAttempt` / `ReviewDecision` / `ReviewTrace`
  dataclasses, and `ReviewLoopRunner` that emits `review.attempt` events
  on the inspector plane while keeping rejected attempts out of the
  canonical `EvidenceStore` / `AuditLog`.
- Both shipped at Oracle 100/100 with full TDD discipline (RED→GREEN per
  step, 100% line coverage on new code).

## Verification

- `import abdp; abdp.__version__ == '0.3.0'` (additive-only release)
- `from abdp.inspector import TraceEvent, TraceRecorder, ...` ✓
- `from abdp.review import CorrectionPolicy, ReviewLoopRunner, ...` ✓
- 1323 tests pass under both `YOUNGGEUL_CORE_BACKEND=local` and `=abdp`
- `ruff check .`, `ruff format --check .`, `mypy` on canonical paths clean

## Adoption status

The new `abdp.inspector` and `abdp.review` packages are **additive only**
and **not yet adopted** by `younggeul_core`'s selective compat layer per
ADR-012. This PR only unblocks newer abdp; selective adoption (if any)
will be tracked separately.