### PR TITLE
feat: default Seoul ingest entrypoints to all 25 districts (#263)

### DIFF
--- a/.github/workflows/data-pipeline.yml
+++ b/.github/workflows/data-pipeline.yml
@@ -15,7 +15,7 @@ on:
       gus:
         description: "Comma-separated 5-digit MOLIT sigungu codes"
         required: false
-        default: "11680"
+        default: "11110,11140,11170,11200,11215,11230,11260,11290,11305,11320,11350,11380,11410,11440,11470,11500,11530,11545,11560,11590,11620,11650,11680,11710,11740"
       months:
         description: "Comma-separated YYYYMM months (empty = last completed UTC month)"
         required: false
@@ -56,6 +56,7 @@ jobs:
           INPUT_MONTHS: ${{ inputs.months || '' }}
           INPUT_OUTPUT_DIR: ${{ inputs.output_dir || '' }}
         run: |
+          DEFAULT_SEOUL_GUS="11110,11140,11170,11200,11215,11230,11260,11290,11305,11320,11350,11380,11410,11440,11470,11500,11530,11545,11560,11590,11620,11650,11680,11710,11740"
           last_completed_month="$(date -u -d "$(date -u +%Y-%m-01) -1 month" +%Y%m)"
 
           # NOTE: GitHub Actions runner IPs are blocked by data.go.kr (MOLIT
@@ -64,12 +65,12 @@ jobs:
           # pipeline still exercises the end-to-end path. See ADR-010.
           if [ "${{ github.event_name }}" = "schedule" ]; then
             source="fixture"
-            gus="11680"
+            gus="$DEFAULT_SEOUL_GUS"
             months="$last_completed_month"
             output_dir="output/pipeline"
           else
             source="${INPUT_SOURCE:-fixture}"
-            gus="${INPUT_GUS:-11680}"
+            gus="${INPUT_GUS:-$DEFAULT_SEOUL_GUS}"
             months="${INPUT_MONTHS:-$last_completed_month}"
             output_dir="${INPUT_OUTPUT_DIR:-output/pipeline}"
           fi

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ To chain ingest → snapshot publish → baseline against real APIs in one shot:
 
 ```bash
 set -a; source .env; set +a   # load KPUBDATA_* keys
-make demo-live                # or: GU=11680 MONTHS=202403,202503 bash scripts/demo_live.sh
+make demo-live                # defaults to all 25 Seoul gu; or narrow with GU=11680 MONTHS=202403,202503 bash scripts/demo_live.sh
 ```
 
-GitHub Actions can also run the live ingest on a schedule or via manual dispatch through `.github/workflows/data-pipeline.yml`. The workflow defaults to Gangnam (`11680`) and the last completed UTC month, and its operational rationale is documented in [ADR-010](docs/adr/010-data-pipeline-live-workflow.md).
+GitHub Actions can also run the live ingest on a schedule or via manual dispatch through `.github/workflows/data-pipeline.yml`. The workflow now defaults to all 25 Seoul gu and the last completed UTC month, while its scheduled `source=fixture` posture remains unchanged because MOLIT blocks GitHub-hosted runner IPs. The operational rationale is documented in [ADR-010](docs/adr/010-data-pipeline-live-workflow.md) and [ADR-013](docs/adr/013-default-all-seoul-districts.md).
 
 ## v0.1 Scope
 

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/canonical/__init__.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/canonical/__init__.py
@@ -1,1 +1,5 @@
 """younggeul_app_kr_seoul_apartment.canonical — canonical data models."""
+
+from .regions import SEOUL_GU_CODES, SEOUL_GU_CODE_TO_NAME, SEOUL_GU_NAME_TO_CODE
+
+__all__ = ["SEOUL_GU_CODES", "SEOUL_GU_CODE_TO_NAME", "SEOUL_GU_NAME_TO_CODE"]

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/canonical/regions.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/canonical/regions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import MappingProxyType
+from typing import Mapping
 
 _SEOUL_GU_ITEMS: tuple[tuple[str, str], ...] = (
     ("11110", "종로구"),
@@ -31,7 +32,7 @@ _SEOUL_GU_ITEMS: tuple[tuple[str, str], ...] = (
 )
 
 SEOUL_GU_CODES: tuple[str, ...] = tuple(code for code, _ in _SEOUL_GU_ITEMS)
-SEOUL_GU_CODE_TO_NAME = MappingProxyType(dict(_SEOUL_GU_ITEMS))
-SEOUL_GU_NAME_TO_CODE = MappingProxyType({name: code for code, name in _SEOUL_GU_ITEMS})
+SEOUL_GU_CODE_TO_NAME: Mapping[str, str] = MappingProxyType(dict(_SEOUL_GU_ITEMS))
+SEOUL_GU_NAME_TO_CODE: Mapping[str, str] = MappingProxyType({name: code for code, name in _SEOUL_GU_ITEMS})
 
 __all__ = ["SEOUL_GU_CODES", "SEOUL_GU_CODE_TO_NAME", "SEOUL_GU_NAME_TO_CODE"]

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/canonical/regions.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/canonical/regions.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+
+_SEOUL_GU_ITEMS: tuple[tuple[str, str], ...] = (
+    ("11110", "종로구"),
+    ("11140", "중구"),
+    ("11170", "용산구"),
+    ("11200", "성동구"),
+    ("11215", "광진구"),
+    ("11230", "동대문구"),
+    ("11260", "중랑구"),
+    ("11290", "성북구"),
+    ("11305", "강북구"),
+    ("11320", "도봉구"),
+    ("11350", "노원구"),
+    ("11380", "은평구"),
+    ("11410", "서대문구"),
+    ("11440", "마포구"),
+    ("11470", "양천구"),
+    ("11500", "강서구"),
+    ("11530", "구로구"),
+    ("11545", "금천구"),
+    ("11560", "영등포구"),
+    ("11590", "동작구"),
+    ("11620", "관악구"),
+    ("11650", "서초구"),
+    ("11680", "강남구"),
+    ("11710", "송파구"),
+    ("11740", "강동구"),
+)
+
+SEOUL_GU_CODES: tuple[str, ...] = tuple(code for code, _ in _SEOUL_GU_ITEMS)
+SEOUL_GU_CODE_TO_NAME = MappingProxyType(dict(_SEOUL_GU_ITEMS))
+SEOUL_GU_NAME_TO_CODE = MappingProxyType({name: code for code, name in _SEOUL_GU_ITEMS})
+
+__all__ = ["SEOUL_GU_CODES", "SEOUL_GU_CODE_TO_NAME", "SEOUL_GU_NAME_TO_CODE"]

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/cli.py
@@ -154,6 +154,68 @@ def _fixture_bronze_input() -> BronzeInput:
     )
 
 
+def _parse_months_csv(months: str) -> list[str]:
+    target_months = [month.strip() for month in months.split(",") if month.strip()]
+    if not target_months:
+        raise click.ClickException("--months must include at least one YYYYMM value")
+    return target_months
+
+
+def _fixture_bronze_input_fanout(lawd_codes: list[str], deal_yms: list[str]) -> BronzeInput:
+    fixture = _fixture_bronze_input()
+    apt_template = fixture.apt_transactions[0]
+    rate_template = fixture.interest_rates[0]
+    migration_template = fixture.migrations[0]
+
+    apt_transactions: list[BronzeAptTransaction] = []
+    interest_rates: list[BronzeInterestRate] = []
+    migrations: list[BronzeMigration] = []
+
+    for month_index, deal_ym in enumerate(deal_yms, start=1):
+        deal_year = deal_ym[:4]
+        deal_month = str(int(deal_ym[4:6]))
+        period_month = deal_ym[4:6]
+
+        interest_rates.append(
+            rate_template.model_copy(
+                update={
+                    "raw_response_hash": f"fixture-rate-{deal_ym}".encode("utf-8").hex().ljust(64, "0")[:64],
+                    "date": f"{deal_year}-{period_month}-01",
+                }
+            )
+        )
+        migrations.append(
+            migration_template.model_copy(
+                update={
+                    "raw_response_hash": f"fixture-migration-{deal_ym}".encode("utf-8").hex().ljust(64, "0")[:64],
+                    "year": deal_year,
+                    "month": period_month,
+                }
+            )
+        )
+
+        for gu_index, lawd_code in enumerate(lawd_codes, start=1):
+            apt_transactions.append(
+                apt_template.model_copy(
+                    update={
+                        "raw_response_hash": f"fixture-apt-{lawd_code}-{deal_ym}".encode("utf-8")
+                        .hex()
+                        .ljust(64, "0")[:64],
+                        "deal_year": deal_year,
+                        "deal_month": deal_month,
+                        "serial_number": f"fixture-{month_index:02d}-{gu_index:02d}",
+                        "sgg_code": lawd_code,
+                    }
+                )
+            )
+
+    return BronzeInput(
+        apt_transactions=apt_transactions,
+        interest_rates=interest_rates,
+        migrations=migrations,
+    )
+
+
 def _load_gold_rows(data_dir: Path) -> list[GoldDistrictMonthlyMetrics]:
     primary = data_dir / "gold_district_monthly_metrics.jsonl"
     candidate_files = [primary] if primary.exists() else sorted(data_dir.glob("*.jsonl"))
@@ -351,13 +413,14 @@ def ingest_command(
     ``KPUBDATA_BOK_API_KEY`` environment variables.
     """
     try:
+        if lawd_code and lawd_codes_csv:
+            raise click.ClickException("--gu and --gus are mutually exclusive")
+        if deal_ym and deal_yms_csv:
+            raise click.ClickException("--month and --months are mutually exclusive")
+
         if source == "live":
-            if lawd_code and lawd_codes_csv:
-                raise click.ClickException("--gu and --gus are mutually exclusive")
             if not lawd_code and not lawd_codes_csv:
                 raise click.ClickException("exactly one of --gu or --gus is required when --source=live")
-            if deal_ym and deal_yms_csv:
-                raise click.ClickException("--month and --months are mutually exclusive")
             if not deal_ym and not deal_yms_csv:
                 raise click.ClickException("exactly one of --month or --months is required when --source=live")
             from younggeul_app_kr_seoul_apartment.connectors.client_factory import build_client
@@ -378,7 +441,29 @@ def ingest_command(
             client = build_client()
             bronze = run_live_ingest_gus_months(client=client, lawd_codes=lawd_codes, deal_yms=deal_yms)
         else:
-            bronze = _fixture_bronze_input()
+            if lawd_codes_csv or deal_yms_csv:
+                if lawd_codes_csv:
+                    lawd_codes = _parse_gus_csv(lawd_codes_csv)
+                elif lawd_code is not None:
+                    lawd_codes = [lawd_code]
+                else:
+                    lawd_codes = ["11680"]
+
+                if deal_yms_csv:
+                    deal_yms = _parse_months_csv(deal_yms_csv)
+                elif deal_ym is not None:
+                    deal_yms = [deal_ym]
+                else:
+                    deal_yms = ["202507"]
+
+                bronze = _fixture_bronze_input_fanout(lawd_codes=lawd_codes, deal_yms=deal_yms)
+            elif lawd_code is not None or deal_ym is not None:
+                bronze = _fixture_bronze_input_fanout(
+                    lawd_codes=[lawd_code or "11680"],
+                    deal_yms=[deal_ym or "202507"],
+                )
+            else:
+                bronze = _fixture_bronze_input()
         result = run_pipeline(bronze)
 
         output_dir.mkdir(parents=True, exist_ok=True)

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/domain/gu_resolver.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/simulation/domain/gu_resolver.py
@@ -2,34 +2,7 @@
 
 from __future__ import annotations
 
-SEOUL_GU_MAP: dict[str, str] = {
-    "11110": "종로구",
-    "11140": "중구",
-    "11170": "용산구",
-    "11200": "성동구",
-    "11215": "광진구",
-    "11230": "동대문구",
-    "11260": "중랑구",
-    "11290": "성북구",
-    "11305": "강북구",
-    "11320": "도봉구",
-    "11350": "노원구",
-    "11380": "은평구",
-    "11410": "서대문구",
-    "11440": "마포구",
-    "11470": "양천구",
-    "11500": "강서구",
-    "11530": "구로구",
-    "11545": "금천구",
-    "11560": "영등포구",
-    "11590": "동작구",
-    "11620": "관악구",
-    "11650": "서초구",
-    "11680": "강남구",
-    "11710": "송파구",
-    "11740": "강동구",
-}
-SEOUL_NAME_TO_CODE: dict[str, str] = {name: code for code, name in SEOUL_GU_MAP.items()}
+from younggeul_app_kr_seoul_apartment.canonical import SEOUL_GU_CODE_TO_NAME, SEOUL_GU_NAME_TO_CODE
 
 
 def resolve_gu_codes(
@@ -55,19 +28,21 @@ def resolve_gu_codes(
     warnings: list[str] = []
     available_set = set(available_gu_codes)
 
-    if hint in SEOUL_GU_MAP:
+    if hint in SEOUL_GU_CODE_TO_NAME:
         if hint in available_set:
             return [hint], warnings
         return list(available_gu_codes), [f"Requested gu code '{hint}' is unavailable in snapshot coverage."]
 
-    direct_code = SEOUL_NAME_TO_CODE.get(hint)
+    direct_code = SEOUL_GU_NAME_TO_CODE.get(hint)
     if direct_code is not None:
         if direct_code in available_set:
             return [direct_code], warnings
         return list(available_gu_codes), [f"Requested district '{hint}' is unavailable in snapshot coverage."]
 
     matched_codes = [
-        code for code in available_gu_codes if SEOUL_GU_MAP.get(code) is not None and SEOUL_GU_MAP[code] in hint
+        code
+        for code in available_gu_codes
+        if SEOUL_GU_CODE_TO_NAME.get(code) is not None and SEOUL_GU_CODE_TO_NAME[code] in hint
     ]
     if matched_codes:
         return matched_codes, warnings

--- a/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py
+++ b/apps/kr-seoul-apartment/src/younggeul_app_kr_seoul_apartment/transforms/silver_apt.py
@@ -5,37 +5,10 @@ from __future__ import annotations
 from datetime import date
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 
+from younggeul_app_kr_seoul_apartment.canonical import SEOUL_GU_CODE_TO_NAME, SEOUL_GU_CODES
 from younggeul_core.connectors.hashing import sha256_payload
 from younggeul_core.state.bronze import BronzeAptTransaction
 from younggeul_core.state.silver import SilverAptTransaction, SilverDataQualityScore
-
-SEOUL_GU_CODES: dict[str, str] = {
-    "11110": "종로구",
-    "11140": "중구",
-    "11170": "용산구",
-    "11200": "성동구",
-    "11215": "광진구",
-    "11230": "동대문구",
-    "11260": "중랑구",
-    "11290": "성북구",
-    "11305": "강북구",
-    "11320": "도봉구",
-    "11350": "노원구",
-    "11380": "은평구",
-    "11410": "서대문구",
-    "11440": "마포구",
-    "11470": "양천구",
-    "11500": "강서구",
-    "11530": "구로구",
-    "11545": "금천구",
-    "11560": "영등포구",
-    "11590": "동작구",
-    "11620": "관악구",
-    "11650": "서초구",
-    "11680": "강남구",
-    "11710": "송파구",
-    "11740": "강동구",
-}
 
 
 def parse_deal_amount(raw: str | None) -> int | None:
@@ -146,7 +119,7 @@ def derive_gu_name(gu_code: str | None) -> str | None:
     """
     if gu_code is None:
         return None
-    return SEOUL_GU_CODES.get(gu_code)
+    return SEOUL_GU_CODE_TO_NAME.get(gu_code)
 
 
 def is_cancelled(cancel_deal_type: str | None) -> bool:

--- a/apps/kr-seoul-apartment/tests/integration/test_pipeline_e2e.py
+++ b/apps/kr-seoul-apartment/tests/integration/test_pipeline_e2e.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any
 
+from younggeul_app_kr_seoul_apartment.canonical import SEOUL_GU_CODES
 from younggeul_app_kr_seoul_apartment.pipeline import BronzeInput, PipelineResult, run_pipeline
 from younggeul_core.state.bronze import BronzeAptTransaction, BronzeInterestRate, BronzeMigration
 
@@ -230,3 +231,20 @@ class TestPipelineEmptyInput:
         assert result.silver.interest_rates == []
         assert result.silver.migrations == []
         assert result.gold == []
+
+
+class TestPipelineAllSeoulDistricts:
+    def test_pipeline_emits_one_gold_row_per_seoul_gu(self) -> None:
+        bronze = BronzeInput(
+            apt_transactions=[
+                _make_bronze_apt(serial_number=f"2025-{index:03d}", sgg_code=code)
+                for index, code in enumerate(SEOUL_GU_CODES, start=1)
+            ],
+            interest_rates=[_make_bronze_rate()],
+            migrations=[_make_bronze_migration()],
+        )
+
+        result = run_pipeline(bronze)
+
+        assert len(result.gold) == len(SEOUL_GU_CODES)
+        assert {row.gu_code for row in result.gold} == set(SEOUL_GU_CODES)

--- a/apps/kr-seoul-apartment/tests/unit/test_canonical_regions.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_canonical_regions.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+
+from younggeul_app_kr_seoul_apartment.canonical.regions import (
+    SEOUL_GU_CODES,
+    SEOUL_GU_CODE_TO_NAME,
+    SEOUL_GU_NAME_TO_CODE,
+)
+
+
+def test_seoul_gu_codes_are_complete_and_sorted() -> None:
+    assert SEOUL_GU_CODES == (
+        "11110",
+        "11140",
+        "11170",
+        "11200",
+        "11215",
+        "11230",
+        "11260",
+        "11290",
+        "11305",
+        "11320",
+        "11350",
+        "11380",
+        "11410",
+        "11440",
+        "11470",
+        "11500",
+        "11530",
+        "11545",
+        "11560",
+        "11590",
+        "11620",
+        "11650",
+        "11680",
+        "11710",
+        "11740",
+    )
+    assert len(SEOUL_GU_CODES) == 25
+    assert tuple(sorted(SEOUL_GU_CODES)) == SEOUL_GU_CODES
+    assert len(set(SEOUL_GU_CODES)) == 25
+    assert all(code.startswith("11") for code in SEOUL_GU_CODES)
+
+
+def test_region_maps_are_frozen_and_bidirectional() -> None:
+    assert isinstance(SEOUL_GU_CODE_TO_NAME, MappingProxyType)
+    assert isinstance(SEOUL_GU_NAME_TO_CODE, MappingProxyType)
+    assert tuple(SEOUL_GU_CODE_TO_NAME) == SEOUL_GU_CODES
+    assert set(SEOUL_GU_CODE_TO_NAME) == set(SEOUL_GU_CODES)
+    assert set(SEOUL_GU_NAME_TO_CODE.values()) == set(SEOUL_GU_CODES)
+    assert SEOUL_GU_CODE_TO_NAME["11680"] == "강남구"
+    assert SEOUL_GU_NAME_TO_CODE["강남구"] == "11680"
+    assert SEOUL_GU_NAME_TO_CODE[SEOUL_GU_CODE_TO_NAME["11440"]] == "11440"

--- a/apps/kr-seoul-apartment/tests/unit/test_canonical_regions.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_canonical_regions.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from importlib import import_module
 from types import MappingProxyType
 
-from younggeul_app_kr_seoul_apartment.canonical.regions import (
-    SEOUL_GU_CODES,
-    SEOUL_GU_CODE_TO_NAME,
-    SEOUL_GU_NAME_TO_CODE,
-)
+regions = import_module("younggeul_app_kr_seoul_apartment.canonical.regions")
+
+SEOUL_GU_CODES = regions.SEOUL_GU_CODES
+SEOUL_GU_CODE_TO_NAME = regions.SEOUL_GU_CODE_TO_NAME
+SEOUL_GU_NAME_TO_CODE = regions.SEOUL_GU_NAME_TO_CODE
 
 
 def test_seoul_gu_codes_are_complete_and_sorted() -> None:

--- a/apps/kr-seoul-apartment/tests/unit/test_cli.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_cli.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 from click.testing import CliRunner
+from younggeul_app_kr_seoul_apartment.canonical import SEOUL_GU_CODES
 
 cli = import_module("younggeul_app_kr_seoul_apartment.cli")
 
@@ -141,6 +142,80 @@ def test_ingest_live_rejects_gu_and_gus_together(runner: CliRunner, tmp_path: Pa
 
     assert result.exit_code != 0
     assert "--gu and --gus are mutually exclusive" in result.output
+
+
+def test_parse_gus_csv_accepts_all_seoul_codes() -> None:
+    assert cli._parse_gus_csv(",".join(SEOUL_GU_CODES)) == list(SEOUL_GU_CODES)
+
+
+def test_ingest_fixture_rejects_gu_and_gus_together(runner: CliRunner, tmp_path: Path) -> None:
+    result = runner.invoke(
+        cli.main,
+        [
+            "ingest",
+            "--source",
+            "fixture",
+            "--gu",
+            "11680",
+            "--gus",
+            "11680,11440",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--gu and --gus are mutually exclusive" in result.output
+
+
+def test_ingest_fixture_rejects_month_and_months_together(runner: CliRunner, tmp_path: Path) -> None:
+    result = runner.invoke(
+        cli.main,
+        [
+            "ingest",
+            "--source",
+            "fixture",
+            "--month",
+            "202503",
+            "--months",
+            "202503,202504",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--month and --months are mutually exclusive" in result.output
+
+
+def test_ingest_fixture_fans_out_requested_gus_and_months(runner: CliRunner, tmp_path: Path) -> None:
+    output_dir = tmp_path / "pipeline"
+    target_gus = list(SEOUL_GU_CODES[:3])
+
+    result = runner.invoke(
+        cli.main,
+        [
+            "ingest",
+            "--source",
+            "fixture",
+            "--gus",
+            ",".join(target_gus),
+            "--months",
+            "202503,202504",
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    assert result.exit_code == 0
+    rows = [
+        json.loads(line)
+        for line in (output_dir / "gold_district_monthly_metrics.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(rows) == len(target_gus) * 2
+    assert {row["gu_code"] for row in rows} == set(target_gus)
+    assert {row["period"] for row in rows} == {"2025-03", "2025-04"}
 
 
 def test_simulate_runs_successfully(runner: CliRunner, tmp_path: Path) -> None:

--- a/apps/kr-seoul-apartment/tests/unit/test_silver_apt.py
+++ b/apps/kr-seoul-apartment/tests/unit/test_silver_apt.py
@@ -4,6 +4,7 @@ from datetime import date, datetime, timezone
 from decimal import Decimal
 from typing import Any
 
+from younggeul_app_kr_seoul_apartment.canonical import SEOUL_GU_CODES
 from younggeul_app_kr_seoul_apartment.transforms.silver_apt import (
     compute_quality_score,
     derive_gu_code,
@@ -123,6 +124,10 @@ class TestDeriveGuCode:
     def test_valid_seoul_code_returns_code(self) -> None:
         assert derive_gu_code("11680") == "11680"
 
+    def test_all_canonical_codes_round_trip(self) -> None:
+        for code in SEOUL_GU_CODES:
+            assert derive_gu_code(code) == code
+
     def test_non_seoul_code_returns_none(self) -> None:
         assert derive_gu_code("41135") is None
 
@@ -133,6 +138,10 @@ class TestDeriveGuCode:
 class TestDeriveGuName:
     def test_valid_lookup_returns_name(self) -> None:
         assert derive_gu_name("11680") == "강남구"
+
+    def test_all_canonical_codes_resolve_names(self) -> None:
+        for code in SEOUL_GU_CODES:
+            assert derive_gu_name(code) is not None
 
     def test_unknown_returns_none(self) -> None:
         assert derive_gu_name("99999") is None

--- a/docs/adr/010-data-pipeline-live-workflow.md
+++ b/docs/adr/010-data-pipeline-live-workflow.md
@@ -162,3 +162,13 @@ Mitigations adopted:
 
 The CLI itself is unchanged; only the workflow defaults and operational
 guidance are revised.
+
+## Amendment 2026-04-25 — 25-gu default rollout
+
+Issue [#263](https://github.com/kpubdata-lab/younggeul/issues/263) expands the workflow and local demo defaults from Gangnam-only (`11680`) to all 25 Seoul gu.
+
+- `.github/workflows/data-pipeline.yml` now defaults `gus` to the full 25-gu CSV for both `workflow_dispatch` and the scheduled fallback branch.
+- The cron posture remains `source=fixture`; GitHub-hosted runners are still blocked by MOLIT, so the workflow continues to exercise the deterministic end-to-end path off live APIs.
+- `younggeul ingest --source fixture` now honors `--gus` and `--months`, so scheduled fixture runs cover the same 25-gu fan-out shape that the defaults request.
+
+This amendment is paired with [ADR-013: Default Seoul ingest entrypoints to all 25 districts](013-default-all-seoul-districts.md).

--- a/docs/adr/013-default-all-seoul-districts.md
+++ b/docs/adr/013-default-all-seoul-districts.md
@@ -1,0 +1,67 @@
+# ADR-013: Default Seoul ingest entrypoints to all 25 districts
+
+## Status
+Accepted
+
+## Date
+2026-04-25
+
+## Context
+
+Several Seoul ingest entrypoints still defaulted to Gangnam-only (`11680`) even though the apartment pipeline, simulation coverage, and live ingest CLI already support all 25 Seoul gu.
+
+- `transforms/silver_apt.py` and `simulation/domain/gu_resolver.py` each carried their own inline Seoul district maps.
+- `.github/workflows/data-pipeline.yml` and `scripts/demo_live.sh` defaulted to Gangnam, which under-exercised multi-gu behavior.
+- `younggeul ingest --source fixture` ignored `--gus` and `--months`, so scheduled fixture runs could not mirror broader coverage defaults.
+
+That drift made the default operator path narrower than the actual product scope and duplicated region definitions across the codebase.
+
+## Decision
+
+Younggeul now standardizes Seoul district coverage around one canonical region module and defaults ingest entrypoints to all 25 Seoul gu.
+
+### 1. Canonical Seoul district definitions live in app code
+
+`younggeul_app_kr_seoul_apartment.canonical.regions` is now the single source of truth for:
+
+- `SEOUL_GU_CODES`
+- `SEOUL_GU_CODE_TO_NAME`
+- `SEOUL_GU_NAME_TO_CODE`
+
+`silver_apt.py` and `gu_resolver.py` import these constants instead of maintaining inline duplicates.
+
+### 2. Fixture ingest mirrors multi-gu operator defaults
+
+`younggeul ingest --source fixture` now honors:
+
+- `--gu` or `--gus`
+- `--month` or `--months`
+
+When explicit fixture gu/month inputs are supplied, the CLI synthesizes deterministic Bronze apartment rows for each requested gu × month combination while keeping the zero-argument fixture invocation unchanged.
+
+### 3. Workflow and demo defaults expand to all 25 Seoul gu
+
+The GitHub Actions data pipeline and `scripts/demo_live.sh` now default to the full 25-gu CSV.
+
+- Explicit `gus`/`GUS` still wins.
+- Explicit single-gu `gu`/`GU` still works unchanged.
+- Scheduled GitHub Actions runs remain on `source=fixture` because MOLIT blocks GitHub-hosted runner IPs.
+
+## Consequences
+
+**Pros.**
+
+- Operator defaults now reflect actual Seoul-wide product scope.
+- One canonical region map reduces drift risk.
+- Scheduled fixture runs exercise broader Seoul coverage without requiring live MOLIT access.
+
+**Cons.**
+
+- Default live demo invocations fan out across more gu and can consume more upstream quota unless narrowed explicitly.
+- Documentation and workflow examples must stay aligned with the broader default.
+
+## Related
+
+- [ADR-007: Live Ingest via kpubdata](007-kpubdata-live-ingest.md)
+- [ADR-010: Run live ingest from the GitHub Actions data pipeline workflow](010-data-pipeline-live-workflow.md)
+- Issue [#263](https://github.com/kpubdata-lab/younggeul/issues/263)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -65,7 +65,13 @@ younggeul ingest --source live --gu 11680 --month 202503 --output-dir ./output/l
 younggeul ingest --source live --gu 11680 --months 202403,202503 --output-dir ./output/live-yoy
 ```
 
-v0.1 covers one gu per invocation. See [ADR-007](../adr/007-kpubdata-live-ingest.md) for the design and current scope.
+For cross-district coverage, use `--gus`:
+
+```bash
+younggeul ingest --source live --gus 11110,11140,11680 --months 202403,202503 --output-dir ./output/live-multi
+```
+
+The GitHub Actions data pipeline and `make demo-live` entrypoints now default to all 25 Seoul gu unless you narrow them explicitly with `gus`/`GU`. See [ADR-007](../adr/007-kpubdata-live-ingest.md), [ADR-010](../adr/010-data-pipeline-live-workflow.md), and [ADR-013](../adr/013-default-all-seoul-districts.md) for the design details.
 
 !!! note
     All tutorial examples use fixture data; no API key is required.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
     - ADR-010 Data Pipeline Live Workflow: adr/010-data-pipeline-live-workflow.md
     - ADR-011 Simulate Live Snapshot Wiring: adr/011-simulate-live-snapshot-wiring.md
     - ADR-012 abdp-Backed Core: adr/012-abdp-backed-core.md
+    - ADR-013 Default All Seoul Districts: adr/013-default-all-seoul-districts.md
   - API Reference:
     - Overview: api/index.md
     - Core:

--- a/scripts/demo_live.sh
+++ b/scripts/demo_live.sh
@@ -12,6 +12,8 @@
 
 set -euo pipefail
 
+DEFAULT_SEOUL_GUS="11110,11140,11170,11200,11215,11230,11260,11290,11305,11320,11350,11380,11410,11440,11470,11500,11530,11545,11560,11590,11620,11650,11680,11710,11740"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -34,7 +36,7 @@ for var in KPUBDATA_DATAGO_API_KEY KPUBDATA_BOK_API_KEY KPUBDATA_KOSIS_API_KEY; 
 done
 
 DEMO_DIR="${DEMO_DIR:-./demo_output_live}"
-GU="${GU:-11680}"
+GU="${GU:-}"
 GUS="${GUS:-}"
 MONTHS="${MONTHS:-202403,202503}"
 mkdir -p "$DEMO_DIR"
@@ -42,9 +44,12 @@ mkdir -p "$DEMO_DIR"
 if [ -n "$GUS" ]; then
     GU_ARGS=(--gus "$GUS")
     echo "  gus=$GUS  months=$MONTHS"
-else
+elif [ -n "${GU:-}" ]; then
     GU_ARGS=(--gu "$GU")
     echo "  gu=$GU   months=$MONTHS"
+else
+    GU_ARGS=(--gus "$DEFAULT_SEOUL_GUS")
+    echo "  gus=$DEFAULT_SEOUL_GUS  months=$MONTHS"
 fi
 
 echo "[1/3] Ingesting live data..."


### PR DESCRIPTION
## Summary
- add a canonical Seoul 25-gu region module and refactor `silver_apt` / `gu_resolver` to consume it
- make fixture ingest honor `--gu`/`--gus` and `--month`/`--months`, with deterministic gu×month fan-out and unchanged zero-arg fixture behavior
- update workflow, demo, docs, and integration coverage so default ingest entrypoints target all 25 Seoul districts

## Acceptance Criteria
- [x] One canonical Seoul 25-gu definition exists in app code; both inline duplicates removed.
- [x] `younggeul ingest --source fixture --gus <25-csv> --months 202503` deterministically yields 25 Gold rows.
- [x] `.github/workflows/data-pipeline.yml` manual default and scheduled fallback both resolve to all 25 Seoul gu.
- [x] `GU=11680 bash scripts/demo_live.sh` still works unchanged.
- [x] Manual workflow dispatch with `gus=11680` still works unchanged.
- [x] No snapshot migration/backfill required.
- [x] All tests pass under both `YOUNGGEUL_CORE_BACKEND=local` and `=abdp`.
- [x] `make lint` is clean.
- [x] 100% line coverage on `younggeul_app_kr_seoul_apartment.canonical.regions`.

## Verification
```bash
source .venv/bin/activate && python -m pytest apps/kr-seoul-apartment/tests/ core/tests/ --no-cov -x
source .venv/bin/activate && YOUNGGEUL_CORE_BACKEND=local python -m pytest --no-cov
source .venv/bin/activate && YOUNGGEUL_CORE_BACKEND=abdp python -m pytest --no-cov
source .venv/bin/activate && make lint
source .venv/bin/activate && python -m pytest --cov=younggeul_app_kr_seoul_apartment.canonical.regions --cov-report=term-missing apps/kr-seoul-apartment/tests/unit/test_canonical_regions.py
```

Closes #263.